### PR TITLE
fix(timeouts): use same blokli timeouts in edgeclient as with standal…

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -94,8 +94,8 @@ impl Edgli {
             let mut connector = create_trustful_hopr_blokli_connector(
                 &hopr_keys.chain_key,
                 BlockchainConnectorConfig {
-                    tx_confirm_timeout: std::time::Duration::from_secs(30),
-                    connection_timeout: std::time::Duration::from_mins(1),
+                    tx_confirm_timeout: std::time::Duration::from_secs(90),
+                    connection_timeout: std::time::Duration::from_mins(2),
                 },
                 new_blokli_client(blokli_url.map(|url| url.parse()).transpose()?),
                 cfg.safe_module.module_address,


### PR DESCRIPTION
…one blokli

fixes https://github.com/hoprnet/hoprnet/issues/7778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted blockchain connector timeout configurations to improve reliability of network operations. Transaction confirmation timeout extended from 30 to 90 seconds, and connection timeout extended from 1 to 2 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->