### PR TITLE
chore: default endpoint points to jura prod network

### DIFF
--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -15,7 +15,7 @@ pub use hopr_lib::ChainKeypair;
 use hopr_lib::api::chain::ChainWriteSafeOperations;
 
 lazy_static::lazy_static! {
-    pub static ref DEFAULT_BLOKLI_URL: Url = "https://blokli.jura.hoprnet.link".parse().unwrap();
+    pub static ref DEFAULT_BLOKLI_URL: Url = "https://blokli.jura.gnosisvpn.io".parse().unwrap();
 }
 
 pub fn new_blokli_client(url: Option<Url>) -> BlokliClient {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default service endpoint URL to a new server location.
  * Effect: new installations or runs that rely on the built-in default endpoint will connect to the updated server unless a custom URL is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->