### PR TITLE
chore(deps): update to stable hoprnet release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "signal-hook",
- "strum 0.27.2",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 signal-hook = "0.4.3"
 serde_yaml = { version = "0.9.34-deprecated" }
-strum = { version = "0.27.2", features = ["derive"] }
+strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = [
   "rt-multi-thread",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strum dependency from 0.27.2 to 0.28.0
  * Refreshed internal library dependencies including hopr-lib, hopr-db-node, hopr-chain-connector, hopr-ct-telemetry, and hopr-strategy to latest available revisions
  * Dependency updates provide improved system performance and enhanced stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->