### PR TITLE
chore: bump hoprnet crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "0.10.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -3310,10 +3310,10 @@ dependencies = [
  "futures",
  "hopr-chain-types",
  "hopr-crypto-packet",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "multiaddr",
  "strum 0.28.0",
  "thiserror 2.0.18",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "hopr-async-runtime"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "auto_impl",
  "futures",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.15.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3366,10 +3366,10 @@ dependencies = [
  "hopr-api",
  "hopr-async-runtime",
  "hopr-chain-types",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3384,16 +3384,16 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-types"
-version = "0.14.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+version = "0.14.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-trait",
  "hex-literal",
  "hopr-bindings",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "lazy_static",
  "multiaddr",
  "serde",
@@ -3405,13 +3405,13 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-keypair"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "hex",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-platform",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "scrypt",
  "serde",
  "serde_json",
@@ -3424,16 +3424,16 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "flagset",
  "hex",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-crypto-sphinx",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-parallelize",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-random"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "generic-array 1.3.5",
  "rand 0.10.0",
@@ -3462,15 +3462,15 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-sphinx"
 version = "0.11.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "bimap",
  "curve25519-dalek",
  "elliptic-curve",
  "generic-array 1.3.5",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "k256",
  "serde",
  "serde_bytes",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-types"
 version = "0.9.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "aes",
  "blake3",
@@ -3524,8 +3524,8 @@ dependencies = [
  "ed25519-dalek",
  "generic-array 1.3.5",
  "hex",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "k256",
  "libp2p-identity",
  "poly1305",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3552,8 +3552,8 @@ dependencies = [
  "futures",
  "hopr-api",
  "hopr-async-runtime",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-network-types",
  "moka",
@@ -3566,15 +3566,15 @@ dependencies = [
 [[package]]
 name = "hopr-db-entity"
 version = "0.6.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "clap",
  "hex",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-db-migration",
  "hopr-internal-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "sea-orm",
  "sea-orm-cli",
  "sea-orm-migration",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "hopr-db-migration"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "hopr-db-node"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -3604,12 +3604,12 @@ dependencies = [
  "hex",
  "hopr-api",
  "hopr-crypto-packet",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-db-entity",
  "hopr-db-migration",
  "hopr-internal-types",
  "hopr-metrics",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "lazy_static",
  "moka",
  "sea-orm",
@@ -3624,15 +3624,15 @@ dependencies = [
 [[package]]
 name = "hopr-internal-types"
 version = "0.17.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "aquamarine",
  "async-trait",
  "hex-literal",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-parallelize",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "multiaddr",
  "num_enum",
  "serde",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.0-rc.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3664,8 +3664,8 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-chain-types",
  "hopr-crypto-keypair",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-ct-telemetry",
  "hopr-db-node",
  "hopr-internal-types",
@@ -3673,7 +3673,7 @@ dependencies = [
  "hopr-network-types",
  "hopr-parallelize",
  "hopr-platform",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-transport",
  "lazy_static",
  "rand 0.10.0",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "hopr-metrics"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "prometheus",
 ]
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-types"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -3710,11 +3710,11 @@ dependencies = [
  "hickory-resolver",
  "hopr-async-runtime",
  "hopr-crypto-packet",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-metrics",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "lazy_static",
  "libp2p-identity",
  "multiaddr",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "hopr-parallelize"
 version = "0.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "futures",
  "hopr-metrics",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "hopr-platform"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "hopr-primitive-types"
 version = "0.10.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -3788,10 +3788,10 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "hopr-crypto-packet",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,14 +3813,14 @@ dependencies = [
  "hex",
  "hopr-api",
  "hopr-crypto-packet",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
  "hopr-parallelize",
  "hopr-platform",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3851,9 +3851,9 @@ dependencies = [
  "hashbrown 0.16.1",
  "hopr-async-runtime",
  "hopr-crypto-packet",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-metrics",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3885,12 +3885,12 @@ dependencies = [
 [[package]]
 name = "hopr-statistics"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 
 [[package]]
 name = "hopr-strategy"
 version = "0.17.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.17.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3924,12 +3924,12 @@ dependencies = [
  "hopr-api",
  "hopr-async-runtime",
  "hopr-crypto-packet",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-ct-telemetry",
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
  "hopr-transport-identity",
@@ -3953,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-identity"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "libp2p-identity",
  "multiaddr",
@@ -3963,11 +3963,11 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "futures",
  "futures-timer",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-metrics",
  "lazy_static",
  "smart-default",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-network"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "dashmap",
  "hopr-api",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.8.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "async-trait",
  "backon",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.3.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4024,12 +4024,12 @@ dependencies = [
  "hex",
  "hopr-api",
  "hopr-async-runtime",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-network-types",
  "hopr-platform",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-protocol-app",
  "humantime-serde",
  "libp2p-identity",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-protocol"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4056,12 +4056,12 @@ dependencies = [
  "halfbrown",
  "hopr-async-runtime",
  "hopr-crypto-packet",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
  "hopr-transport-identity",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.18.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432#2612c9442cca0638b6ed6e6427b2b5c487cf1432"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc#cacfb94fc40b71f36891cdb56c9e708efb3ec1bc"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4092,12 +4092,12 @@ dependencies = [
  "futures-time",
  "hopr-async-runtime",
  "hopr-crypto-packet",
- "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
- "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
+ "hopr-crypto-types 0.9.2 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=2612c9442cca0638b6ed6e6427b2b5c487cf1432)",
+ "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?rev=cacfb94fc40b71f36891cdb56c9e708efb3ec1bc)",
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,19 +61,19 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "2612c9442cca0638b6ed6e6427b2b5c487cf1432", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "cacfb94fc40b71f36891cdb56c9e708efb3ec1bc", features = [
   "transport-use-quic", # use quic transport, but do not announce it
   "session-client",
   "serde",
 ] }
-hopr-db-node = { git = "https://github.com/hoprnet/hoprnet", rev = "2612c9442cca0638b6ed6e6427b2b5c487cf1432", features = [
+hopr-db-node = { git = "https://github.com/hoprnet/hoprnet", rev = "cacfb94fc40b71f36891cdb56c9e708efb3ec1bc", features = [
   "runtime-tokio",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "2612c9442cca0638b6ed6e6427b2b5c487cf1432", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "cacfb94fc40b71f36891cdb56c9e708efb3ec1bc", features = [
   "runtime-tokio",
 ] }
-hopr-ct-telemetry = { git = "https://github.com/hoprnet/hoprnet", rev = "2612c9442cca0638b6ed6e6427b2b5c487cf1432" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "2612c9442cca0638b6ed6e6427b2b5c487cf1432" }
+hopr-ct-telemetry = { git = "https://github.com/hoprnet/hoprnet", rev = "cacfb94fc40b71f36891cdb56c9e708efb3ec1bc" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "cacfb94fc40b71f36891cdb56c9e708efb3ec1bc" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
Bump all crates from hoprnet to get the latest updates from branch `release/edinburgh`. Contains:
- gas limit reduction
- blokli-client retry mechanism on closed streams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->