### PR TITLE
feat: adopt ChannelLifecycleStrategy and switch to EdgeHopr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2462,7 +2462,6 @@ dependencies = [
  "clap",
  "console-subscriber",
  "futures",
- "hopr-api",
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-lib",
@@ -3372,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "hopr-async-runtime"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "auto_impl",
  "futures",
@@ -3401,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3431,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-keypair"
 version = "0.5.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "hex",
  "hopr-platform",
@@ -3448,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "flagset",
  "hex",
@@ -3465,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-sphinx"
 version = "0.12.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3483,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3500,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3535,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "hopr-metrics"
 version = "2.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
@@ -3545,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3562,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-types"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "arrayvec",
  "flume",
@@ -3589,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "hopr-parallelize"
 version = "0.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "futures",
  "hopr-metrics",
@@ -3604,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "hopr-platform"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -3612,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3625,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3657,7 +3656,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3689,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3703,8 +3702,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-reference"
-version = "4.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+version = "4.2.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "futures",
@@ -3722,15 +3721,15 @@ dependencies = [
 [[package]]
 name = "hopr-statistics"
 version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "rand 0.10.1",
 ]
 
 [[package]]
 name = "hopr-strategy"
-version = "0.18.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+version = "0.19.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3754,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3776,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3814,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3830,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3849,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-path"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "futures",
@@ -3871,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3897,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-protocol"
 version = "1.8.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3931,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.21.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3966,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcf9563d6c344c5e469400cf83a1bb43df1549d3#bcf9563d6c344c5e469400cf83a1bb43df1549d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4922c9247d#4922c9247d26757e858cea97eb61e405a0b24a10"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -66,21 +66,19 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-api = "=1.8.2"
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "bcf9563d6c344c5e469400cf83a1bb43df1549d3", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "4922c9247d", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bcf9563d6c344c5e469400cf83a1bb43df1549d3", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "4922c9247d", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "bcf9563d6c344c5e469400cf83a1bb43df1549d3", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "4922c9247d", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "bcf9563d6c344c5e469400cf83a1bb43df1549d3" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "bcf9563d6c344c5e469400cf83a1bb43df1549d3", features = [
-  "strategy-auto-funding",
-  "strategy-closure-finalizer",
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "4922c9247d" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "4922c9247d", features = [
+  "strategy-channel-lifecycle",
 ] }
 
 # Target-specific dependencies for memory allocators
@@ -90,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bcf9563d6c344c5e469400cf83a1bb43df1549d3", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "4922c9247d", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.1.0"
+version = "3.0.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,9 +14,6 @@ use crate::errors::EdgliError;
 use crate::new_blokli_client;
 
 /// The concrete HOPR edge node type used by this client.
-///
-/// Edge nodes carry no ticket manager (`TMgr = ()`); they originate outgoing
-/// tickets but never relay incoming ones.
 pub type HoprEdgeClient = hopr_reference::EdgeHopr;
 
 /// Represents the initialization states of the Edgli client.
@@ -222,9 +219,8 @@ impl Edgli {
 
     /// Run a node with HOPR edge strategies integrated.
     ///
-    /// Edge strategies comprise:
-    /// 1. Automatically funding channels that fall below a stake threshold
-    /// 2. Automatically closing channels stuck in pending-close state
+    /// The default reactor runs a single [`ChannelLifecycleStrategy`] which
+    /// owns open / fund / close / finalize for outgoing payment channels.
     ///
     /// Returns an [`AbortHandle`] that stops the strategy reactor when aborted.
     #[cfg(feature = "blokli")]
@@ -234,12 +230,10 @@ impl Edgli {
     ) -> anyhow::Result<AbortHandle> {
         use super::strategy::EdgeStrategyKind;
         use hopr_strategy::{
-            auto_funding::AutoFundingStrategy,
-            channel_finalizer::ClosureFinalizerStrategy,
+            channel_lifecycle::ChannelLifecycleStrategy,
             strategy::{MultiStrategy, Strategy},
         };
 
-        let interval = cfg.execution_interval;
         let node = self.hopr.clone();
 
         let strategies = cfg
@@ -247,11 +241,8 @@ impl Edgli {
             .into_iter()
             .map(|kind| -> Box<dyn Strategy + Send> {
                 match kind {
-                    EdgeStrategyKind::AutoFunding(sub_cfg) => {
-                        AutoFundingStrategy::new(sub_cfg, interval).build(Arc::clone(&node))
-                    }
-                    EdgeStrategyKind::ClosureFinalizer(sub_cfg) => {
-                        ClosureFinalizerStrategy::new(sub_cfg, interval).build(Arc::clone(&node))
+                    EdgeStrategyKind::ChannelLifecycle(sub_cfg) => {
+                        ChannelLifecycleStrategy::new(sub_cfg).build(Arc::clone(&node))
                     }
                 }
             })

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,41 +1,25 @@
-pub use hopr_lib::api::types::primitive::prelude::HoprBalance;
-pub use hopr_strategy::auto_funding::AutoFundingStrategyConfig;
-pub use hopr_strategy::channel_finalizer::ClosureFinalizerStrategyConfig;
+pub use hopr_strategy::channel_lifecycle::ChannelLifecycleConfig;
 
 /// Subset of strategies relevant to an edge node.
 pub enum EdgeStrategyKind {
-    AutoFunding(AutoFundingStrategyConfig),
-    ClosureFinalizer(ClosureFinalizerStrategyConfig),
+    ChannelLifecycle(ChannelLifecycleConfig),
 }
 
 /// Strategy configuration for an edge node reactor.
 pub struct MultiStrategyConfig {
-    /// Interval between periodic strategy ticks.
-    pub execution_interval: std::time::Duration,
     /// Ordered list of strategies to run concurrently.
     pub strategies: Vec<EdgeStrategyKind>,
 }
 
 /// Returns the default [`MultiStrategyConfig`] for an edge client telemetry reactor.
 ///
-/// Configures two strategies that run every 15 seconds:
-/// 1. **AutoFunding** — tops up channels that fall below `min_channel_balance`
-/// 2. **ClosureFinalizer** — force-closes channels that have been pending-close for >5 minutes
-pub fn default_edge_client_telemetry_reactor_cfg(
-    min_channel_balance: HoprBalance,
-    top_up_amount: HoprBalance,
-) -> MultiStrategyConfig {
+/// Runs a single [`ChannelLifecycleStrategy`] with its built-in defaults, which
+/// opens, funds, closes, and finalizes outgoing payment channels automatically.
+pub fn default_edge_client_telemetry_reactor_cfg() -> MultiStrategyConfig {
     MultiStrategyConfig {
-        execution_interval: std::time::Duration::from_secs(15),
-        strategies: vec![
-            EdgeStrategyKind::AutoFunding(AutoFundingStrategyConfig {
-                min_stake_threshold: min_channel_balance,
-                funding_amount: top_up_amount,
-            }),
-            EdgeStrategyKind::ClosureFinalizer(ClosureFinalizerStrategyConfig {
-                max_closure_overdue: std::time::Duration::from_secs(300),
-            }),
-        ],
+        strategies: vec![EdgeStrategyKind::ChannelLifecycle(
+            ChannelLifecycleConfig::default(),
+        )],
     }
 }
 
@@ -43,48 +27,18 @@ pub fn default_edge_client_telemetry_reactor_cfg(
 mod tests {
     use super::*;
 
-    fn wxhopr(amount: u128) -> HoprBalance {
-        // HoprBalance = Balance<WxHOPR>; construct from a known string representation.
-        amount.to_string().parse().unwrap_or_default()
+    #[test]
+    fn default_cfg_has_one_strategy() {
+        let cfg = default_edge_client_telemetry_reactor_cfg();
+        assert_eq!(cfg.strategies.len(), 1);
     }
 
     #[test]
-    fn default_cfg_has_two_strategies() {
-        let cfg = default_edge_client_telemetry_reactor_cfg(wxhopr(1), wxhopr(10));
-        assert_eq!(cfg.strategies.len(), 2);
-    }
-
-    #[test]
-    fn default_cfg_execution_interval_is_15s() {
-        let cfg = default_edge_client_telemetry_reactor_cfg(wxhopr(1), wxhopr(10));
-        assert_eq!(cfg.execution_interval, std::time::Duration::from_secs(15));
-    }
-
-    #[test]
-    fn default_cfg_first_strategy_is_auto_funding() {
-        let cfg = default_edge_client_telemetry_reactor_cfg(wxhopr(1), wxhopr(10));
+    fn default_cfg_strategy_is_channel_lifecycle() {
+        let cfg = default_edge_client_telemetry_reactor_cfg();
         assert!(
-            matches!(cfg.strategies[0], EdgeStrategyKind::AutoFunding(_)),
-            "expected first strategy to be AutoFunding"
+            matches!(cfg.strategies[0], EdgeStrategyKind::ChannelLifecycle(_)),
+            "expected strategy to be ChannelLifecycle"
         );
-    }
-
-    #[test]
-    fn default_cfg_second_strategy_is_closure_finalizer() {
-        let cfg = default_edge_client_telemetry_reactor_cfg(wxhopr(1), wxhopr(10));
-        assert!(
-            matches!(cfg.strategies[1], EdgeStrategyKind::ClosureFinalizer(_)),
-            "expected second strategy to be ClosureFinalizer"
-        );
-    }
-
-    #[test]
-    fn closure_finalizer_overdue_is_300s() {
-        let cfg = default_edge_client_telemetry_reactor_cfg(wxhopr(1), wxhopr(10));
-        if let EdgeStrategyKind::ClosureFinalizer(c) = &cfg.strategies[1] {
-            assert_eq!(c.max_closure_overdue, std::time::Duration::from_secs(300));
-        } else {
-            panic!("expected ClosureFinalizer");
-        }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `AutoFundingStrategy` + `ClosureFinalizerStrategy` with the new upstream `ChannelLifecycleStrategy`, which owns open / fund / close / finalize for outgoing payment channels in a single coordinator.
- Switches `HoprEdgeClient` from `FullHopr` to `hopr_reference::EdgeHopr` (= `Hopr<..., ()>`) — entry/exit nodes originate but never relay tickets, so the ticket manager is unnecessary.
- `MultiStrategyConfig` no longer carries `execution_interval`; cadence (tick interval, jitter) is declared inside `ChannelLifecycleConfig` so operators can tune via YAML/TOML without touching wiring code.
- Bumps hoprnet rev pin to `919a165099` and keeps `edgli` at **3.0.0** (strategy wiring only — no behaviour change to released functionality).

Depends on:
- hoprnet/hoprnet#8106 — upstream `ChannelLifecycleStrategy` + `EdgeHopr` restoration

Stacked on:
- #57 (`kauki/feat/api/use-hopr-lib-master`)