### PR TITLE
feat(strategy): compute channel stake from chain ticket price and win prob

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  path_filters:
+    - "!vendor/**"
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+    base_branches:
+      - "master"
+      - "release/.*"
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,7 +18,7 @@ reviews:
       - "DO NOT MERGE"
     drafts: false
     base_branches:
-      - "master"
+      - "main"
       - "release/.*"
 chat:
   auto_reply: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,7 @@ dependencies = [
  "opentelemetry_sdk",
  "serde_yaml",
  "signal-hook",
+ "smart-default",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,15 +843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,13 +1286,10 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -1309,15 +1297,10 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1336,7 +1319,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1347,16 +1329,6 @@ checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "futures-timer",
-]
-
-[[package]]
-name = "bandwidth"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a464cd54c99441ba44d3d09f6f980f8c29d068645022852ab66cbaad42ef6a0"
-dependencies = [
- "rustversion",
- "serde",
 ]
 
 [[package]]
@@ -1650,15 +1622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bytesize"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -2395,17 +2358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,10 +2496,9 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-ct-full-network",
- "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-lib",
  "hopr-reference",
  "hopr-strategy",
- "hoprd-api-client",
  "lazy_static",
  "mimalloc",
  "nix 0.29.0",
@@ -2832,7 +2783,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -3497,17 +3447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-async-runtime"
-version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "auto_impl",
- "futures",
- "indexmap 2.14.0",
- "tokio",
-]
-
-[[package]]
 name = "hopr-bindings"
 version = "4.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,7 +3481,7 @@ dependencies = [
  "futures-time",
  "hex",
  "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-async-runtime",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3561,24 +3500,7 @@ version = "0.5.3"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
  "hex",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "scrypt",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "typenum",
- "uuid",
-]
-
-[[package]]
-name = "hopr-crypto-keypair"
-version = "0.5.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "hex",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-platform",
  "hopr-types",
  "scrypt",
  "serde",
@@ -3596,25 +3518,8 @@ source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff
 dependencies = [
  "flagset",
  "hex",
- "hopr-crypto-sphinx 0.12.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "serde",
- "serde_bytes",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "hopr-crypto-packet"
-version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "flagset",
- "hex",
- "hopr-crypto-sphinx 0.12.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-sphinx",
+ "hopr-parallelize",
  "hopr-types",
  "serde",
  "serde_bytes",
@@ -3627,24 +3532,6 @@ dependencies = [
 name = "hopr-crypto-sphinx"
 version = "0.12.1"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "bimap",
- "curve25519-dalek",
- "elliptic-curve",
- "generic-array 1.4.1",
- "hopr-types",
- "k256",
- "serde",
- "serde_bytes",
- "subtle",
- "thiserror 2.0.18",
- "typenum",
-]
-
-[[package]]
-name = "hopr-crypto-sphinx"
-version = "0.12.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3670,7 +3557,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-statistics",
  "smart-default",
  "tracing",
  "validator",
@@ -3691,48 +3578,13 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-crypto-keypair 0.5.3 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport 0.28.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "humantime-serde",
- "lazy_static",
- "parking_lot",
- "serde",
- "serde_with",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "hopr-lib"
-version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "async-broadcast",
- "async-trait",
- "backon",
- "cfg_eval",
- "const_format",
- "futures",
- "futures-concurrency",
- "futures-time",
- "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-crypto-keypair 0.5.3 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport 0.28.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-crypto-keypair",
+ "hopr-metrics",
+ "hopr-network-types",
+ "hopr-parallelize",
+ "hopr-platform",
+ "hopr-transport",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3750,16 +3602,6 @@ dependencies = [
 name = "hopr-metrics"
 version = "2.0.0"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "opentelemetry",
- "opentelemetry-prometheus-text-exporter",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "hopr-metrics"
-version = "2.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
 dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
@@ -3775,7 +3617,7 @@ dependencies = [
  "bimap",
  "futures",
  "hopr-api",
- "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-statistics",
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
@@ -3793,35 +3635,8 @@ dependencies = [
  "futures",
  "futures-time",
  "hickory-resolver 0.26.1",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "pin-project",
- "serde",
- "serde_bytes",
- "socket2 0.6.3",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hopr-network-types"
-version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "arrayvec",
- "flume",
- "futures",
- "futures-time",
- "hickory-resolver 0.26.1",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-metrics",
  "hopr-types",
  "lazy_static",
  "libp2p-identity",
@@ -3843,22 +3658,7 @@ version = "0.2.2"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
  "futures",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "lazy_static",
- "libc",
- "rayon",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hopr-parallelize"
-version = "0.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "futures",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics",
  "lazy_static",
  "libc",
  "rayon",
@@ -3876,32 +3676,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-platform"
-version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "serde",
- "serde_bytes",
- "strum 0.28.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "hopr-protocol-app"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet",
  "hopr-types",
  "serde",
  "serde_bytes",
@@ -3922,43 +3701,11 @@ dependencies = [
  "cfg_eval",
  "hex",
  "hopr-api",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "humantime-serde",
- "lazy_static",
- "moka",
- "parking_lot",
- "ringbuffer",
- "serde",
- "serde_with",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "hopr-protocol-hopr"
-version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "async-trait",
- "auto_impl",
- "bloomfilter",
- "bytes",
- "cfg_eval",
- "hex",
- "hopr-api",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet",
+ "hopr-metrics",
+ "hopr-parallelize",
+ "hopr-platform",
+ "hopr-ticket-manager",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3988,41 +3735,9 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hashbrown 0.17.0",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "lazy_static",
- "parking_lot",
- "pin-project",
- "ringbuffer",
- "serde",
- "serde_bytes",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hopr-protocol-session"
-version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "aquamarine",
- "asynchronous-codec",
- "auto_impl",
- "bitvec",
- "bytes",
- "dashmap",
- "futures",
- "futures-concurrency",
- "futures-time",
- "hashbrown 0.17.0",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-crypto-packet",
+ "hopr-metrics",
  "hopr-types",
  "lazy_static",
  "parking_lot",
@@ -4044,23 +3759,8 @@ source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff
 dependencies = [
  "aquamarine",
  "flagset",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "serde",
- "serde_cbor_2",
- "strum 0.28.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "hopr-protocol-start"
-version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "aquamarine",
- "flagset",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet",
+ "hopr-protocol-app",
  "serde",
  "serde_cbor_2",
  "strum 0.28.0",
@@ -4076,9 +3776,9 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-ct-full-network",
- "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-lib",
  "hopr-network-graph",
- "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-ticket-manager",
  "hopr-transport-p2p",
  "tokio",
  "tracing",
@@ -4094,14 +3794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-statistics"
-version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "rand 0.10.1",
-]
-
-[[package]]
 name = "hopr-strategy"
 version = "0.19.0"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
@@ -4112,8 +3804,8 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-async-runtime",
+ "hopr-lib",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4138,29 +3830,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.0",
  "hopr-api",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "parking_lot",
- "postcard",
- "redb",
- "strum 0.28.0",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "hopr-ticket-manager"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "ahash",
- "anyhow",
- "clap",
- "dashmap",
- "futures",
- "hashbrown 0.17.0",
- "hopr-api",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-platform",
  "parking_lot",
  "postcard",
  "redb",
@@ -4182,56 +3852,18 @@ dependencies = [
  "futures",
  "futures-time",
  "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-mixer 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-path 0.3.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-probe 0.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-protocol 1.8.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-session 0.21.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "humantime-serde",
- "lazy_static",
- "moka",
- "multiaddr",
- "proc-macro-regex",
- "rust-stream-ext-concurrent",
- "serde",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "hopr-transport"
-version = "0.28.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "cfg-if",
- "futures",
- "futures-time",
- "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-mixer 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-path 0.3.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-probe 0.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-protocol 1.8.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-session 0.21.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-crypto-packet",
+ "hopr-network-types",
+ "hopr-protocol-app",
+ "hopr-protocol-hopr",
+ "hopr-ticket-manager",
+ "hopr-transport-mixer",
+ "hopr-transport-path",
+ "hopr-transport-probe",
+ "hopr-transport-protocol",
+ "hopr-transport-session",
+ "hopr-transport-tag-allocator",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4253,23 +3885,7 @@ source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff
 dependencies = [
  "futures",
  "futures-timer",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "lazy_static",
- "parking_lot",
- "smart-default",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "hopr-transport-mixer"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "futures",
- "futures-timer",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics",
  "hopr-types",
  "lazy_static",
  "parking_lot",
@@ -4289,7 +3905,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-network-types",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4306,32 +3922,10 @@ dependencies = [
  "futures",
  "futures-time",
  "hopr-api",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "lazy_static",
- "moka",
- "smart-default",
- "thiserror 2.0.18",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "hopr-transport-path"
-version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "futures",
- "futures-time",
- "hopr-api",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet",
+ "hopr-metrics",
+ "hopr-protocol-hopr",
+ "hopr-statistics",
  "hopr-types",
  "lazy_static",
  "moka",
@@ -4352,36 +3946,10 @@ dependencies = [
  "futures-concurrency",
  "hex",
  "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "humantime-serde",
- "moka",
- "rand 0.10.1",
- "serde",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "hopr-transport-probe"
-version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "futures-concurrency",
- "hex",
- "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-platform",
+ "hopr-protocol-app",
+ "hopr-transport-tag-allocator",
  "humantime-serde",
  "moka",
  "rand 0.10.1",
@@ -4406,47 +3974,13 @@ dependencies = [
  "futures-time",
  "halfbrown",
  "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "humantime-serde",
- "lazy_static",
- "libp2p",
- "moka",
- "rust-stream-ext-concurrent",
- "serde",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio-util",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "hopr-transport-protocol"
-version = "1.8.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "ahash",
- "anyhow",
- "bytes",
- "dashmap",
- "futures",
- "futures-time",
- "halfbrown",
- "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-crypto-packet",
+ "hopr-metrics",
+ "hopr-network-types",
+ "hopr-parallelize",
+ "hopr-protocol-app",
+ "hopr-protocol-hopr",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4472,49 +4006,14 @@ dependencies = [
  "flagset",
  "futures",
  "futures-time",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-session 1.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-protocol-start 1.1.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "hopr-types",
- "humantime-serde",
- "lazy_static",
- "moka",
- "parking_lot",
- "pid",
- "pin-project",
- "serde",
- "serde_repr",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hopr-transport-session"
-version = "0.21.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "arrayvec",
- "async-trait",
- "flagset",
- "futures",
- "futures-time",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-session 1.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-protocol-start 1.1.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-async-runtime",
+ "hopr-crypto-packet",
+ "hopr-metrics",
+ "hopr-network-types",
+ "hopr-protocol-app",
+ "hopr-protocol-session",
+ "hopr-protocol-start",
+ "hopr-transport-tag-allocator",
  "hopr-types",
  "humantime-serde",
  "lazy_static",
@@ -4536,19 +4035,7 @@ name = "hopr-transport-tag-allocator"
 version = "0.1.1"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
- "serde",
- "smart-default",
- "thiserror 2.0.18",
- "validator",
-]
-
-[[package]]
-name = "hopr-transport-tag-allocator"
-version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-app",
  "serde",
  "smart-default",
  "thiserror 2.0.18",
@@ -4605,91 +4092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-utils-session"
-version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "bytesize",
- "dashmap",
- "futures",
- "futures-time",
- "hopr-api",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-transport 0.28.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "human-bandwidth",
- "lazy_static",
- "parking_lot",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "hoprd-api"
-version = "4.11.0"
-source = "git+https://github.com/hoprnet/hoprd?rev=e36eb8164d222a24c16408fc38a39d3478541971#e36eb8164d222a24c16408fc38a39d3478541971"
-dependencies = [
- "axum",
- "base64 0.22.1",
- "bytesize",
- "const_format",
- "futures",
- "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
- "hopr-utils-session",
- "human-bandwidth",
- "lazy_static",
- "regex",
- "serde",
- "serde_json",
- "serde_with",
- "smart-default",
- "strum 0.28.0",
- "tokio",
- "tower",
- "tower-http",
- "tracing",
- "utoipa",
- "utoipa-scalar",
- "utoipa-swagger-ui",
- "validator",
-]
-
-[[package]]
-name = "hoprd-api-client"
-version = "0.1.2"
-source = "git+https://github.com/hoprnet/hoprd?rev=e36eb8164d222a24c16408fc38a39d3478541971#e36eb8164d222a24c16408fc38a39d3478541971"
-dependencies = [
- "bytes",
- "chrono",
- "futures",
- "futures-core",
- "hoprd-api",
- "http",
- "openapiv3",
- "percent-encoding",
- "prettyplease",
- "progenitor",
- "progenitor-client",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "syn 2.0.117",
- "utoipa",
- "uuid",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,16 +4135,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "human-bandwidth"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5afe042873d564e1fccc5d50983e1e6341ffcae8fb7603c6c542de7129a785"
-dependencies = [
- "bandwidth",
- "serde",
-]
 
 [[package]]
 name = "humantime"
@@ -5913,16 +5305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6254,17 +5636,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openapiv3"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "openssl"
@@ -6797,72 +6168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "progenitor"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36315275b213c64c68dff684477ea7118a0f630832f737b550796a368f9962c"
-dependencies = [
- "progenitor-client",
- "progenitor-impl",
- "progenitor-macro",
-]
-
-[[package]]
-name = "progenitor-client"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3999c302f5f2a42b7ca1cc39ad9e612c74cf2910ef6e58f869e45f3068b9659f"
-dependencies = [
- "bytes",
- "futures-core",
- "percent-encoding",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "serde_urlencoded",
-]
-
-[[package]]
-name = "progenitor-impl"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de362a0477182f45accdbad4d43cd89a95a1db0a518a7c1ddf3e525e6896f0f0"
-dependencies = [
- "heck 0.5.0",
- "http",
- "indexmap 2.14.0",
- "openapiv3",
- "proc-macro2",
- "quote",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "typify",
- "unicode-ident",
-]
-
-[[package]]
-name = "progenitor-macro"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98aeaaab266bf848a602c78e039e7d62c80ba36303ae4092ec65f17e7fd0eaa"
-dependencies = [
- "openapiv3",
- "proc-macro2",
- "progenitor-impl",
- "quote",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "serde_yaml",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "prometheus-client"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7252,16 +6557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "regress"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
-dependencies = [
- "hashbrown 0.16.1",
- "memchr",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7300,7 +6595,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -7313,7 +6608,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -7330,18 +6624,15 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -7442,40 +6733,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.117",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2 0.10.9",
- "walkdir",
-]
 
 [[package]]
 name = "rust-stream-ext-concurrent"
@@ -7681,20 +6938,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "chrono",
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -7715,18 +6958,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7841,10 +7072,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "semver-parser"
@@ -7906,17 +7133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7930,17 +7146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7948,18 +7153,6 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
  "syn 2.0.117",
 ]
 
@@ -8736,14 +7929,12 @@ dependencies = [
  "http-body",
  "http-body-util",
  "iri-string",
- "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -8764,7 +7955,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8846,53 +8036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
-name = "typify"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
-dependencies = [
- "typify-impl",
- "typify-macro",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
-dependencies = [
- "heck 0.5.0",
- "log",
- "proc-macro2",
- "quote",
- "regress",
- "schemars 0.8.22",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "typify-macro"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars 0.8.22",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn 2.0.117",
- "typify-impl",
-]
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8927,12 +8070,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -9010,66 +8147,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "utoipa"
-version = "5.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_json",
- "utoipa-gen",
-]
-
-[[package]]
-name = "utoipa-gen"
-version = "5.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "utoipa-scalar"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
-dependencies = [
- "axum",
- "serde",
- "serde_json",
- "utoipa",
-]
-
-[[package]]
-name = "utoipa-swagger-ui"
-version = "9.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
-dependencies = [
- "axum",
- "base64 0.22.1",
- "mime_guess",
- "regex",
- "rust-embed",
- "serde",
- "serde_json",
- "url",
- "utoipa",
- "utoipa-swagger-ui-vendored",
- "zip",
-]
-
-[[package]]
-name = "utoipa-swagger-ui-vendored"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
@@ -9265,19 +8342,6 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -9968,42 +9032,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap 2.14.0",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1266,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,10 +1295,13 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -1275,10 +1309,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1297,6 +1336,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1307,6 +1347,16 @@ checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "futures-timer",
+]
+
+[[package]]
+name = "bandwidth"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a464cd54c99441ba44d3d09f6f980f8c29d068645022852ab66cbaad42ef6a0"
+dependencies = [
+ "rustversion",
+ "serde",
 ]
 
 [[package]]
@@ -1603,6 +1653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "c-kzg"
 version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1821,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -2327,6 +2395,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,18 +2544,26 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-ct-full-network",
- "hopr-lib",
+ "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "hopr-reference",
  "hopr-strategy",
+ "hoprd-api-client",
  "lazy_static",
  "mimalloc",
+ "nix 0.29.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rand 0.8.6",
+ "reqwest 0.13.3",
+ "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "signal-hook",
  "smart-default",
  "strum 0.28.0",
+ "tempfile",
+ "test-log",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2577,6 +2664,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -2724,6 +2832,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2787,6 +2896,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3382,6 +3497,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-async-runtime"
+version = "0.5.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "auto_impl",
+ "futures",
+ "indexmap 2.14.0",
+ "tokio",
+]
+
+[[package]]
 name = "hopr-bindings"
 version = "4.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,7 +3542,7 @@ dependencies = [
  "futures-time",
  "hex",
  "hopr-api",
- "hopr-async-runtime",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3435,7 +3561,24 @@ version = "0.5.3"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
  "hex",
- "hopr-platform",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "typenum",
+ "uuid",
+]
+
+[[package]]
+name = "hopr-crypto-keypair"
+version = "0.5.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "hex",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "scrypt",
  "serde",
@@ -3453,8 +3596,25 @@ source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff
 dependencies = [
  "flagset",
  "hex",
- "hopr-crypto-sphinx",
- "hopr-parallelize",
+ "hopr-crypto-sphinx 0.12.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-crypto-packet"
+version = "1.3.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "flagset",
+ "hex",
+ "hopr-crypto-sphinx 0.12.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "serde",
  "serde_bytes",
@@ -3482,6 +3642,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-crypto-sphinx"
+version = "0.12.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "bimap",
+ "curve25519-dalek",
+ "elliptic-curve",
+ "generic-array 1.4.1",
+ "hopr-types",
+ "k256",
+ "serde",
+ "serde_bytes",
+ "subtle",
+ "thiserror 2.0.18",
+ "typenum",
+]
+
+[[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
@@ -3492,7 +3670,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-statistics",
+ "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "smart-default",
  "tracing",
  "validator",
@@ -3513,13 +3691,48 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-async-runtime",
- "hopr-crypto-keypair",
- "hopr-metrics",
- "hopr-network-types",
- "hopr-parallelize",
- "hopr-platform",
- "hopr-transport",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-crypto-keypair 0.5.3 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport 0.28.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "humantime-serde",
+ "lazy_static",
+ "parking_lot",
+ "serde",
+ "serde_with",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "hopr-lib"
+version = "4.0.2-rc.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "async-broadcast",
+ "async-trait",
+ "backon",
+ "cfg_eval",
+ "const_format",
+ "futures",
+ "futures-concurrency",
+ "futures-time",
+ "hopr-api",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-keypair 0.5.3 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport 0.28.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3544,6 +3757,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-metrics"
+version = "2.0.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-prometheus-text-exporter",
+ "opentelemetry_sdk",
+]
+
+[[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
@@ -3552,7 +3775,7 @@ dependencies = [
  "bimap",
  "futures",
  "hopr-api",
- "hopr-statistics",
+ "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
@@ -3570,8 +3793,35 @@ dependencies = [
  "futures",
  "futures-time",
  "hickory-resolver 0.26.1",
- "hopr-async-runtime",
- "hopr-metrics",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "pin-project",
+ "serde",
+ "serde_bytes",
+ "socket2 0.6.3",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-network-types"
+version = "1.2.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "arrayvec",
+ "flume",
+ "futures",
+ "futures-time",
+ "hickory-resolver 0.26.1",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "lazy_static",
  "libp2p-identity",
@@ -3593,7 +3843,22 @@ version = "0.2.2"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
  "futures",
- "hopr-metrics",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "lazy_static",
+ "libc",
+ "rayon",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-parallelize"
+version = "0.2.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "futures",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "lazy_static",
  "libc",
  "rayon",
@@ -3611,11 +3876,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-platform"
+version = "0.3.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "hopr-protocol-app"
+version = "1.0.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "serde",
  "serde_bytes",
@@ -3636,11 +3922,43 @@ dependencies = [
  "cfg_eval",
  "hex",
  "hopr-api",
- "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-parallelize",
- "hopr-platform",
- "hopr-ticket-manager",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "humantime-serde",
+ "lazy_static",
+ "moka",
+ "parking_lot",
+ "ringbuffer",
+ "serde",
+ "serde_with",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "hopr-protocol-hopr"
+version = "4.6.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "auto_impl",
+ "bloomfilter",
+ "bytes",
+ "cfg_eval",
+ "hex",
+ "hopr-api",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3670,9 +3988,41 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hashbrown 0.17.0",
- "hopr-async-runtime",
- "hopr-crypto-packet",
- "hopr-metrics",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "lazy_static",
+ "parking_lot",
+ "pin-project",
+ "ringbuffer",
+ "serde",
+ "serde_bytes",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-protocol-session"
+version = "1.1.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "aquamarine",
+ "asynchronous-codec",
+ "auto_impl",
+ "bitvec",
+ "bytes",
+ "dashmap",
+ "futures",
+ "futures-concurrency",
+ "futures-time",
+ "hashbrown 0.17.0",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "lazy_static",
  "parking_lot",
@@ -3694,8 +4044,23 @@ source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff
 dependencies = [
  "aquamarine",
  "flagset",
- "hopr-crypto-packet",
- "hopr-protocol-app",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "serde",
+ "serde_cbor_2",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "hopr-protocol-start"
+version = "1.1.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "aquamarine",
+ "flagset",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "serde",
  "serde_cbor_2",
  "strum 0.28.0",
@@ -3711,9 +4076,9 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-ct-full-network",
- "hopr-lib",
+ "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "hopr-network-graph",
- "hopr-ticket-manager",
+ "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "hopr-transport-p2p",
  "tokio",
  "tracing",
@@ -3729,6 +4094,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-statistics"
+version = "0.2.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "rand 0.10.1",
+]
+
+[[package]]
 name = "hopr-strategy"
 version = "0.19.0"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
@@ -3739,8 +4112,8 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
- "hopr-async-runtime",
- "hopr-lib",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3765,7 +4138,29 @@ dependencies = [
  "futures",
  "hashbrown 0.17.0",
  "hopr-api",
- "hopr-platform",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "parking_lot",
+ "postcard",
+ "redb",
+ "strum 0.28.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-ticket-manager"
+version = "0.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "clap",
+ "dashmap",
+ "futures",
+ "hashbrown 0.17.0",
+ "hopr-api",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "parking_lot",
  "postcard",
  "redb",
@@ -3787,18 +4182,56 @@ dependencies = [
  "futures",
  "futures-time",
  "hopr-api",
- "hopr-async-runtime",
- "hopr-crypto-packet",
- "hopr-network-types",
- "hopr-protocol-app",
- "hopr-protocol-hopr",
- "hopr-ticket-manager",
- "hopr-transport-mixer",
- "hopr-transport-path",
- "hopr-transport-probe",
- "hopr-transport-protocol",
- "hopr-transport-session",
- "hopr-transport-tag-allocator",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-mixer 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-path 0.3.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-probe 0.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-protocol 1.8.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-session 0.21.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "humantime-serde",
+ "lazy_static",
+ "moka",
+ "multiaddr",
+ "proc-macro-regex",
+ "rust-stream-ext-concurrent",
+ "serde",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "hopr-transport"
+version = "0.28.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "futures",
+ "futures-time",
+ "hopr-api",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-ticket-manager 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-mixer 0.4.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-path 0.3.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-probe 0.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-protocol 1.8.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-session 0.21.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3820,7 +4253,23 @@ source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff
 dependencies = [
  "futures",
  "futures-timer",
- "hopr-metrics",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "lazy_static",
+ "parking_lot",
+ "smart-default",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-transport-mixer"
+version = "0.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "lazy_static",
  "parking_lot",
@@ -3840,7 +4289,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-network-types",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -3857,10 +4306,32 @@ dependencies = [
  "futures",
  "futures-time",
  "hopr-api",
- "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-protocol-hopr",
- "hopr-statistics",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "lazy_static",
+ "moka",
+ "smart-default",
+ "thiserror 2.0.18",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "hopr-transport-path"
+version = "0.3.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "futures",
+ "futures-time",
+ "hopr-api",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-statistics 0.2.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "lazy_static",
  "moka",
@@ -3881,10 +4352,36 @@ dependencies = [
  "futures-concurrency",
  "hex",
  "hopr-api",
- "hopr-async-runtime",
- "hopr-platform",
- "hopr-protocol-app",
- "hopr-transport-tag-allocator",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "humantime-serde",
+ "moka",
+ "rand 0.10.1",
+ "serde",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "hopr-transport-probe"
+version = "0.6.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "futures-concurrency",
+ "hex",
+ "hopr-api",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-platform 0.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "humantime-serde",
  "moka",
  "rand 0.10.1",
@@ -3909,13 +4406,47 @@ dependencies = [
  "futures-time",
  "halfbrown",
  "hopr-api",
- "hopr-async-runtime",
- "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-network-types",
- "hopr-parallelize",
- "hopr-protocol-app",
- "hopr-protocol-hopr",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "humantime-serde",
+ "lazy_static",
+ "libp2p",
+ "moka",
+ "rust-stream-ext-concurrent",
+ "serde",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio-util",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "hopr-transport-protocol"
+version = "1.8.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bytes",
+ "dashmap",
+ "futures",
+ "futures-time",
+ "halfbrown",
+ "hopr-api",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-parallelize 0.2.2 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-hopr 4.6.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -3941,14 +4472,49 @@ dependencies = [
  "flagset",
  "futures",
  "futures-time",
- "hopr-async-runtime",
- "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-network-types",
- "hopr-protocol-app",
- "hopr-protocol-session",
- "hopr-protocol-start",
- "hopr-transport-tag-allocator",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-session 1.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-protocol-start 1.1.0 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "hopr-types",
+ "humantime-serde",
+ "lazy_static",
+ "moka",
+ "parking_lot",
+ "pid",
+ "pin-project",
+ "serde",
+ "serde_repr",
+ "smart-default",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-transport-session"
+version = "0.21.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "async-trait",
+ "flagset",
+ "futures",
+ "futures-time",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-crypto-packet 1.3.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-session 1.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-protocol-start 1.1.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport-tag-allocator 0.1.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "hopr-types",
  "humantime-serde",
  "lazy_static",
@@ -3970,7 +4536,19 @@ name = "hopr-transport-tag-allocator"
 version = "0.1.1"
 source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
 dependencies = [
- "hopr-protocol-app",
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14)",
+ "serde",
+ "smart-default",
+ "thiserror 2.0.18",
+ "validator",
+]
+
+[[package]]
+name = "hopr-transport-tag-allocator"
+version = "0.1.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "hopr-protocol-app 1.0.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
  "serde",
  "smart-default",
  "thiserror 2.0.18",
@@ -4027,6 +4605,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-utils-session"
+version = "1.1.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad#f7ffd6261a924948f617f3712232fdb8c228d3ad"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytesize",
+ "dashmap",
+ "futures",
+ "futures-time",
+ "hopr-api",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-network-types 1.2.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-transport 0.28.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "human-bandwidth",
+ "lazy_static",
+ "parking_lot",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "hoprd-api"
+version = "4.11.0"
+source = "git+https://github.com/hoprnet/hoprd?rev=e36eb8164d222a24c16408fc38a39d3478541971#e36eb8164d222a24c16408fc38a39d3478541971"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "bytesize",
+ "const_format",
+ "futures",
+ "hopr-async-runtime 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-lib 4.0.2-rc.1 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-metrics 2.0.0 (git+https://github.com/hoprnet/hoprnet?rev=f7ffd6261a924948f617f3712232fdb8c228d3ad)",
+ "hopr-utils-session",
+ "human-bandwidth",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smart-default",
+ "strum 0.28.0",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "utoipa",
+ "utoipa-scalar",
+ "utoipa-swagger-ui",
+ "validator",
+]
+
+[[package]]
+name = "hoprd-api-client"
+version = "0.1.2"
+source = "git+https://github.com/hoprnet/hoprd?rev=e36eb8164d222a24c16408fc38a39d3478541971#e36eb8164d222a24c16408fc38a39d3478541971"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures",
+ "futures-core",
+ "hoprd-api",
+ "http",
+ "openapiv3",
+ "percent-encoding",
+ "prettyplease",
+ "progenitor",
+ "progenitor-client",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "syn 2.0.117",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,6 +4733,16 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human-bandwidth"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5afe042873d564e1fccc5d50983e1e6341ffcae8fb7603c6c542de7129a785"
+dependencies = [
+ "bandwidth",
+ "serde",
+]
 
 [[package]]
 name = "humantime"
@@ -5240,6 +5913,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,6 +6096,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -5559,6 +6254,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openapiv3"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "openssl"
@@ -6091,6 +6797,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "progenitor"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36315275b213c64c68dff684477ea7118a0f630832f737b550796a368f9962c"
+dependencies = [
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3999c302f5f2a42b7ca1cc39ad9e612c74cf2910ef6e58f869e45f3068b9659f"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de362a0477182f45accdbad4d43cd89a95a1db0a518a7c1ddf3e525e6896f0f0"
+dependencies = [
+ "heck 0.5.0",
+ "http",
+ "indexmap 2.14.0",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "typify",
+ "unicode-ident",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98aeaaab266bf848a602c78e039e7d62c80ba36303ae4092ec65f17e7fd0eaa"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl",
+ "quote",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "serde_yaml",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6219,6 +6991,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6479,6 +7252,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6517,7 +7300,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -6530,25 +7313,35 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -6611,7 +7404,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
- "nix",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6649,6 +7442,40 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
 
 [[package]]
 name = "rust-stream-ext-concurrent"
@@ -6718,6 +7545,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -6750,11 +7578,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6825,6 +7681,20 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -6845,6 +7715,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6959,6 +7841,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"
@@ -7020,6 +7906,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7033,6 +7930,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7040,6 +7948,18 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
  "syn 2.0.117",
 ]
 
@@ -7490,6 +8410,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-core"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn 2.0.117",
+ "test-log-core",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7612,7 +8564,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "tracing",
@@ -7782,12 +8736,14 @@ dependencies = [
  "http-body",
  "http-body-util",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7808,6 +8764,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7889,6 +8846,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "typify"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+dependencies = [
+ "heck 0.5.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars 0.8.22",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars 0.8.22",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.117",
+ "typify-impl",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7923,6 +8927,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -8000,6 +9010,66 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "utoipa-swagger-ui-vendored",
+ "zip",
+]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
@@ -8204,6 +9274,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8247,6 +9330,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8876,10 +9968,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ prof = [
 
 [dependencies]
 anyhow = "1.0.100"
+smart-default = "0.7"
 async-signal = "0.2.13"
 async-trait = "0.1"
 cfg-if = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,10 @@ hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2
   "testing",
 ] }
 tokio = { version = "1", features = ["full", "process"] }
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+reqwest = { version = "0.13", default-features = false, features = [
+  "rustls",
+  "json",
+] }
 tempfile = "3"
 sha2 = "0.10"
 nix = { version = "0.29", features = ["signal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,8 +93,6 @@ hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2
   "runtime-tokio",
   "testing",
 ] }
-# Integration test dependencies
-hoprd-api-client = { git = "https://github.com/hoprnet/hoprd", rev = "e36eb8164d222a24c16408fc38a39d3478541971" }
 tokio = { version = "1", features = ["full", "process"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,17 @@ hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2
   "runtime-tokio",
   "testing",
 ] }
+# Integration test dependencies
+hoprd-api-client = { git = "https://github.com/hoprnet/hoprd", rev = "e36eb8164d222a24c16408fc38a39d3478541971" }
+tokio = { version = "1", features = ["full", "process"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+tempfile = "3"
+sha2 = "0.10"
+nix = { version = "0.29", features = ["signal"] }
+rand = "0.8"
+serde_json = "1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+test-log = { version = "0.2", features = ["trace"] }
 
 [build-dependencies]
 anyhow = "1.0.100"

--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -36,6 +36,10 @@ pub(crate) fn new_blokli_client(url: Option<Url>) -> BlokliClient {
             timeout: std::time::Duration::from_secs(3),
             // This is actually maximum delay; starts at 2 s with backoff until 30 s.
             stream_reconnect_timeout: std::time::Duration::from_secs(30),
+            // bloklid-anvil :latest does not yet advertise `indexes_safe_events`
+            // in its feature flags even though it indexes them. Skip the check
+            // so local-cluster testing works without pinning an unreleased image.
+            auto_compatibility_check: false,
             ..Default::default()
         },
     )

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -75,14 +75,14 @@ pub fn compute_funding_config(
     })
 }
 
-/// Returns the default [`MultiStrategyConfig`] for an edge client telemetry reactor.
+/// Returns the default [`MultiStrategyConfig`] for an edge client reactor.
 ///
 /// Fetches the minimum ticket price and winning probability from the chain and
 /// sizes the [`ChannelLifecycleStrategy`] funding to cover
 /// `sizing.desired_message_count` messages per channel.
 /// See [`compute_funding_config`] for the sizing formula.
 #[cfg(feature = "runtime-tokio")]
-pub async fn default_edge_client_telemetry_reactor_cfg(
+pub async fn default_strategy_cfg(
     node: &crate::client::Edgli,
     sizing: IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -59,12 +59,14 @@ impl IncentiveConfiguration {
 
 /// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
 ///
-/// `ticket_price` is the oracle's minimum expected value per relayed hop.
-/// The ticket face value (amount locked per ticket) = `ticket_price / win_prob`.
+/// **Semantics:** `ticket_price` is the *expected* per-hop value (= `face_value × win_prob`),
+/// not the face value. Per-hop expected channel drain is therefore `ticket_price`,
+/// regardless of `win_prob`. The ticket face value (amount locked per ticket)
+/// = `ticket_price / win_prob`.
 ///
 /// Sizes `initial_balance` as the larger of:
-/// - expected drain over `sizing.desired_message_count` messages: `N × ticket_price`
-/// - one ticket's face value (floor so the channel can send at least one packet):
+/// - expected drain over `sizing.desired_message_count` packets: `N × ticket_price`
+/// - one ticket's face value (the channel cannot mint a single ticket otherwise):
 ///   `ticket_price / win_prob`
 ///
 /// Derived fields keep the strategy's semantic invariants
@@ -83,7 +85,9 @@ pub fn compute_funding_config(
     );
     // face_value = price / win_prob: channel needs ≥1 face_value to issue any ticket.
     let face_value = ticket_price.div_f64(win_prob)?;
-    // expected_drain = N × ticket_price: each message costs one ticket_price in expected channel drain.
+    // expected_drain = N × ticket_price (NOT × win_prob — ticket_price is already
+    // the expected per-hop value: each ticket has face = ticket_price/win_prob
+    // and pays out with probability win_prob, so expected per-ticket drain = ticket_price).
     let expected_drain = ticket_price * sizing.desired_message_count;
     let initial = expected_drain.max(face_value);
     anyhow::ensure!(

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,6 +1,6 @@
 use hopr_lib::api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps as _};
 pub use hopr_strategy::channel_lifecycle::{
-    ChannelLifecycleConfig, FundingConfig, PopulationConfig,
+    ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
 };
 
 #[cfg(feature = "runtime-tokio")]
@@ -25,7 +25,7 @@ pub struct MultiStrategyConfig {
 #[derive(Debug, Clone, Copy, smart_default::SmartDefault)]
 pub struct IncentiveConfiguration {
     /// Expected number of mixnet messages this channel should forward before exhaustion.
-    /// The stake is sized as the expected drain: `desired_message_count × win_prob × ticket_price`.
+    /// The stake is sized as the expected drain: `desired_message_count × ticket_price`.
     /// Default: 1,000,000.
     #[default = 1_000_000]
     pub desired_message_count: u64,
@@ -41,9 +41,13 @@ pub struct IncentiveConfiguration {
 
 /// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
 ///
-/// Sizes the initial channel stake as the expected drain over
-/// `sizing.desired_message_count` messages:
-/// `desired_message_count × win_prob × ticket_price`.
+/// `ticket_price` is the oracle's minimum expected value per relayed hop.
+/// The ticket face value (amount locked per ticket) = `ticket_price / win_prob`.
+///
+/// Sizes `initial_balance` as the larger of:
+/// - expected drain over `sizing.desired_message_count` messages: `N × ticket_price`
+/// - one ticket's face value (floor so the channel can send at least one packet):
+///   `ticket_price / win_prob`
 ///
 /// Derived fields keep the strategy's semantic invariants
 /// (`lower < initial`, `topup + lower ≈ initial`):
@@ -59,10 +63,14 @@ pub fn compute_funding_config(
         win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
         "win_prob must be in (0, 1]; got {win_prob}"
     );
-    let initial = (ticket_price * sizing.desired_message_count).mul_f64(win_prob)?;
+    // face_value = price / win_prob: channel needs ≥1 face_value to issue any ticket.
+    let face_value = ticket_price.div_f64(win_prob)?;
+    // expected_drain = N × ticket_price: each message costs one ticket_price in expected channel drain.
+    let expected_drain = ticket_price * sizing.desired_message_count;
+    let initial = expected_drain.max(face_value);
     anyhow::ensure!(
         initial > HoprBalance::new_base(0),
-        "computed initial_balance is zero; increase desired_message_count or ticket_price"
+        "computed initial_balance is zero; ticket_price is zero"
     );
     let topup = initial.mul_f64(0.75)?;
     let lower = initial.mul_f64(0.25)?;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,4 +1,5 @@
-pub use hopr_strategy::channel_lifecycle::ChannelLifecycleConfig;
+use hopr_lib::api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps as _};
+pub use hopr_strategy::channel_lifecycle::{ChannelLifecycleConfig, FundingConfig};
 
 /// Subset of strategies relevant to an edge node.
 pub enum EdgeStrategyKind {
@@ -11,34 +12,148 @@ pub struct MultiStrategyConfig {
     pub strategies: Vec<EdgeStrategyKind>,
 }
 
+/// Desired channel capacity for computing the initial stake.
+#[derive(Debug, Clone, Copy)]
+pub struct ChannelSizing {
+    /// Expected number of mixnet messages this channel should forward before exhaustion.
+    /// The stake is sized as the expected drain: `desired_message_count × win_prob × ticket_price`.
+    /// Default: 1,000,000.
+    pub desired_message_count: u64,
+}
+
+impl Default for ChannelSizing {
+    fn default() -> Self {
+        Self {
+            desired_message_count: 1_000_000,
+        }
+    }
+}
+
+/// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
+///
+/// Sizes the initial channel stake as the expected drain over
+/// `sizing.desired_message_count` messages:
+/// `desired_message_count × win_prob × ticket_price`.
+///
+/// Derived fields keep the strategy's semantic invariants
+/// (`lower < initial`, `topup + lower ≈ initial`):
+/// - `topup_balance`            = 75% of `initial_balance`
+/// - `lower_balance_threshold`  = 25% of `initial_balance`
+/// - `min_safe_balance_required` = `initial_balance`
+pub fn compute_funding_config(
+    ticket_price: HoprBalance,
+    win_prob: f64,
+    sizing: &ChannelSizing,
+) -> anyhow::Result<FundingConfig> {
+    anyhow::ensure!(win_prob > 0.0, "win_prob must be positive; got {win_prob}");
+    let initial = (ticket_price * sizing.desired_message_count).mul_f64(win_prob)?;
+    let topup = initial.mul_f64(0.75)?;
+    let lower = initial.mul_f64(0.25)?;
+    Ok(FundingConfig {
+        initial_balance: initial,
+        topup_balance: topup,
+        lower_balance_threshold: lower,
+        min_safe_balance_required: initial,
+        stop_when_unfunded: true,
+    })
+}
+
 /// Returns the default [`MultiStrategyConfig`] for an edge client telemetry reactor.
 ///
-/// Runs a single [`ChannelLifecycleStrategy`] with its built-in defaults, which
-/// opens, funds, closes, and finalizes outgoing payment channels automatically.
-pub fn default_edge_client_telemetry_reactor_cfg() -> MultiStrategyConfig {
-    MultiStrategyConfig {
-        strategies: vec![EdgeStrategyKind::ChannelLifecycle(
-            ChannelLifecycleConfig::default(),
-        )],
-    }
+/// Fetches the minimum ticket price and winning probability from the chain and
+/// sizes the [`ChannelLifecycleStrategy`] funding to cover
+/// `sizing.desired_message_count` messages per channel.
+/// See [`compute_funding_config`] for the sizing formula.
+#[cfg(feature = "runtime-tokio")]
+pub async fn default_edge_client_telemetry_reactor_cfg(
+    node: &crate::client::Edgli,
+    sizing: ChannelSizing,
+) -> anyhow::Result<MultiStrategyConfig> {
+    use hopr_lib::api::{chain::ChainValues as _, node::HasChainApi as _};
+    let chain = node.chain_api();
+    let ticket_price = chain.minimum_ticket_price().await?;
+    let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
+    let cfg = ChannelLifecycleConfig {
+        funding: compute_funding_config(ticket_price, win_prob, &sizing)?,
+        ..Default::default()
+    };
+    Ok(MultiStrategyConfig {
+        strategies: vec![EdgeStrategyKind::ChannelLifecycle(cfg)],
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use hopr_lib::api::types::primitive::prelude::HoprBalance;
+
     use super::*;
 
     #[test]
-    fn default_cfg_has_one_strategy() {
-        let cfg = default_edge_client_telemetry_reactor_cfg();
-        assert_eq!(cfg.strategies.len(), 1);
+    fn compute_funding_config_win_prob_one() {
+        // With win_prob=1.0, every ticket pays out → initial = ticket_price × msg_count
+        let cfg = compute_funding_config(
+            HoprBalance::new_base(1),
+            1.0,
+            &ChannelSizing {
+                desired_message_count: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(cfg.initial_balance, HoprBalance::new_base(1));
+        assert_eq!(cfg.min_safe_balance_required, HoprBalance::new_base(1));
+        assert!(cfg.lower_balance_threshold < cfg.initial_balance);
+        assert!(cfg.topup_balance > cfg.lower_balance_threshold);
+        assert!(cfg.topup_balance < cfg.initial_balance);
+        assert!(cfg.stop_when_unfunded);
     }
 
     #[test]
-    fn default_cfg_strategy_is_channel_lifecycle() {
-        let cfg = default_edge_client_telemetry_reactor_cfg();
+    fn compute_funding_config_proportional_fields() {
+        // Verify lower < initial, min_safe == initial, topup ∈ (lower, initial)
+        let cfg = compute_funding_config(
+            HoprBalance::new_base(10),
+            1.0,
+            &ChannelSizing {
+                desired_message_count: 100,
+            },
+        )
+        .unwrap();
+        assert_eq!(cfg.min_safe_balance_required, cfg.initial_balance);
+        assert!(cfg.lower_balance_threshold < cfg.initial_balance);
+        assert!(cfg.topup_balance < cfg.initial_balance);
+        assert!(cfg.topup_balance > cfg.lower_balance_threshold);
+    }
+
+    #[test]
+    fn compute_funding_config_rejects_zero_win_prob() {
         assert!(
-            matches!(cfg.strategies[0], EdgeStrategyKind::ChannelLifecycle(_)),
-            "expected strategy to be ChannelLifecycle"
+            compute_funding_config(HoprBalance::new_base(1), 0.0, &ChannelSizing::default())
+                .is_err()
         );
+    }
+
+    #[test]
+    fn compute_funding_config_default_sizing_has_one_strategy_shape() {
+        // Smoke-test: can build a MultiStrategyConfig from compute_funding_config output
+        let funding = compute_funding_config(
+            HoprBalance::new_base(1),
+            1.0,
+            &ChannelSizing {
+                desired_message_count: 1,
+            },
+        )
+        .unwrap();
+        let lifecycle_cfg = ChannelLifecycleConfig {
+            funding,
+            ..Default::default()
+        };
+        let cfg = MultiStrategyConfig {
+            strategies: vec![EdgeStrategyKind::ChannelLifecycle(lifecycle_cfg)],
+        };
+        assert_eq!(cfg.strategies.len(), 1);
+        assert!(matches!(
+            cfg.strategies[0],
+            EdgeStrategyKind::ChannelLifecycle(_)
+        ));
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -39,6 +39,19 @@ pub struct IncentiveConfiguration {
     pub target_open_channels: usize,
 }
 
+impl IncentiveConfiguration {
+    /// Validate internal consistency of the configuration.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.target_open_channels >= self.min_open_channels,
+            "target_open_channels ({}) must be >= min_open_channels ({})",
+            self.target_open_channels,
+            self.min_open_channels
+        );
+        Ok(())
+    }
+}
+
 /// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
 ///
 /// `ticket_price` is the oracle's minimum expected value per relayed hop.
@@ -94,6 +107,7 @@ pub async fn default_strategy_cfg(
     node: &crate::client::Edgli,
     sizing: IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {
+    sizing.validate()?;
     let chain = node.chain_api();
     let ticket_price = chain.minimum_ticket_price().await?;
     let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -45,8 +45,15 @@ pub fn compute_funding_config(
     win_prob: f64,
     sizing: &ChannelSizing,
 ) -> anyhow::Result<FundingConfig> {
-    anyhow::ensure!(win_prob > 0.0, "win_prob must be positive; got {win_prob}");
+    anyhow::ensure!(
+        win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
+        "win_prob must be in (0, 1]; got {win_prob}"
+    );
     let initial = (ticket_price * sizing.desired_message_count).mul_f64(win_prob)?;
+    anyhow::ensure!(
+        initial > HoprBalance::new_base(0),
+        "computed initial_balance is zero; increase desired_message_count or ticket_price"
+    );
     let topup = initial.mul_f64(0.75)?;
     let lower = initial.mul_f64(0.25)?;
     Ok(FundingConfig {
@@ -129,6 +136,44 @@ mod tests {
         assert!(
             compute_funding_config(HoprBalance::new_base(1), 0.0, &ChannelSizing::default())
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn compute_funding_config_rejects_win_prob_above_one() {
+        assert!(
+            compute_funding_config(HoprBalance::new_base(1), 1.1, &ChannelSizing::default())
+                .is_err()
+        );
+        assert!(
+            compute_funding_config(
+                HoprBalance::new_base(1),
+                f64::INFINITY,
+                &ChannelSizing::default()
+            )
+            .is_err()
+        );
+        assert!(
+            compute_funding_config(
+                HoprBalance::new_base(1),
+                f64::NAN,
+                &ChannelSizing::default()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn compute_funding_config_rejects_zero_initial_balance() {
+        assert!(
+            compute_funding_config(
+                HoprBalance::new_base(0),
+                1.0,
+                &ChannelSizing {
+                    desired_message_count: 0
+                }
+            )
+            .is_err()
         );
     }
 

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -17,9 +17,13 @@ pub struct MultiStrategyConfig {
     pub strategies: Vec<EdgeStrategyKind>,
 }
 
-/// Desired channel capacity and topology for computing the initial stake.
+/// Top-level incentive parameters for the channel lifecycle strategy reactor.
+///
+/// Bundles channel funding sizing with population topology so callers
+/// have a single config knob for the reactor. Designed to accommodate
+/// future incentive extensions beyond the current channel lifecycle strategy.
 #[derive(Debug, Clone, Copy, smart_default::SmartDefault)]
-pub struct ChannelSizing {
+pub struct IncentiveConfiguration {
     /// Expected number of mixnet messages this channel should forward before exhaustion.
     /// The stake is sized as the expected drain: `desired_message_count × win_prob × ticket_price`.
     /// Default: 1,000,000.
@@ -49,7 +53,7 @@ pub struct ChannelSizing {
 pub fn compute_funding_config(
     ticket_price: HoprBalance,
     win_prob: f64,
-    sizing: &ChannelSizing,
+    sizing: &IncentiveConfiguration,
 ) -> anyhow::Result<FundingConfig> {
     anyhow::ensure!(
         win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
@@ -80,7 +84,7 @@ pub fn compute_funding_config(
 #[cfg(feature = "runtime-tokio")]
 pub async fn default_edge_client_telemetry_reactor_cfg(
     node: &crate::client::Edgli,
-    sizing: ChannelSizing,
+    sizing: IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {
     let chain = node.chain_api();
     let ticket_price = chain.minimum_ticket_price().await?;
@@ -111,7 +115,7 @@ mod tests {
         let cfg = compute_funding_config(
             HoprBalance::new_base(1),
             1.0,
-            &ChannelSizing {
+            &IncentiveConfiguration {
                 desired_message_count: 1,
                 ..Default::default()
             },
@@ -131,7 +135,7 @@ mod tests {
         let cfg = compute_funding_config(
             HoprBalance::new_base(10),
             1.0,
-            &ChannelSizing {
+            &IncentiveConfiguration {
                 desired_message_count: 100,
                 ..Default::default()
             },
@@ -146,22 +150,30 @@ mod tests {
     #[test]
     fn compute_funding_config_rejects_zero_win_prob() {
         assert!(
-            compute_funding_config(HoprBalance::new_base(1), 0.0, &ChannelSizing::default())
-                .is_err()
+            compute_funding_config(
+                HoprBalance::new_base(1),
+                0.0,
+                &IncentiveConfiguration::default()
+            )
+            .is_err()
         );
     }
 
     #[test]
     fn compute_funding_config_rejects_win_prob_above_one() {
         assert!(
-            compute_funding_config(HoprBalance::new_base(1), 1.1, &ChannelSizing::default())
-                .is_err()
+            compute_funding_config(
+                HoprBalance::new_base(1),
+                1.1,
+                &IncentiveConfiguration::default()
+            )
+            .is_err()
         );
         assert!(
             compute_funding_config(
                 HoprBalance::new_base(1),
                 f64::INFINITY,
-                &ChannelSizing::default()
+                &IncentiveConfiguration::default()
             )
             .is_err()
         );
@@ -169,7 +181,7 @@ mod tests {
             compute_funding_config(
                 HoprBalance::new_base(1),
                 f64::NAN,
-                &ChannelSizing::default()
+                &IncentiveConfiguration::default()
             )
             .is_err()
         );
@@ -181,7 +193,7 @@ mod tests {
             compute_funding_config(
                 HoprBalance::new_base(0),
                 1.0,
-                &ChannelSizing {
+                &IncentiveConfiguration {
                     desired_message_count: 0,
                     ..Default::default()
                 }
@@ -196,7 +208,7 @@ mod tests {
         let funding = compute_funding_config(
             HoprBalance::new_base(1),
             1.0,
-            &ChannelSizing {
+            &IncentiveConfiguration {
                 desired_message_count: 1,
                 ..Default::default()
             },
@@ -218,7 +230,7 @@ mod tests {
 
     #[test]
     fn channel_sizing_defaults_match_population_config_defaults() {
-        let sizing = ChannelSizing::default();
+        let sizing = IncentiveConfiguration::default();
         let population = PopulationConfig::default();
         assert_eq!(sizing.min_open_channels, population.min_open_channels);
         assert_eq!(sizing.target_open_channels, population.target_open_channels);

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,5 +1,10 @@
 use hopr_lib::api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps as _};
-pub use hopr_strategy::channel_lifecycle::{ChannelLifecycleConfig, FundingConfig};
+pub use hopr_strategy::channel_lifecycle::{
+    ChannelLifecycleConfig, FundingConfig, PopulationConfig,
+};
+
+#[cfg(feature = "runtime-tokio")]
+use hopr_lib::api::{chain::ChainValues as _, node::HasChainApi as _};
 
 /// Subset of strategies relevant to an edge node.
 pub enum EdgeStrategyKind {
@@ -12,21 +17,22 @@ pub struct MultiStrategyConfig {
     pub strategies: Vec<EdgeStrategyKind>,
 }
 
-/// Desired channel capacity for computing the initial stake.
-#[derive(Debug, Clone, Copy)]
+/// Desired channel capacity and topology for computing the initial stake.
+#[derive(Debug, Clone, Copy, smart_default::SmartDefault)]
 pub struct ChannelSizing {
     /// Expected number of mixnet messages this channel should forward before exhaustion.
     /// The stake is sized as the expected drain: `desired_message_count × win_prob × ticket_price`.
     /// Default: 1,000,000.
+    #[default = 1_000_000]
     pub desired_message_count: u64,
-}
 
-impl Default for ChannelSizing {
-    fn default() -> Self {
-        Self {
-            desired_message_count: 1_000_000,
-        }
-    }
+    /// Minimum number of open outgoing channels to maintain. Default: 5.
+    #[default = 5]
+    pub min_open_channels: usize,
+
+    /// Target number of open outgoing channels to open towards. Default: 8.
+    #[default = 8]
+    pub target_open_channels: usize,
 }
 
 /// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
@@ -76,12 +82,16 @@ pub async fn default_edge_client_telemetry_reactor_cfg(
     node: &crate::client::Edgli,
     sizing: ChannelSizing,
 ) -> anyhow::Result<MultiStrategyConfig> {
-    use hopr_lib::api::{chain::ChainValues as _, node::HasChainApi as _};
     let chain = node.chain_api();
     let ticket_price = chain.minimum_ticket_price().await?;
     let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
     let cfg = ChannelLifecycleConfig {
         funding: compute_funding_config(ticket_price, win_prob, &sizing)?,
+        population: PopulationConfig {
+            min_open_channels: sizing.min_open_channels,
+            target_open_channels: sizing.target_open_channels,
+            ..Default::default()
+        },
         ..Default::default()
     };
     Ok(MultiStrategyConfig {
@@ -103,6 +113,7 @@ mod tests {
             1.0,
             &ChannelSizing {
                 desired_message_count: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -122,6 +133,7 @@ mod tests {
             1.0,
             &ChannelSizing {
                 desired_message_count: 100,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -170,7 +182,8 @@ mod tests {
                 HoprBalance::new_base(0),
                 1.0,
                 &ChannelSizing {
-                    desired_message_count: 0
+                    desired_message_count: 0,
+                    ..Default::default()
                 }
             )
             .is_err()
@@ -185,6 +198,7 @@ mod tests {
             1.0,
             &ChannelSizing {
                 desired_message_count: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -200,5 +214,13 @@ mod tests {
             cfg.strategies[0],
             EdgeStrategyKind::ChannelLifecycle(_)
         ));
+    }
+
+    #[test]
+    fn channel_sizing_defaults_match_population_config_defaults() {
+        let sizing = ChannelSizing::default();
+        let population = PopulationConfig::default();
+        assert_eq!(sizing.min_open_channels, population.min_open_channels);
+        assert_eq!(sizing.target_open_channels, population.target_open_channels);
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -24,8 +24,14 @@ pub struct MultiStrategyConfig {
 /// future incentive extensions beyond the current channel lifecycle strategy.
 #[derive(Debug, Clone, Copy, smart_default::SmartDefault)]
 pub struct IncentiveConfiguration {
-    /// Expected number of mixnet messages this channel should forward before exhaustion.
-    /// The stake is sized as the expected drain: `desired_message_count × ticket_price`.
+    /// Number of forwarded packets the initial channel stake is sized to cover.
+    ///
+    /// Sets `initial_balance = max(N × ticket_price, ticket_price / win_prob)`:
+    /// the first term is the expected channel drain; the second is a minimum floor
+    /// ensuring at least one ticket face value is available even at low message counts.
+    ///
+    /// The channel strategy tops up when balance falls below 25% of `initial_balance`,
+    /// so the channel can forward more than this many packets over its lifetime.
     /// Default: 1,000,000.
     #[default = 1_000_000]
     pub desired_message_count: u64,
@@ -40,7 +46,6 @@ pub struct IncentiveConfiguration {
 }
 
 impl IncentiveConfiguration {
-    /// Validate internal consistency of the configuration.
     pub fn validate(&self) -> anyhow::Result<()> {
         anyhow::ensure!(
             self.target_open_channels >= self.min_open_channels,

--- a/tests/edgli_session_e2e.rs
+++ b/tests/edgli_session_e2e.rs
@@ -52,31 +52,27 @@
 //! The test will NOT stop the external cluster when it finishes.
 
 use anyhow::Context as _;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    time::Duration,
-};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
-use hopr_chain_connector::BlockchainConnectorConfig;
 use edgli::{
+    Edgli, EdgliInitState,
     hopr_lib::{
         HopRouting, HoprKeys, HoprSessionClientConfig, IdentityRetrievalModes,
-        exports::transport::SessionCapability,
         api::{
             node::HoprSessionClientOperations,
             types::{
-                internal::channels::{ChannelStatus, ChannelEntry},
+                internal::channels::{ChannelEntry, ChannelStatus},
                 primitive::prelude::Address,
             },
         },
         config::{HoprLibConfig, HostConfig, HostType, SafeModule},
+        exports::transport::SessionCapability,
         exports::transport::{HoprSession, SessionTarget},
     },
     strategy::{EdgeStrategyKind, EligibilityConfig, IncentiveConfiguration, default_strategy_cfg},
     traits::EdgeNodeApi,
-    Edgli, EdgliInitState,
 };
+use hopr_chain_connector::BlockchainConnectorConfig;
 use rand::RngCore as _;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
@@ -206,9 +202,16 @@ fn parse_summary(stdout: &str) -> anyhow::Result<ClusterSummary> {
     let blokli_url =
         blokli_url.ok_or_else(|| anyhow::anyhow!("blokli URL not found in cluster summary"))?;
     anyhow::ensure!(!nodes.is_empty(), "no nodes found in cluster summary");
-    anyhow::ensure!(!extras.is_empty(), "no extra identities found in cluster summary");
+    anyhow::ensure!(
+        !extras.is_empty(),
+        "no extra identities found in cluster summary"
+    );
 
-    Ok(ClusterSummary { blokli_url, nodes, extras })
+    Ok(ClusterSummary {
+        blokli_url,
+        nodes,
+        extras,
+    })
 }
 
 fn parse_node_info(fields: &HashMap<String, String>) -> anyhow::Result<NodeInfo> {
@@ -237,7 +240,12 @@ fn parse_extra_info(fields: &HashMap<String, String>) -> anyhow::Result<ExtraInf
         .get("password")
         .cloned()
         .unwrap_or_else(|| "local-cluster".to_string());
-    Ok(ExtraInfo { safe_address, module_address, keystore_path, password })
+    Ok(ExtraInfo {
+        safe_address,
+        module_address,
+        keystore_path,
+        password,
+    })
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -313,8 +321,9 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
         });
     }
 
-    let lc_bin = std::env::var("HOPRD_LOCALCLUSTER_BIN").map_err(|_| anyhow::anyhow!(
-        "HOPRD_LOCALCLUSTER_BIN is not set.\n\
+    let lc_bin = std::env::var("HOPRD_LOCALCLUSTER_BIN").map_err(|_| {
+        anyhow::anyhow!(
+            "HOPRD_LOCALCLUSTER_BIN is not set.\n\
          \n\
          Prerequisites — pick one of two modes:\n\
          \n\
@@ -343,9 +352,10 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
             RUST_LOG=info,edgli=debug \
                 cargo test --test edgli_session_e2e -- --ignored --nocapture\n\
         "
-    ))?;
-    let hoprd_bin = std::env::var("HOPRD_BIN")
-        .map_err(|_| anyhow::anyhow!("HOPRD_BIN is not set"))?;
+        )
+    })?;
+    let hoprd_bin =
+        std::env::var("HOPRD_BIN").map_err(|_| anyhow::anyhow!("HOPRD_BIN is not set"))?;
     let chain_image = std::env::var("HOPRD_CHAIN_IMAGE")
         .map_err(|_| anyhow::anyhow!("HOPRD_CHAIN_IMAGE is not set"))?;
     let container_runtime = std::env::var("HOPRD_CONTAINER_RUNTIME").ok();
@@ -355,15 +365,24 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
 
     let mut cmd = tokio::process::Command::new(&lc_bin);
     cmd.args([
-        "--hoprd-bin", &hoprd_bin,
-        "--size", &CLUSTER_SIZE.to_string(),
-        "--extra-identities", "1",
-        "--data-dir", data_dir.to_str().unwrap(),
-        "--api-host", API_HOST,
-        "--api-port-base", &API_PORT_BASE.to_string(),
-        "--p2p-port-base", &P2P_PORT_BASE.to_string(),
-        "--api-token", API_TOKEN,
-        "--chain-image", &chain_image,
+        "--hoprd-bin",
+        &hoprd_bin,
+        "--size",
+        &CLUSTER_SIZE.to_string(),
+        "--extra-identities",
+        "1",
+        "--data-dir",
+        data_dir.to_str().unwrap(),
+        "--api-host",
+        API_HOST,
+        "--api-port-base",
+        &API_PORT_BASE.to_string(),
+        "--p2p-port-base",
+        &P2P_PORT_BASE.to_string(),
+        "--api-token",
+        API_TOKEN,
+        "--chain-image",
+        &chain_image,
     ]);
     if let Some(runtime) = container_runtime {
         cmd.args(["--container-runtime", &runtime]);
@@ -396,10 +415,10 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
                 buf.push_str(&line);
                 buf.push('\n');
             }
-            if line.contains("localcluster running") {
-                if let Some(tx) = ready_tx.take() {
-                    let _ = tx.send(());
-                }
+            if line.contains("localcluster running")
+                && let Some(tx) = ready_tx.take()
+            {
+                let _ = tx.send(());
             }
         }
     });
@@ -643,9 +662,15 @@ async fn await_edgli_channels_open(edgli: &Edgli, min_open: usize) -> anyhow::Re
     let deadline = tokio::time::Instant::now() + CHANNEL_OPEN_TIMEOUT;
     loop {
         let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
-        let open = channels.iter().filter(|ch| ch.status == ChannelStatus::Open).count();
+        let open = channels
+            .iter()
+            .filter(|ch| ch.status == ChannelStatus::Open)
+            .count();
         if open >= min_open {
-            tracing::info!(open_channels = open, "Edgli outgoing channels confirmed Open");
+            tracing::info!(
+                open_channels = open,
+                "Edgli outgoing channels confirmed Open"
+            );
             return Ok(());
         }
         tracing::debug!("Edgli: {open}/{min_open} outgoing channels Open (waiting for strategy)");
@@ -681,7 +706,6 @@ fn build_edgli_config(extra: &ExtraInfo) -> HoprLibConfig {
             transport: TransportConfig {
                 announce_local_addresses: true,
                 prefer_local_addresses: true,
-                ..Default::default()
             },
             ..Default::default()
         },
@@ -772,7 +796,6 @@ async fn pump_and_verify(session: HoprSession, payload: &[u8], label: &str) -> a
 #[ignore]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn edgli_sends_one_megabyte_through_cluster() -> anyhow::Result<()> {
-
     // ── 1. Start the 3-node HOPR cluster ────────────────────────────────────
     // hoprd-localcluster provisions identities, deploys Safes, starts hoprd
     // processes, waits for peer discovery, opens full-mesh channels, then
@@ -892,8 +915,8 @@ async fn edgli_sends_one_megabyte_through_cluster() -> anyhow::Result<()> {
             loopback_target(),
             HoprSessionClientConfig {
                 forward_path: HopRouting::try_from(0_usize)?,
-                return_path:  HopRouting::try_from(0_usize)?,
-                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl).into(),
+                return_path: HopRouting::try_from(0_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
                 ..Default::default()
             },
         )
@@ -912,8 +935,8 @@ async fn edgli_sends_one_megabyte_through_cluster() -> anyhow::Result<()> {
             loopback_target(),
             HoprSessionClientConfig {
                 forward_path: HopRouting::try_from(1_usize)?,
-                return_path:  HopRouting::try_from(1_usize)?,
-                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl).into(),
+                return_path: HopRouting::try_from(1_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
                 ..Default::default()
             },
         )
@@ -922,7 +945,10 @@ async fn edgli_sends_one_megabyte_through_cluster() -> anyhow::Result<()> {
 
     // ── 11. Final state assertion ─────────────────────────────────────────────
     let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
-    let open_count = channels.iter().filter(|ch| ch.status == ChannelStatus::Open).count();
+    let open_count = channels
+        .iter()
+        .filter(|ch| ch.status == ChannelStatus::Open)
+        .count();
     assert!(
         open_count >= 1,
         "expected ≥1 Open outgoing channel after pumping; got {open_count}"

--- a/tests/edgli_session_e2e.rs
+++ b/tests/edgli_session_e2e.rs
@@ -457,6 +457,8 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
 // Cluster node state helpers (plain reqwest)
 // ────────────────────────────────────────────────────────────────────────────
 
+const CHANNEL_STATUS_OPEN: &str = "Open";
+
 fn node_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -468,34 +470,60 @@ fn auth_header() -> String {
     format!("Bearer {API_TOKEN}")
 }
 
+/// Loop until `check_node(node_index, port)` returns `true` for every cluster node,
+/// or bail after `timeout`.
+async fn poll_cluster_until<Fut>(
+    timeout: Duration,
+    sleep: Duration,
+    success_msg: &str,
+    timeout_msg: &str,
+    mut check_node: impl FnMut(usize, u16) -> Fut,
+) -> anyhow::Result<()>
+where
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let all_ok = {
+            let mut ok = true;
+            for i in 0..CLUSTER_SIZE {
+                if !check_node(i, API_PORT_BASE + i as u16).await {
+                    ok = false;
+                    break;
+                }
+            }
+            ok
+        };
+        if all_ok {
+            tracing::info!("{success_msg}");
+            return Ok(());
+        }
+        anyhow::ensure!(tokio::time::Instant::now() < deadline, "{timeout_msg}");
+        tokio::time::sleep(sleep).await;
+    }
+}
+
 /// Poll /readyz on all cluster nodes until every one returns 200.
 async fn await_nodes_ready() -> anyhow::Result<()> {
     let client = node_http_client();
-    let deadline = tokio::time::Instant::now() + READYZ_TIMEOUT;
-    loop {
-        let mut all_ready = true;
-        for i in 0..CLUSTER_SIZE {
-            let port = API_PORT_BASE + i as u16;
-            let ok = client
-                .get(format!("http://{API_HOST}:{port}/readyz"))
-                .send()
-                .await
-                .map(|r| r.status().is_success())
-                .unwrap_or(false);
-            if !ok {
-                all_ready = false;
-                break;
+    poll_cluster_until(
+        READYZ_TIMEOUT,
+        Duration::from_secs(3),
+        &format!("all {} cluster nodes passed /readyz", CLUSTER_SIZE),
+        &format!("timeout ({READYZ_TIMEOUT:?}) waiting for cluster /readyz"),
+        |_i, port| {
+            let client = client.clone();
+            async move {
+                client
+                    .get(format!("http://{API_HOST}:{port}/readyz"))
+                    .send()
+                    .await
+                    .map(|r| r.status().is_success())
+                    .unwrap_or(false)
             }
-        }
-        if all_ready {
-            tracing::info!("all {} cluster nodes passed /readyz", CLUSTER_SIZE);
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            anyhow::bail!("timeout ({READYZ_TIMEOUT:?}) waiting for cluster /readyz");
-        }
-        tokio::time::sleep(Duration::from_secs(3)).await;
-    }
+        },
+    )
+    .await
 }
 
 /// Poll /api/v4/network/announced on each node until every node sees CLUSTER_SIZE-1 peers.
@@ -506,40 +534,34 @@ async fn await_nodes_ready() -> anyhow::Result<()> {
 async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
     let client = node_http_client();
     let expected = CLUSTER_SIZE - 1;
-    let deadline = tokio::time::Instant::now() + PEER_DISCOVERY_TIMEOUT;
-    loop {
-        let mut all_discovered = true;
-        for i in 0..CLUSTER_SIZE {
-            let port = API_PORT_BASE + i as u16;
-            let announced = async {
-                let body: serde_json::Value = client
-                    .get(format!("http://{API_HOST}:{port}/api/v4/network/announced"))
-                    .header("Authorization", auth_header())
-                    .send()
-                    .await?
-                    .json()
-                    .await?;
-                anyhow::Ok(body.as_array().map(|a| a.len()).unwrap_or(0))
+    poll_cluster_until(
+        PEER_DISCOVERY_TIMEOUT,
+        Duration::from_secs(3),
+        "all cluster nodes see full peer announcement set",
+        &format!("timeout ({PEER_DISCOVERY_TIMEOUT:?}) waiting for cluster peer discovery"),
+        |i, port| {
+            let client = client.clone();
+            async move {
+                let announced = async {
+                    let body: serde_json::Value = client
+                        .get(format!("http://{API_HOST}:{port}/api/v4/network/announced"))
+                        .header("Authorization", auth_header())
+                        .send()
+                        .await?
+                        .json()
+                        .await?;
+                    anyhow::Ok(body.as_array().map(|a| a.len()).unwrap_or(0))
+                }
+                .await
+                .unwrap_or(0);
+                if announced < expected {
+                    tracing::debug!("node {i}: {announced}/{expected} announced peers");
+                }
+                announced >= expected
             }
-            .await
-            .unwrap_or(0);
-            if announced < expected {
-                tracing::debug!("node {i}: {announced}/{expected} announced peers");
-                all_discovered = false;
-                break;
-            }
-        }
-        if all_discovered {
-            tracing::info!("all cluster nodes see full peer announcement set");
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            anyhow::bail!(
-                "timeout ({PEER_DISCOVERY_TIMEOUT:?}) waiting for cluster peer discovery"
-            );
-        }
-        tokio::time::sleep(Duration::from_secs(3)).await;
-    }
+        },
+    )
+    .await
 }
 
 /// Poll /api/v4/channels on each node until every node has CLUSTER_SIZE-1 Open outgoing channels.
@@ -550,51 +572,47 @@ async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
 async fn await_intracluster_channels_open() -> anyhow::Result<()> {
     let client = node_http_client();
     let expected = CLUSTER_SIZE - 1;
-    let deadline = tokio::time::Instant::now() + INTRACLUSTER_CHANNEL_TIMEOUT;
-    loop {
-        let mut all_open = true;
-        for i in 0..CLUSTER_SIZE {
-            let port = API_PORT_BASE + i as u16;
-            let open = async {
-                let body: serde_json::Value = client
-                    .get(format!(
-                        "http://{API_HOST}:{port}/api/v4/channels?includingClosed=false"
-                    ))
-                    .header("Authorization", auth_header())
-                    .send()
-                    .await?
-                    .json()
-                    .await?;
-                anyhow::Ok(
-                    body["outgoing"]
-                        .as_array()
-                        .map(|arr| {
-                            arr.iter()
-                                .filter(|ch| ch["status"].as_str() == Some("Open"))
-                                .count()
-                        })
-                        .unwrap_or(0),
-                )
+    poll_cluster_until(
+        INTRACLUSTER_CHANNEL_TIMEOUT,
+        Duration::from_secs(5),
+        "full-mesh intracluster channels confirmed Open",
+        &format!(
+            "timeout ({INTRACLUSTER_CHANNEL_TIMEOUT:?}) waiting for intracluster channels to open"
+        ),
+        |i, port| {
+            let client = client.clone();
+            async move {
+                let open = async {
+                    let body: serde_json::Value = client
+                        .get(format!(
+                            "http://{API_HOST}:{port}/api/v4/channels?includingClosed=false"
+                        ))
+                        .header("Authorization", auth_header())
+                        .send()
+                        .await?
+                        .json()
+                        .await?;
+                    anyhow::Ok(
+                        body["outgoing"]
+                            .as_array()
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter(|ch| ch["status"].as_str() == Some(CHANNEL_STATUS_OPEN))
+                                    .count()
+                            })
+                            .unwrap_or(0),
+                    )
+                }
+                .await
+                .unwrap_or(0);
+                if open < expected {
+                    tracing::debug!("node {i}: {open}/{expected} outgoing channels Open");
+                }
+                open >= expected
             }
-            .await
-            .unwrap_or(0);
-            if open < expected {
-                tracing::debug!("node {i}: {open}/{expected} outgoing channels Open");
-                all_open = false;
-                break;
-            }
-        }
-        if all_open {
-            tracing::info!("full-mesh intracluster channels confirmed Open");
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            anyhow::bail!(
-                "timeout ({INTRACLUSTER_CHANNEL_TIMEOUT:?}) waiting for intracluster channels to open"
-            );
-        }
-        tokio::time::sleep(Duration::from_secs(5)).await;
-    }
+        },
+    )
+    .await
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/edgli_session_e2e.rs
+++ b/tests/edgli_session_e2e.rs
@@ -1,0 +1,874 @@
+//! End-to-end integration test: Edgli + hoprd localcluster.
+//!
+//! # What this test does
+//!
+//! 1. Spins up a 3-node HOPR cluster via `hoprd-localcluster`.
+//! 2. Boots Edgli with a pre-funded extra identity created by the cluster.
+//! 3. Verifies cluster state: full P2P peer visibility and full-mesh channels.
+//! 4. Lets the channel-lifecycle strategy open Edgli's outgoing channels.
+//! 5. Pumps 1 MiB of random data through a 0-hop session (sanity check, no relay).
+//! 6. Pumps 1 MiB of random data through a 1-hop session (full relay path).
+//! 7. Verifies SHA-256 integrity of both echo round-trips.
+//!
+//! # Modes of operation
+//!
+//! ## Managed mode (default): test owns cluster lifetime
+//!
+//! The test starts `hoprd-localcluster`, waits for readiness, runs the session
+//! pumps, then tears the cluster down. Required env vars:
+//!
+//! | Variable                  | Required | Description                              |
+//! |---------------------------|----------|------------------------------------------|
+//! | `HOPRD_LOCALCLUSTER_BIN`  | yes      | Path to `hoprd-localcluster` binary      |
+//! | `HOPRD_BIN`               | yes      | Path to `hoprd` binary                   |
+//! | `HOPRD_CHAIN_IMAGE`       | yes      | `bloklid-anvil` container image tag      |
+//! | `HOPRD_CONTAINER_RUNTIME` | no       | Container runtime (default: docker)      |
+//!
+//! ```text
+//! export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd-localcluster
+//! export HOPRD_BIN=/path/to/hoprd
+//! export HOPRD_CHAIN_IMAGE='<bloklid-anvil image tag>'
+//! # --release is required: HOPR's async future chains overflow the default debug stack
+//! RUST_LOG=info,edgli=debug cargo test --test edgli_session_e2e --release -- --ignored --nocapture
+//! ```
+//!
+//! ## External mode: attach to an already-running cluster
+//!
+//! Start the cluster manually in one terminal, capture its stdout to a file,
+//! then point the test at that file to skip cluster startup:
+//!
+//! ```text
+//! # Terminal 1 — start cluster and tee its output
+//! hoprd-localcluster --size 3 --extra-identities 1 \
+//!   --api-port-base 13000 --p2p-port-base 19000 \
+//!   --api-token test-token-localcluster \
+//!   --chain-image '...' ... 2>&1 | tee /tmp/cluster.log
+//!
+//! # Wait for "localcluster running" in Terminal 1, then in Terminal 2:
+//! export HOPRD_CLUSTER_SUMMARY_FILE=/tmp/cluster.log
+//! RUST_LOG=info,edgli=debug cargo test --test edgli_session_e2e --release -- --ignored --nocapture
+//! ```
+//!
+//! The test will NOT stop the external cluster when it finishes.
+
+use anyhow::Context as _;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    time::Duration,
+};
+
+use hopr_chain_connector::BlockchainConnectorConfig;
+use edgli::{
+    hopr_lib::{
+        HopRouting, HoprKeys, HoprSessionClientConfig, IdentityRetrievalModes,
+        exports::transport::SessionCapability,
+        api::{
+            node::HoprSessionClientOperations,
+            types::{
+                internal::channels::{ChannelStatus, ChannelEntry},
+                primitive::prelude::Address,
+            },
+        },
+        config::{HoprLibConfig, HostConfig, HostType, SafeModule},
+        exports::transport::{HoprSession, SessionTarget},
+    },
+    strategy::{EdgeStrategyKind, EligibilityConfig, IncentiveConfiguration, default_strategy_cfg},
+    traits::EdgeNodeApi,
+    Edgli, EdgliInitState,
+};
+use hoprd_api_client::Client as HoprdClient;
+use rand::RngCore as _;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────────────
+
+const PAYLOAD_SIZE: usize = 1_024 * 1_024; // 1 MiB
+/// HOPR session MTU (bytes that fit in a single HOPR packet payload).
+/// Equal to `hopr_transport_session::SESSION_MTU = 1018`.
+const SESSION_MTU: usize = 1018;
+/// Packets per write-batch in `pump_and_verify`.  Keeps the Rayon encoding
+/// queue well below the `PACKET_ENCODING_TIMEOUT = 150 ms` threshold even
+/// when the host machine is under load running a 3-node cluster.
+const PUMP_BATCH_PACKETS: usize = 16;
+const PUMP_BATCH_BYTES: usize = PUMP_BATCH_PACKETS * SESSION_MTU;
+const CLUSTER_SIZE: usize = 3;
+const API_PORT_BASE: u16 = 13000;
+const P2P_PORT_BASE: u16 = 19000;
+/// Edgli's P2P port — one slot beyond the cluster nodes.
+const EDGE_P2P_PORT: u16 = P2P_PORT_BASE + CLUSTER_SIZE as u16;
+const API_HOST: &str = "127.0.0.1";
+const API_TOKEN: &str = "test-token-localcluster";
+
+// Timeouts (generous to handle slow CI environments and image pulls).
+const CLUSTER_START_TIMEOUT: Duration = Duration::from_secs(600); // 10 min
+const READYZ_TIMEOUT: Duration = Duration::from_secs(120);
+const PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
+const INTRACLUSTER_CHANNEL_TIMEOUT: Duration = Duration::from_secs(120);
+const EDGLI_PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
+const CHANNEL_OPEN_TIMEOUT: Duration = Duration::from_secs(120);
+const PUMP_TIMEOUT: Duration = Duration::from_secs(120);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Cluster summary types
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct NodeInfo {
+    address: Address,
+}
+
+#[derive(Debug, Clone)]
+struct ExtraInfo {
+    safe_address: Address,
+    module_address: Address,
+    keystore_path: PathBuf,
+    password: String,
+}
+
+#[derive(Debug, Clone)]
+struct ClusterSummary {
+    blokli_url: String,
+    nodes: Vec<NodeInfo>,
+    extras: Vec<ExtraInfo>,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Summary parser (reads hoprd-localcluster stdout)
+// ────────────────────────────────────────────────────────────────────────────
+
+fn parse_summary(stdout: &str) -> anyhow::Result<ClusterSummary> {
+    let mut blokli_url: Option<String> = None;
+    let mut nodes: Vec<NodeInfo> = Vec::new();
+    let mut extras: Vec<ExtraInfo> = Vec::new();
+    let mut in_node: Option<HashMap<String, String>> = None;
+    let mut in_extra: Option<HashMap<String, String>> = None;
+
+    let flush_node = |in_node: &mut Option<HashMap<String, String>>,
+                      nodes: &mut Vec<NodeInfo>|
+     -> anyhow::Result<()> {
+        if let Some(fields) = in_node.take() {
+            nodes.push(parse_node_info(&fields)?);
+        }
+        Ok(())
+    };
+    let flush_extra = |in_extra: &mut Option<HashMap<String, String>>,
+                       extras: &mut Vec<ExtraInfo>|
+     -> anyhow::Result<()> {
+        if let Some(fields) = in_extra.take() {
+            extras.push(parse_extra_info(&fields)?);
+        }
+        Ok(())
+    };
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+
+        if let Some(rest) = trimmed.strip_prefix("Chain (Blokli):") {
+            blokli_url = Some(rest.trim().to_string());
+            continue;
+        }
+
+        if trimmed.starts_with("Node ") && !trimmed.contains(':') {
+            flush_node(&mut in_node, &mut nodes)?;
+            flush_extra(&mut in_extra, &mut extras)?;
+            in_node = Some(HashMap::new());
+            continue;
+        }
+        if trimmed.starts_with("Extra ") && !trimmed.contains(':') {
+            flush_node(&mut in_node, &mut nodes)?;
+            flush_extra(&mut in_extra, &mut extras)?;
+            in_extra = Some(HashMap::new());
+            continue;
+        }
+
+        // "  Key  : value" field lines — skip if the key part contains '/' (URL).
+        if let Some(colon_pos) = trimmed.find(':') {
+            let key = trimmed[..colon_pos].trim();
+            if key.contains('/') {
+                continue;
+            }
+            let val = trimmed[colon_pos + 1..].trim().to_string();
+            let key_lower = key.to_ascii_lowercase();
+            if let Some(fields) = in_node.as_mut() {
+                fields.insert(key_lower, val);
+            } else if let Some(fields) = in_extra.as_mut() {
+                fields.insert(key_lower, val);
+            }
+        }
+    }
+
+    flush_node(&mut in_node, &mut nodes)?;
+    flush_extra(&mut in_extra, &mut extras)?;
+
+    let blokli_url =
+        blokli_url.ok_or_else(|| anyhow::anyhow!("blokli URL not found in cluster summary"))?;
+    anyhow::ensure!(!nodes.is_empty(), "no nodes found in cluster summary");
+    anyhow::ensure!(!extras.is_empty(), "no extra identities found in cluster summary");
+
+    Ok(ClusterSummary { blokli_url, nodes, extras })
+}
+
+fn parse_node_info(fields: &HashMap<String, String>) -> anyhow::Result<NodeInfo> {
+    let address = fields
+        .get("address")
+        .ok_or_else(|| anyhow::anyhow!("node: missing Address field"))?
+        .parse::<Address>()?;
+    Ok(NodeInfo { address })
+}
+
+fn parse_extra_info(fields: &HashMap<String, String>) -> anyhow::Result<ExtraInfo> {
+    let safe_address = fields
+        .get("safe address")
+        .ok_or_else(|| anyhow::anyhow!("extra: missing Safe address field"))?
+        .parse::<Address>()?;
+    let module_address = fields
+        .get("module address")
+        .ok_or_else(|| anyhow::anyhow!("extra: missing Module address field"))?
+        .parse::<Address>()?;
+    let keystore_path = PathBuf::from(
+        fields
+            .get("identity file")
+            .ok_or_else(|| anyhow::anyhow!("extra: missing Identity file field"))?,
+    );
+    let password = fields
+        .get("password")
+        .cloned()
+        .unwrap_or_else(|| "local-cluster".to_string());
+    Ok(ExtraInfo { safe_address, module_address, keystore_path, password })
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Cluster RAII handle
+// ────────────────────────────────────────────────────────────────────────────
+
+struct ClusterHandle {
+    /// `Some` when the test started the cluster; `None` in external mode.
+    child: Option<tokio::process::Child>,
+    summary: ClusterSummary,
+    _tempdir: Option<tempfile::TempDir>,
+    // Keeps the write end of the stdin pipe alive so the child never receives
+    // EOF on stdin.  hoprd-localcluster treats stdin EOF as a shutdown signal
+    // (useful in pipelines); dropping this causes graceful shutdown.
+    _child_stdin: Option<tokio::process::ChildStdin>,
+}
+
+impl Drop for ClusterHandle {
+    fn drop(&mut self) {
+        let Some(child) = self.child.as_mut() else {
+            // External cluster — do not touch it.
+            return;
+        };
+        // SIGINT → triggers the orchestrator's Cleanup::shutdown (kills hoprd
+        // subprocesses and removes the chain container).
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+            if let Some(pid) = child.id() {
+                let _ = kill(Pid::from_raw(pid as i32), Signal::SIGINT);
+            }
+        }
+        // Wait up to 30 s for graceful exit, then force-kill.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+                _ => {
+                    let _ = child.start_kill();
+                    break;
+                }
+            }
+        }
+        // _tempdir drops here and removes the data directory.
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Cluster lifecycle
+// ────────────────────────────────────────────────────────────────────────────
+
+async fn start_cluster() -> anyhow::Result<ClusterHandle> {
+    // External mode: attach to an already-running cluster instead of starting one.
+    if let Ok(summary_file) = std::env::var("HOPRD_CLUSTER_SUMMARY_FILE") {
+        let text = std::fs::read_to_string(&summary_file)
+            .with_context(|| format!("reading HOPRD_CLUSTER_SUMMARY_FILE={summary_file}"))?;
+        let summary = parse_summary(&text)?;
+        tracing::info!(
+            blokli_url = %summary.blokli_url,
+            nodes = summary.nodes.len(),
+            extras = summary.extras.len(),
+            "external cluster summary loaded from {summary_file}"
+        );
+        return Ok(ClusterHandle {
+            child: None,
+            summary,
+            _tempdir: None,
+            _child_stdin: None,
+        });
+    }
+
+    let lc_bin = std::env::var("HOPRD_LOCALCLUSTER_BIN").map_err(|_| anyhow::anyhow!(
+        "HOPRD_LOCALCLUSTER_BIN is not set.\n\
+         \n\
+         Prerequisites — pick one of two modes:\n\
+         \n\
+         ── A. Managed mode (test owns cluster lifetime) ────────────────\n\
+         \n\
+         Build binaries from hoprnet/hoprnet:\n\
+            cargo build --release -p hoprd-localcluster -p hoprd\n\
+         \n\
+         Export:\n\
+            export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd-localcluster\n\
+            export HOPRD_BIN=/path/to/hoprd\n\
+            export HOPRD_CHAIN_IMAGE='<bloklid-anvil image tag>'\n\
+            # export HOPRD_CONTAINER_RUNTIME=/path/to/container  # non-Docker runtimes\n\
+         \n\
+         ── B. External mode (attach to already-running cluster) ─────────\n\
+         \n\
+         Start the cluster in another terminal, tee output to a file:\n\
+            hoprd-localcluster --size 3 --extra-identities 1 \\\n\
+              --api-port-base 13000 --p2p-port-base 19000 \\\n\
+              --api-token test-token-localcluster ... 2>&1 | tee /tmp/cluster.log\n\
+         \n\
+         Once 'localcluster running' appears, run the test:\n\
+            export HOPRD_CLUSTER_SUMMARY_FILE=/tmp/cluster.log\n\
+         \n\
+         ── Run the test ─────────────────────────────────────────────────\n\
+            RUST_LOG=info,edgli=debug \
+                cargo test --test edgli_session_e2e -- --ignored --nocapture\n\
+        "
+    ))?;
+    let hoprd_bin = std::env::var("HOPRD_BIN")
+        .map_err(|_| anyhow::anyhow!("HOPRD_BIN is not set"))?;
+    let chain_image = std::env::var("HOPRD_CHAIN_IMAGE")
+        .map_err(|_| anyhow::anyhow!("HOPRD_CHAIN_IMAGE is not set"))?;
+    let container_runtime = std::env::var("HOPRD_CONTAINER_RUNTIME").ok();
+
+    let tempdir = tempfile::TempDir::with_prefix("edgli-it-")?;
+    let data_dir = tempdir.path().to_path_buf();
+
+    let mut cmd = tokio::process::Command::new(&lc_bin);
+    cmd.args([
+        "--hoprd-bin", &hoprd_bin,
+        "--size", &CLUSTER_SIZE.to_string(),
+        "--extra-identities", "1",
+        "--data-dir", data_dir.to_str().unwrap(),
+        "--api-host", API_HOST,
+        "--api-port-base", &API_PORT_BASE.to_string(),
+        "--p2p-port-base", &P2P_PORT_BASE.to_string(),
+        "--api-token", API_TOKEN,
+        "--chain-image", &chain_image,
+    ]);
+    if let Some(runtime) = container_runtime {
+        cmd.args(["--container-runtime", &runtime]);
+    }
+    // Disable OTel OTLP export in cluster nodes — prevents PeriodicReader failures
+    // when no OTLP collector is running and keeps node logs clean.
+    cmd.env("HOPRD_USE_OPENTELEMETRY", "false");
+    cmd.stdout(std::process::Stdio::piped())
+        .stdin(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit());
+
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().expect("stdout must be captured");
+    // Keep the write end of stdin alive so the cluster never sees EOF.
+    // hoprd-localcluster treats stdin EOF as a shutdown signal.
+    let child_stdin = child.stdin.take().expect("stdin pipe must be available");
+
+    // Stream and collect stdout; signal when the cluster prints its ready sentinel.
+    let collected = std::sync::Arc::new(tokio::sync::Mutex::new(String::new()));
+    let collected_clone = collected.clone();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut ready_tx = Some(ready_tx);
+
+    tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            tracing::info!(target: "localcluster", "{}", line);
+            {
+                let mut buf = collected_clone.lock().await;
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+            if line.contains("localcluster running") {
+                if let Some(tx) = ready_tx.take() {
+                    let _ = tx.send(());
+                }
+            }
+        }
+    });
+
+    tokio::time::timeout(CLUSTER_START_TIMEOUT, ready_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!(
+            "timeout ({CLUSTER_START_TIMEOUT:?}) waiting for 'localcluster running' sentinel"
+        ))?
+        .map_err(|_| anyhow::anyhow!(
+            "localcluster stdout closed before printing 'localcluster running'"
+        ))?;
+
+    // Brief pause so any trailing summary lines in the same stdout flush are
+    // buffered before we snapshot.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let stdout_text = collected.lock().await.clone();
+    let summary = parse_summary(&stdout_text)?;
+
+    tracing::info!(
+        blokli_url = %summary.blokli_url,
+        nodes = summary.nodes.len(),
+        extras = summary.extras.len(),
+        "cluster summary parsed"
+    );
+
+    Ok(ClusterHandle {
+        child: Some(child),
+        summary,
+        _tempdir: Some(tempdir),
+        _child_stdin: Some(child_stdin),
+    })
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Cluster node state helpers (hoprd-api-client native types)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build an authenticated `hoprd_api_client::Client` for the given node port.
+fn node_client(port: u16) -> HoprdClient {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {API_TOKEN}")).unwrap(),
+    );
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .default_headers(headers)
+        .build()
+        .unwrap();
+    HoprdClient::new_with_client(
+        &format!("http://{API_HOST}:{port}"),
+        http,
+    )
+}
+
+/// Poll /readyz on all cluster nodes until every one returns 200.
+async fn await_nodes_ready() -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + READYZ_TIMEOUT;
+    loop {
+        let mut all_ready = true;
+        for i in 0..CLUSTER_SIZE {
+            if node_client(API_PORT_BASE + i as u16).readyz().await.is_err() {
+                all_ready = false;
+                break;
+            }
+        }
+        if all_ready {
+            tracing::info!("all {} cluster nodes passed /readyz", CLUSTER_SIZE);
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("timeout ({READYZ_TIMEOUT:?}) waiting for cluster /readyz");
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+/// Poll /api/v4/network/announced on each node until every node sees CLUSTER_SIZE-1 peers.
+///
+/// The localcluster waits for full-mesh P2P reachability (via ping_peer) before
+/// opening channels, so this check typically completes immediately after
+/// 'localcluster running'.
+async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
+    let expected = CLUSTER_SIZE - 1;
+    let deadline = tokio::time::Instant::now() + PEER_DISCOVERY_TIMEOUT;
+    loop {
+        let mut all_discovered = true;
+        for i in 0..CLUSTER_SIZE {
+            let announced = node_client(API_PORT_BASE + i as u16)
+                .announced()
+                .await
+                .map(|r| r.into_inner().len())
+                .unwrap_or(0);
+            if announced < expected {
+                tracing::debug!("node {i}: {announced}/{expected} announced peers");
+                all_discovered = false;
+                break;
+            }
+        }
+        if all_discovered {
+            tracing::info!("all cluster nodes see full peer announcement set");
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timeout ({PEER_DISCOVERY_TIMEOUT:?}) waiting for cluster peer discovery"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+/// Poll /api/v4/channels on each node until every node has CLUSTER_SIZE-1 Open outgoing channels.
+///
+/// The localcluster opens a full directed mesh between nodes before printing its
+/// ready sentinel, so this check typically completes immediately after
+/// 'localcluster running'.
+async fn await_intracluster_channels_open() -> anyhow::Result<()> {
+    let expected = CLUSTER_SIZE - 1;
+    let deadline = tokio::time::Instant::now() + INTRACLUSTER_CHANNEL_TIMEOUT;
+    loop {
+        let mut all_open = true;
+        for i in 0..CLUSTER_SIZE {
+            let open = node_client(API_PORT_BASE + i as u16)
+                .list_channels(None, Some(false))
+                .await
+                .map(|r| {
+                    r.into_inner()
+                        .outgoing
+                        .iter()
+                        .filter(|ch| ch.status == "Open")
+                        .count()
+                })
+                .unwrap_or(0);
+            if open < expected {
+                tracing::debug!("node {i}: {open}/{expected} outgoing channels Open");
+                all_open = false;
+                break;
+            }
+        }
+        if all_open {
+            tracing::info!("full-mesh intracluster channels confirmed Open");
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timeout ({INTRACLUSTER_CHANNEL_TIMEOUT:?}) waiting for intracluster channels to open"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Edge client state helpers (use EdgeNodeApi)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Wait until Edgli has at least `min_peers` cluster nodes as connected P2P peers.
+async fn await_edgli_peers_connected(edgli: &Edgli, min_peers: usize) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + EDGLI_PEER_DISCOVERY_TIMEOUT;
+    loop {
+        let peers = edgli.connected_peer_addresses().await?;
+        if peers.len() >= min_peers {
+            tracing::info!(peer_count = peers.len(), "Edgli P2P connectivity confirmed");
+            return Ok(());
+        }
+        tracing::debug!("Edgli: {}/{min_peers} cluster peers connected", peers.len());
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timeout ({EDGLI_PEER_DISCOVERY_TIMEOUT:?}) waiting for Edgli to connect to {min_peers} peer(s)"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+/// Wait until Edgli's strategy reactor has opened at least `min_open` outgoing channels.
+async fn await_edgli_channels_open(edgli: &Edgli, min_open: usize) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + CHANNEL_OPEN_TIMEOUT;
+    loop {
+        let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
+        let open = channels.iter().filter(|ch| ch.status == ChannelStatus::Open).count();
+        if open >= min_open {
+            tracing::info!(open_channels = open, "Edgli outgoing channels confirmed Open");
+            return Ok(());
+        }
+        tracing::debug!("Edgli: {open}/{min_open} outgoing channels Open (waiting for strategy)");
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timeout ({CHANNEL_OPEN_TIMEOUT:?}) waiting for Edgli strategy to open {min_open} channel(s)"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+/// `SessionTarget` that causes the exit node to loop data back to the entry
+/// without an external TCP server.  `ExitNode(0)` maps to the built-in
+/// loopback service in `HoprServerIpForwardingReactor`.
+fn loopback_target() -> SessionTarget {
+    SessionTarget::ExitNode(0)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Edgli config builder
+// ────────────────────────────────────────────────────────────────────────────
+
+fn build_edgli_config(extra: &ExtraInfo) -> HoprLibConfig {
+    use edgli::hopr_lib::config::{HoprProtocolConfig, TransportConfig};
+    HoprLibConfig {
+        host: HostConfig {
+            address: HostType::IPv4("0.0.0.0".to_string()),
+            port: EDGE_P2P_PORT,
+        },
+        publish: true,
+        protocol: HoprProtocolConfig {
+            transport: TransportConfig {
+                announce_local_addresses: true,
+                prefer_local_addresses: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        safe_module: SafeModule {
+            safe_address: extra.safe_address,
+            module_address: extra.module_address,
+        },
+        ..Default::default()
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Bulk data pump helper
+// ────────────────────────────────────────────────────────────────────────────
+
+fn sha256_digest(data: &[u8]) -> Vec<u8> {
+    let mut h = Sha256::new();
+    h.update(data);
+    h.finalize().to_vec()
+}
+
+/// Write `payload` into `session`, read exactly `payload.len()` bytes back from
+/// the echo server, and verify SHA-256 integrity.
+///
+/// Writes in `PUMP_BATCH_BYTES`-sized chunks with a 100 ms pause between each
+/// batch.  Without pacing, `write_all(1 MiB)` submits ~1030 HOPR packets to
+/// the Rayon encoding pool simultaneously.  The pool's `PACKET_ENCODING_TIMEOUT`
+/// is 150 ms; with `then_concurrent(8×cpus)` concurrent encoding futures sharing
+/// a pool of only `cpus` Rayon threads, tasks queued near the end wait ≈
+/// 7×encode_time ≥ 150 ms and are silently dropped, causing the echo read to
+/// time out.  Writing 16 packets per batch keeps Rayon queue wait ≈ 1×encode_time
+/// (≤ 30 ms), well inside the timeout window.
+///
+/// Does NOT call `shutdown()` on the write half: HOPR sessions do not support
+/// TCP half-close.
+async fn pump_and_verify(session: HoprSession, payload: &[u8], label: &str) -> anyhow::Result<()> {
+    let (mut r, mut w) = tokio::io::split(session);
+    let payload_bytes = payload.to_vec();
+    let expected = sha256_digest(payload);
+    let n = payload.len();
+
+    let writer = tokio::spawn(async move {
+        let mut offset = 0;
+        while offset < payload_bytes.len() {
+            let end = (offset + PUMP_BATCH_BYTES).min(payload_bytes.len());
+            w.write_all(&payload_bytes[offset..end]).await?;
+            w.flush().await?;
+            offset = end;
+            if offset < payload_bytes.len() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+        Ok::<_, std::io::Error>(())
+    });
+
+    let mut received = vec![0u8; n];
+    tokio::time::timeout(PUMP_TIMEOUT, r.read_exact(&mut received))
+        .await
+        .map_err(|_| anyhow::anyhow!("{label}: read timeout ({PUMP_TIMEOUT:?}) after {n} B"))?
+        .map_err(|e| anyhow::anyhow!("{label}: read error: {e}"))?;
+
+    tokio::time::timeout(PUMP_TIMEOUT, writer)
+        .await
+        .map_err(|_| anyhow::anyhow!("{label}: writer timeout ({PUMP_TIMEOUT:?})"))?
+        .map_err(|e| anyhow::anyhow!("{label}: writer panicked: {e}"))?
+        .map_err(|e| anyhow::anyhow!("{label}: write error: {e}"))?;
+
+    anyhow::ensure!(
+        sha256_digest(&received) == expected,
+        "{label}: SHA-256 mismatch — {n} bytes corrupted in transit"
+    );
+    tracing::info!("{label}: ✓ {n} B verified (SHA-256 match)");
+    Ok(())
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// The test
+// ────────────────────────────────────────────────────────────────────────────
+
+/// End-to-end test: 3-node localcluster + Edgli + 1 MiB session pump.
+///
+/// Gated behind `#[ignore]` — see module-level docs for required setup.
+#[ignore]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn edgli_sends_one_megabyte_through_cluster() -> anyhow::Result<()> {
+
+    // ── 1. Start the 3-node HOPR cluster ────────────────────────────────────
+    // hoprd-localcluster provisions identities, deploys Safes, starts hoprd
+    // processes, waits for peer discovery, opens full-mesh channels, then
+    // prints 'localcluster running'. All of this happens before we proceed.
+    tracing::info!("starting hoprd-localcluster (3 nodes + 1 extra identity)");
+    let cluster = start_cluster().await?;
+    let summary = cluster.summary.clone();
+
+    // ── 2. Verify cluster state ──────────────────────────────────────────────
+    tracing::info!("verifying cluster: /readyz");
+    await_nodes_ready().await?;
+    tracing::info!("verifying cluster: full P2P peer visibility");
+    await_cluster_peers_discovered().await?;
+    tracing::info!("verifying cluster: full-mesh outgoing channels Open");
+    await_intracluster_channels_open().await?;
+
+    // ── 3. Boot Edgli with the pre-funded extra identity ────────────────────
+    let extra = &summary.extras[0];
+    let hopr_keys: HoprKeys = IdentityRetrievalModes::FromFile {
+        password: &extra.password,
+        id_path: extra.keystore_path.to_str().unwrap(),
+    }
+    .try_into()?;
+
+    tracing::info!(
+        safe    = %extra.safe_address,
+        module  = %extra.module_address,
+        keystore = %extra.keystore_path.display(),
+        "booting Edgli"
+    );
+
+    // Increase tx confirmation budget: the default (2 s) is too tight for
+    // blokli's SSE indexing on the Anvil test chain.
+    let connector_cfg = BlockchainConnectorConfig {
+        tx_timeout_multiplier: 10,
+        ..Default::default()
+    };
+    let edgli = Edgli::new(
+        build_edgli_config(extra),
+        hopr_keys,
+        Some(summary.blokli_url.clone()),
+        Some(connector_cfg),
+        |s: EdgliInitState| tracing::info!(?s, "edgli init"),
+    )
+    .await?;
+
+    // ── 5. Verify Edgli P2P connectivity ────────────────────────────────────
+    // Edgli must reach at least one cluster node before the strategy can open
+    // channels.  On a local setup this typically happens within seconds.
+    tracing::info!("waiting for Edgli to connect to at least 1 cluster peer");
+    await_edgli_peers_connected(&edgli, 1).await?;
+
+    // ── 6. Start the channel-lifecycle strategy reactor ─────────────────────
+    // desired_message_count = 1000 × expected session packets (forward + SURB
+    // return). This absorbs background probe traffic and the probabilistic
+    // accumulation of winning tickets: at Rotsee values (price ≈ 1e-16 wxHOPR,
+    // win_prob ≈ 0.000125) the expected drain per packet is tiny, but the
+    // channel must hold at least `ticket_price` per winning ticket. Scaling by
+    // 1000× ensures the computed initial_balance comfortably exceeds the
+    // expected winning-ticket accumulation from both test and probe traffic.
+    let session_packets = (PAYLOAD_SIZE / SESSION_MTU + 1) * 2; // fwd + SURB return
+    let sizing = IncentiveConfiguration {
+        desired_message_count: (session_packets as u64) * 1_000,
+        min_open_channels: 1,
+        target_open_channels: CLUSTER_SIZE,
+    };
+    let mut strat_cfg = default_strategy_cfg(&edgli, sizing).await?;
+
+    // Integration-test overrides:
+    // - Fresh nodes have no graph history → quality scores are 0.0, below the
+    //   default threshold of 0.5.  Set to 0 so all connected peers are eligible.
+    // - Disable require_observed_since_start for a deterministic first tick.
+    // - 10 s tick_interval (vs. 60 s default) fits the test budget.
+    for kind in &mut strat_cfg.strategies {
+        let EdgeStrategyKind::ChannelLifecycle(lc) = kind;
+        lc.eligibility = EligibilityConfig {
+            min_peer_quality_score: 0.0,
+            require_observed_since_start: false,
+            ..Default::default()
+        };
+        lc.tick_interval = Duration::from_secs(10);
+    }
+
+    let EdgeStrategyKind::ChannelLifecycle(lc0) = &strat_cfg.strategies[0];
+    tracing::info!(
+        initial_balance = ?lc0.funding.initial_balance,
+        target_channels = sizing.target_open_channels,
+        "strategy configured; starting reactor"
+    );
+
+    let _reactor_handle = edgli.run_reactor_from_cfg(strat_cfg)?;
+
+    // ── 7. Wait for Edgli outgoing channels to open ──────────────────────────
+    tracing::info!("waiting for strategy to open ≥1 outgoing channel");
+    await_edgli_channels_open(&edgli, 1).await?;
+
+    // ── 8. Prepare 1 MiB random payload ─────────────────────────────────────
+    // Random bytes produce unique HOPR packet ciphertexts on every test run,
+    // preventing false replay-detection hits in cluster nodes' in-memory
+    // packet-tag caches (which persist across Edgli reconnections to the same
+    // hoprd instance).
+    let mut payload = vec![0u8; PAYLOAD_SIZE];
+    rand::thread_rng().fill_bytes(&mut payload);
+
+    // ── 9. 0-hop session — direct path, no relay ─────────────────────────────
+    // Forward: Edgli → node 0 (0-hop in HOPR terms = direct, no relay)
+    // Return:  node 0 echoes via built-in loopback service (ExitNode(0))
+    //
+    // NoRateControl disables the exit node's egress rate limiter (default: 10
+    // pkt/s initial rate).  Without it, returning 1 MiB (~1030 packets) at
+    // 10 pkt/s takes ~103 s, nearly exhausting the 120 s PUMP_TIMEOUT before
+    // the rate-adaptive controller has time to ramp up.
+    tracing::info!("opening 0-hop session to node 0 (loopback)");
+    let (session_0h, _) = edgli
+        .connect_to(
+            summary.nodes[0].address,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(0_usize)?,
+                return_path:  HopRouting::try_from(0_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl).into(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    pump_and_verify(session_0h, &payload, "0-hop").await?;
+
+    // ── 10. 1-hop session — full relay path ──────────────────────────────────
+    // Forward: Edgli → relay (auto-selected) → node 2 (1-hop in HOPR terms)
+    // Return:  node 2 echoes via built-in loopback service (ExitNode(0))
+    // Intracluster channels (relay→node2, node2→relay) were opened by the
+    // localcluster before it printed 'localcluster running'.
+    tracing::info!("opening 1-hop session to node 2 (loopback)");
+    let (session_1h, _) = edgli
+        .connect_to(
+            summary.nodes[2].address,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(1_usize)?,
+                return_path:  HopRouting::try_from(1_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl).into(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    pump_and_verify(session_1h, &payload, "1-hop").await?;
+
+    // ── 11. Final state assertion ─────────────────────────────────────────────
+    let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
+    let open_count = channels.iter().filter(|ch| ch.status == ChannelStatus::Open).count();
+    assert!(
+        open_count >= 1,
+        "expected ≥1 Open outgoing channel after pumping; got {open_count}"
+    );
+    tracing::info!(open_channels = open_count, "test passed ✓");
+
+    // Drop Edgli first to cancel background tasks cleanly, then the cluster.
+    drop(edgli);
+    drop(cluster);
+
+    Ok(())
+}

--- a/tests/edgli_session_e2e.rs
+++ b/tests/edgli_session_e2e.rs
@@ -77,9 +77,7 @@ use edgli::{
     traits::EdgeNodeApi,
     Edgli, EdgliInitState,
 };
-use hoprd_api_client::Client as HoprdClient;
 use rand::RngCore as _;
-use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 
@@ -406,21 +404,39 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
         }
     });
 
-    tokio::time::timeout(CLUSTER_START_TIMEOUT, ready_rx)
-        .await
-        .map_err(|_| anyhow::anyhow!(
-            "timeout ({CLUSTER_START_TIMEOUT:?}) waiting for 'localcluster running' sentinel"
-        ))?
-        .map_err(|_| anyhow::anyhow!(
-            "localcluster stdout closed before printing 'localcluster running'"
-        ))?;
+    let startup_result: anyhow::Result<ClusterSummary> = async {
+        tokio::time::timeout(CLUSTER_START_TIMEOUT, ready_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!(
+                "timeout ({CLUSTER_START_TIMEOUT:?}) waiting for 'localcluster running' sentinel"
+            ))?
+            .map_err(|_| anyhow::anyhow!(
+                "localcluster stdout closed before printing 'localcluster running'"
+            ))?;
 
-    // Brief pause so any trailing summary lines in the same stdout flush are
-    // buffered before we snapshot.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+        // Brief pause so any trailing summary lines in the same stdout flush are
+        // buffered before we snapshot.
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
-    let stdout_text = collected.lock().await.clone();
-    let summary = parse_summary(&stdout_text)?;
+        let stdout_text = collected.lock().await.clone();
+        parse_summary(&stdout_text)
+    }
+    .await;
+
+    let summary = match startup_result {
+        Ok(s) => s,
+        Err(err) => {
+            #[cfg(unix)]
+            if let Some(pid) = child.id() {
+                let _ = nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid as i32),
+                    nix::sys::signal::Signal::SIGINT,
+                );
+            }
+            let _ = child.start_kill();
+            return Err(err);
+        }
+    };
 
     tracing::info!(
         blokli_url = %summary.blokli_url,
@@ -438,34 +454,35 @@ async fn start_cluster() -> anyhow::Result<ClusterHandle> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Cluster node state helpers (hoprd-api-client native types)
+// Cluster node state helpers (plain reqwest)
 // ────────────────────────────────────────────────────────────────────────────
 
-/// Build an authenticated `hoprd_api_client::Client` for the given node port.
-fn node_client(port: u16) -> HoprdClient {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(&format!("Bearer {API_TOKEN}")).unwrap(),
-    );
-    let http = reqwest::Client::builder()
+fn node_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
-        .default_headers(headers)
         .build()
-        .unwrap();
-    HoprdClient::new_with_client(
-        &format!("http://{API_HOST}:{port}"),
-        http,
-    )
+        .unwrap()
+}
+
+fn auth_header() -> String {
+    format!("Bearer {API_TOKEN}")
 }
 
 /// Poll /readyz on all cluster nodes until every one returns 200.
 async fn await_nodes_ready() -> anyhow::Result<()> {
+    let client = node_http_client();
     let deadline = tokio::time::Instant::now() + READYZ_TIMEOUT;
     loop {
         let mut all_ready = true;
         for i in 0..CLUSTER_SIZE {
-            if node_client(API_PORT_BASE + i as u16).readyz().await.is_err() {
+            let port = API_PORT_BASE + i as u16;
+            let ok = client
+                .get(format!("http://{API_HOST}:{port}/readyz"))
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+            if !ok {
                 all_ready = false;
                 break;
             }
@@ -487,16 +504,25 @@ async fn await_nodes_ready() -> anyhow::Result<()> {
 /// opening channels, so this check typically completes immediately after
 /// 'localcluster running'.
 async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
+    let client = node_http_client();
     let expected = CLUSTER_SIZE - 1;
     let deadline = tokio::time::Instant::now() + PEER_DISCOVERY_TIMEOUT;
     loop {
         let mut all_discovered = true;
         for i in 0..CLUSTER_SIZE {
-            let announced = node_client(API_PORT_BASE + i as u16)
-                .announced()
-                .await
-                .map(|r| r.into_inner().len())
-                .unwrap_or(0);
+            let port = API_PORT_BASE + i as u16;
+            let announced = async {
+                let body: serde_json::Value = client
+                    .get(format!("http://{API_HOST}:{port}/api/v4/network/announced"))
+                    .header("Authorization", auth_header())
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
+                anyhow::Ok(body.as_array().map(|a| a.len()).unwrap_or(0))
+            }
+            .await
+            .unwrap_or(0);
             if announced < expected {
                 tracing::debug!("node {i}: {announced}/{expected} announced peers");
                 all_discovered = false;
@@ -522,22 +548,36 @@ async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
 /// ready sentinel, so this check typically completes immediately after
 /// 'localcluster running'.
 async fn await_intracluster_channels_open() -> anyhow::Result<()> {
+    let client = node_http_client();
     let expected = CLUSTER_SIZE - 1;
     let deadline = tokio::time::Instant::now() + INTRACLUSTER_CHANNEL_TIMEOUT;
     loop {
         let mut all_open = true;
         for i in 0..CLUSTER_SIZE {
-            let open = node_client(API_PORT_BASE + i as u16)
-                .list_channels(None, Some(false))
-                .await
-                .map(|r| {
-                    r.into_inner()
-                        .outgoing
-                        .iter()
-                        .filter(|ch| ch.status == "Open")
-                        .count()
-                })
-                .unwrap_or(0);
+            let port = API_PORT_BASE + i as u16;
+            let open = async {
+                let body: serde_json::Value = client
+                    .get(format!(
+                        "http://{API_HOST}:{port}/api/v4/channels?includingClosed=false"
+                    ))
+                    .header("Authorization", auth_header())
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
+                anyhow::Ok(
+                    body["outgoing"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter(|ch| ch["status"].as_str() == Some("Open"))
+                                .count()
+                        })
+                        .unwrap_or(0),
+                )
+            }
+            .await
+            .unwrap_or(0);
             if open < expected {
                 tracing::debug!("node {i}: {open}/{expected} outgoing channels Open");
                 all_open = false;
@@ -680,10 +720,15 @@ async fn pump_and_verify(session: HoprSession, payload: &[u8], label: &str) -> a
     });
 
     let mut received = vec![0u8; n];
-    tokio::time::timeout(PUMP_TIMEOUT, r.read_exact(&mut received))
+    if let Err(err) = tokio::time::timeout(PUMP_TIMEOUT, r.read_exact(&mut received))
         .await
-        .map_err(|_| anyhow::anyhow!("{label}: read timeout ({PUMP_TIMEOUT:?}) after {n} B"))?
-        .map_err(|e| anyhow::anyhow!("{label}: read error: {e}"))?;
+        .map_err(|_| anyhow::anyhow!("{label}: read timeout ({PUMP_TIMEOUT:?}) after {n} B"))
+        .and_then(|r| r.map_err(|e| anyhow::anyhow!("{label}: read error: {e}")))
+    {
+        writer.abort();
+        let _ = writer.await;
+        return Err(err);
+    }
 
     tokio::time::timeout(PUMP_TIMEOUT, writer)
         .await


### PR DESCRIPTION
## Summary

- Adds `compute_funding_config` to derive channel funding from on-chain `ticket_price` and `win_prob`: sizes `initial_balance` as `max(N × ticket_price, ticket_price / win_prob)` ensuring at least one ticket can always be issued
- Adds `default_strategy_cfg` — async helper that fetches chain values and builds a ready-to-use `MultiStrategyConfig` for the channel-lifecycle reactor
- Adds `IncentiveConfiguration` with smart defaults for channel count and message budget, plus a `validate()` method enforcing `target_open_channels >= min_open_channels`
- Re-exports `EligibilityConfig` from `hopr-strategy` for callers that need eligibility tuning
- Disables blokli `auto_compatibility_check` in local-cluster mode so `bloklid-anvil` dev images work without the `IndexesSafeEvents` feature flag (follow-up scoping in #62)
- Adds end-to-end integration test (`tests/edgli_session_e2e.rs`) that spins up a real 3-node HOPR cluster, boots Edgli with a pre-funded extra identity, opens channels via the strategy reactor, and verifies 1 MiB SHA-256 integrity through both a 0-hop and a 1-hop session

## Test results

```
test edgli_sends_one_megabyte_through_cluster ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; finished in 351.43s
```

- 0-hop: ✓ 1048576 B verified (SHA-256 match)
- 1-hop: ✓ 1048576 B verified (SHA-256 match)

## Dependencies

Depends on: https://github.com/hoprnet/hoprd/pull/21 (localcluster OTel override — required for clean cluster nodes during test)

## Running the test

```bash
export HOPRD_LOCALCLUSTER_BIN=~/Fun/hoprnet.org/hoprd/target/release/hoprd-localcluster
export HOPRD_BIN=~/Fun/hoprnet.org/hoprd/target/release/hoprd
export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:0.10.6-pr.351'
export HOPRD_CONTAINER_RUNTIME=/opt/homebrew/bin/container  # macOS Apple container
# --release required: HOPR async future chains overflow the debug stack
RUST_LOG=info,edgli=debug cargo test --test edgli_session_e2e --release -- --ignored --nocapture
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable incentive-based funding and an async default strategy that derives minimum ticket parameters from the network.

* **Bug Fixes**
  * Disabled an over-eager compatibility check to improve local cluster testing reliability.

* **Tests**
  * Strengthened funding-validation tests and added an ignored multi-node end-to-end session integrity test.

* **Chores**
  * Updated development dependencies to support integration testing and local development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoprnet/edge-client/pull/61)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->