### PR TITLE
feat: balance recommendations and channel capacity API

### DIFF
--- a/.github/scripts/generate-metrics-docs.sh
+++ b/.github/scripts/generate-metrics-docs.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Lint: ensures every Prometheus metric defined in Rust code is documented in
+# METRICS.md, and that METRICS.md does not reference non-existing metrics.
+#
+# Usage:  ./.github/scripts/generate-metrics-docs.sh              (lint — verify sync)
+#         ./.github/scripts/generate-metrics-docs.sh --fix         (update METRICS.md and git-add)
+#         ./.github/scripts/generate-metrics-docs.sh --generate    (print markdown table to stdout)
+#         just generate-metrics-docs                               (via justfile recipe)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+METRICS_DOC="$REPO_ROOT/METRICS.md"
+
+# ── Helper: extract metrics from code ────────────────────────────────────────
+# Outputs tab-separated rows:  name \t type \t description \t detail
+# Requires 8 lines of trailing context to capture buckets/keys on later lines.
+extract_metrics() {
+  (cd "$REPO_ROOT" && grep -rA8 -E '(Simple|Multi)(Counter|Gauge|Histogram)::new\(' --exclude-dir='.git' --exclude-dir='target' --exclude-dir='.cargo' --exclude-dir='.claude' --include='*.rs' .) |
+    gawk '
+    /^\.\/misc\/metrics\// { next }
+
+    # ── new ::new( call → flush previous metric and start fresh ──
+    match($0, /(Simple|Multi)(Counter|Gauge|Histogram)::new\(/, t) {
+      if (name != "") {
+        detail = ""
+        if (keys != "") detail = detail "keys: " keys
+        if (buckets != "") { if (detail != "") detail = detail "; "; detail = detail "buckets: " buckets }
+        printf "%s\t%s\t%s\t%s\n", name, type, desc, detail
+      }
+      name = ""; type = ""; desc = ""; buckets = ""; keys = ""
+      type = t[1] t[2]
+      # Try to extract name + description + keys + buckets from the same line
+      if (match($0, /"(hopr_[a-z0-9_]+)"/, m)) name = m[1]
+      if (name != "" && match($0, /hopr_[a-z0-9_]+",[ ]*"([^"]+)"/, d)) desc = d[1]
+      if (name != "" && match($0, /&\[([^\]]+)\]/, k)) {
+        keys = k[1]; gsub(/"/, "", keys); gsub(/,  */, ", ", keys)
+      }
+      if (name != "" && match($0, /vec!\[([0-9.,_ ]+)\]/, b)) {
+        buckets = b[1]; gsub(/[_ ]/, "", buckets)
+      }
+      next
+    }
+
+    # ── group separator ──
+    /^--$/ {
+      if (name != "") {
+        detail = ""
+        if (keys != "") detail = detail "keys: " keys
+        if (buckets != "") { if (detail != "") detail = detail "; "; detail = detail "buckets: " buckets }
+        printf "%s\t%s\t%s\t%s\n", name, type, desc, detail
+      }
+      name = ""; type = ""; desc = ""; buckets = ""; keys = ""
+      next
+    }
+
+    # ── first "hopr_..." string is the metric name ──
+    name == "" && match($0, /"(hopr_[a-z0-9_]+)"/, m) { name = m[1]; next }
+
+    # ── second quoted string is the description ──
+    name != "" && desc == "" && match($0, /"([^"]+)"/, d) { desc = d[1]; next }
+
+    # ── collect bucket values (vec![...]) ──
+    name != "" && match($0, /vec!\[([0-9.,_ ]+)\]/, b) {
+      buckets = b[1]; gsub(/[_ ]/, "", buckets); next
+    }
+
+    # ── collect named constant buckets ──
+    name != "" && buckets == "" && match($0, /(TIMING_BUCKETS|BUCKETS)/, cb) {
+      buckets = cb[1]; next
+    }
+
+    # ── collect label keys (&["key1", "key2"]) ──
+    name != "" && match($0, /&\[([^\]]+)\]/, k) {
+      keys = k[1]; gsub(/"/, "", keys); gsub(/,  */, ", ", keys); next
+    }
+
+    END {
+      if (name != "") {
+        detail = ""
+        if (keys != "") detail = detail "keys: " keys
+        if (buckets != "") { if (detail != "") detail = detail "; "; detail = detail "buckets: " buckets }
+        printf "%s\t%s\t%s\t%s\n", name, type, desc, detail
+      }
+    }
+  ' |
+    LC_ALL=C sort -t$'\t' -k1,1
+}
+
+# ── --generate: print a column-aligned markdown table and exit ────────────────
+if [[ ${1:-} == "--generate" ]]; then
+  # Collect rows first to compute column widths
+  extract_stderr=$(mktemp)
+  trap 'rm -f "$extract_stderr"' EXIT
+  rows=()
+  while IFS=$'\t' read -r name type desc detail; do
+    rows+=("$(printf "\`%s\`\t%s\t%s\t%s" "$name" "$type" "$desc" "$detail")")
+  done < <(extract_metrics 2>"$extract_stderr")
+
+  if [[ ${#rows[@]} -eq 0 ]]; then
+    echo "No Prometheus metrics are defined in this codebase."
+    exit 0
+  fi
+
+  # Compute max width per column (start with header widths)
+  headers=("Name" "Type" "Description" "Detail")
+  widths=(${#headers[0]} ${#headers[1]} ${#headers[2]} ${#headers[3]})
+  for row in "${rows[@]}"; do
+    IFS=$'\t' read -r c1 c2 c3 c4 <<<"$row"
+    ((${#c1} > widths[0])) && widths[0]=${#c1}
+    ((${#c2} > widths[1])) && widths[1]=${#c2}
+    ((${#c3} > widths[2])) && widths[2]=${#c3}
+    ((${#c4} > widths[3])) && widths[3]=${#c4}
+  done
+
+  # Print header
+  printf "| %-${widths[0]}s | %-${widths[1]}s | %-${widths[2]}s | %-${widths[3]}s |\n" \
+    "${headers[0]}" "${headers[1]}" "${headers[2]}" "${headers[3]}"
+  # Print separator
+  printf "| %s | %s | %s | %s |\n" \
+    "$(printf '%0.s-' $(seq 1 ${widths[0]}))" \
+    "$(printf '%0.s-' $(seq 1 ${widths[1]}))" \
+    "$(printf '%0.s-' $(seq 1 ${widths[2]}))" \
+    "$(printf '%0.s-' $(seq 1 ${widths[3]}))"
+  # Print rows
+  for row in "${rows[@]}"; do
+    IFS=$'\t' read -r c1 c2 c3 c4 <<<"$row"
+    printf "| %-${widths[0]}s | %-${widths[1]}s | %-${widths[2]}s | %-${widths[3]}s |\n" \
+      "$c1" "$c2" "$c3" "$c4"
+  done
+  exit 0
+fi
+
+# ── --fix: regenerate METRICS.md in place and stage it ─────────────────────────
+if [[ ${1:-} == "--fix" ]]; then
+  expected=$(bash "$0" --generate)
+  echo "$expected" >"$METRICS_DOC"
+  git -C "$REPO_ROOT" add "$METRICS_DOC"
+  echo "METRICS.md updated and staged."
+  exit 0
+fi
+
+# ── Lint mode ────────────────────────────────────────────────────────────────
+
+if [[ ! -f $METRICS_DOC ]]; then
+  echo "ERROR: METRICS.md not found at $METRICS_DOC" >&2
+  exit 1
+fi
+
+# Normalize a markdown table: collapse runs of whitespace around pipes so that
+# column-aligned (prettified) tables compare equal to compact ones.
+normalize_table() {
+  sed -E 's/[ ]+\|/|/g; s/\|[ ]+/|/g; s/\|-+/|---/g'
+}
+
+# Generate expected content and compare with the actual file (whitespace-tolerant)
+expected=$(bash "$0" --generate)
+
+if ! diff -q <(echo "$expected" | normalize_table) <(normalize_table <"$METRICS_DOC") >/dev/null 2>&1; then
+  echo "ERROR: METRICS.md is out of date. Differences:"
+  diff -u <(normalize_table <"$METRICS_DOC") <(echo "$expected" | normalize_table) | head -40
+  echo ""
+  echo "Run:  $0 --generate > METRICS.md"
+  exit 1
+fi
+
+count=$(echo "$expected" | grep -c '^|' || true)
+count=$((count > 2 ? count - 2 : 0))
+echo "OK: All $count metrics are in sync between code and METRICS.md."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e56ce0ee006aafac6eb430dac4ef3098fe9b6912#e56ce0ee006aafac6eb430dac4ef3098fe9b6912"
+source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.42"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e84ab07ca0c3210734019e4d0e5392952ed574196ab0f904ab9c7ba0ae15595"
+checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
+checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -218,7 +218,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
+checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
+checksum = "c3f2f7dac66147d165063c670dabca7b34807428130bef4583a7976523140f8d"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -424,7 +424,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
  "k256",
@@ -435,15 +435,16 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
+checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -504,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -527,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
+checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -539,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
+checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -551,20 +552,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -583,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -594,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -609,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -625,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -639,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -651,16 +656,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.11.0",
  "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -676,19 +681,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -698,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -721,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -753,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1106,6 +1111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1212,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async_channel_io"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2817ab4eedf77732e9b8fa765801a598df651b49264112a75c72d8f5f56319d"
+dependencies = [
+ "async-channel 2.5.0",
+ "futures",
+ "log",
 ]
 
 [[package]]
@@ -2485,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2983,7 +3011,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24076708e74fbd55fb36079acbba19988175140026cc67a878b91b0c3751220b"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-io",
  "futures-core",
  "pin-project-lite",
@@ -3194,19 +3222,19 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3416,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253cae294dced141adf9e102a09bd4bcbac36efaf13451d1fad93661b59c5a16"
+checksum = "e33fb0c32d216e93e58a050edea339bc8ed5bd8fe844bf893b849fc402824412"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3436,21 +3464,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-async-runtime"
-version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "auto_impl",
- "futures",
- "indexmap 2.14.0",
- "tokio",
-]
-
-[[package]]
 name = "hopr-bindings"
-version = "4.7.3"
+version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9d4048861f0bf39104f3837153b35b20f4e08c3dd943ea1bc31a001eda11fc"
+checksum = "608e63087ec94960a191199c4392a30895694a88de04ad5b23804733b729251b"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3467,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3481,7 +3498,7 @@ dependencies = [
  "futures-time",
  "hex",
  "hopr-api",
- "hopr-async-runtime",
+ "hopr-utils",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3495,61 +3512,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-crypto-keypair"
-version = "0.5.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "hex",
- "hopr-platform",
- "hopr-types",
- "scrypt",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "typenum",
- "uuid",
-]
-
-[[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "flagset",
- "hex",
- "hopr-crypto-sphinx",
- "hopr-parallelize",
- "hopr-types",
- "serde",
- "serde_bytes",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "hopr-crypto-sphinx"
-version = "0.12.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "bimap",
  "curve25519-dalek",
  "elliptic-curve",
+ "flagset",
  "generic-array 1.4.1",
+ "hex",
  "hopr-types",
+ "hopr-utils",
  "k256",
  "serde",
  "serde_bytes",
+ "strum 0.28.0",
  "subtle",
  "thiserror 2.0.18",
+ "tracing",
  "typenum",
 ]
 
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3557,7 +3545,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-statistics",
+ "hopr-utils",
  "smart-default",
  "tracing",
  "validator",
@@ -3565,8 +3553,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "4.0.2-rc.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3578,13 +3566,8 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-async-runtime",
- "hopr-crypto-keypair",
- "hopr-metrics",
- "hopr-network-types",
- "hopr-parallelize",
- "hopr-platform",
  "hopr-transport",
+ "hopr-utils",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3599,25 +3582,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-metrics"
-version = "2.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "opentelemetry",
- "opentelemetry-prometheus-text-exporter",
- "opentelemetry_sdk",
-]
-
-[[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-statistics",
+ "hopr-utils",
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
@@ -3626,59 +3599,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-network-types"
-version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "arrayvec",
- "flume",
- "futures",
- "futures-time",
- "hickory-resolver 0.26.1",
- "hopr-async-runtime",
- "hopr-metrics",
- "hopr-types",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "pin-project",
- "serde",
- "serde_bytes",
- "socket2 0.6.3",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hopr-parallelize"
-version = "0.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "futures",
- "hopr-metrics",
- "lazy_static",
- "libc",
- "rayon",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hopr-platform"
-version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3690,8 +3613,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "4.6.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3702,10 +3625,8 @@ dependencies = [
  "hex",
  "hopr-api",
  "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-parallelize",
- "hopr-platform",
  "hopr-ticket-manager",
+ "hopr-utils",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3723,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3734,11 +3655,10 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
- "hashbrown 0.17.0",
- "hopr-async-runtime",
+ "hashbrown 0.17.1",
  "hopr-crypto-packet",
- "hopr-metrics",
  "hopr-types",
+ "hopr-utils",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -3755,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3769,11 +3689,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-reference"
-version = "4.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "4.2.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "futures",
+ "hopr-api",
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-lib",
@@ -3786,17 +3707,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-statistics"
-version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "rand 0.10.1",
-]
-
-[[package]]
 name = "hopr-strategy"
-version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "0.19.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3804,8 +3717,8 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
- "hopr-async-runtime",
- "hopr-lib",
+ "hopr-api",
+ "hopr-utils",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3821,16 +3734,16 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "ahash",
  "anyhow",
  "clap",
  "dashmap",
  "futures",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hopr-api",
- "hopr-platform",
+ "hopr-utils",
  "parking_lot",
  "postcard",
  "redb",
@@ -3842,30 +3755,32 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "0.28.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-trait",
+ "async_channel_io",
  "bytes",
  "cfg-if",
+ "dashmap",
  "futures",
  "futures-time",
+ "halfbrown",
  "hopr-api",
- "hopr-async-runtime",
  "hopr-crypto-packet",
- "hopr-network-types",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
  "hopr-ticket-manager",
  "hopr-transport-mixer",
- "hopr-transport-path",
  "hopr-transport-probe",
- "hopr-transport-protocol",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
+ "hopr-utils",
  "humantime-serde",
  "lazy_static",
+ "libp2p",
  "moka",
  "multiaddr",
  "proc-macro-regex",
@@ -3874,6 +3789,7 @@ dependencies = [
  "smart-default",
  "strum 0.28.0",
  "thiserror 2.0.18",
+ "tokio-util",
  "tracing",
  "validator",
 ]
@@ -3881,11 +3797,10 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "futures",
  "futures-timer",
- "hopr-metrics",
  "hopr-types",
  "lazy_static",
  "parking_lot",
@@ -3896,8 +3811,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "0.9.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3905,7 +3820,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-network-types",
+ "hopr-utils",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -3914,31 +3829,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-transport-path"
-version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "anyhow",
- "futures",
- "futures-time",
- "hopr-api",
- "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-protocol-hopr",
- "hopr-statistics",
- "hopr-types",
- "lazy_static",
- "moka",
- "smart-default",
- "thiserror 2.0.18",
- "tracing",
- "validator",
-]
-
-[[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3946,10 +3839,9 @@ dependencies = [
  "futures-concurrency",
  "hex",
  "hopr-api",
- "hopr-async-runtime",
- "hopr-platform",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
+ "hopr-utils",
  "humantime-serde",
  "moka",
  "rand 0.10.1",
@@ -3962,43 +3854,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-transport-protocol"
-version = "1.8.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
-dependencies = [
- "ahash",
- "anyhow",
- "bytes",
- "dashmap",
- "futures",
- "futures-time",
- "halfbrown",
- "hopr-api",
- "hopr-async-runtime",
- "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-network-types",
- "hopr-parallelize",
- "hopr-protocol-app",
- "hopr-protocol-hopr",
- "humantime-serde",
- "lazy_static",
- "libp2p",
- "moka",
- "rust-stream-ext-concurrent",
- "serde",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tokio-util",
- "tracing",
- "validator",
-]
-
-[[package]]
 name = "hopr-transport-session"
-version = "0.21.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+version = "0.22.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4006,15 +3864,13 @@ dependencies = [
  "flagset",
  "futures",
  "futures-time",
- "hopr-async-runtime",
+ "hopr-api",
  "hopr-crypto-packet",
- "hopr-metrics",
- "hopr-network-types",
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
  "hopr-transport-tag-allocator",
- "hopr-types",
+ "hopr-utils",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4033,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=37d2a1cc14#37d2a1cc1478d4ff419f07b5fdbbc79e350324aa"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4044,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.5.4"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d918bfe437f576b2395aa776e12bf678ba652fee5085a6ce77c8355f11fbbb0"
+checksum = "75e82a6426de74cdef7bbef15f651ce546ab39fc77ef1dc4002247b6bbf034fc"
 dependencies = [
  "aes",
  "anyhow",
@@ -4071,24 +3927,60 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "num_enum",
+ "opentelemetry",
+ "opentelemetry-prometheus-text-exporter",
+ "opentelemetry_sdk",
  "poly1305",
  "primitive-types 0.14.0",
  "rand 0.10.1",
  "rayon",
  "regex",
+ "scrypt",
  "secp256k1 0.31.1",
  "serde",
  "serde_bytes",
+ "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "smart-default",
  "strum 0.28.0",
  "subtle",
  "thiserror 2.0.18",
  "tracing",
  "typenum",
+ "uuid",
  "zeroize",
+]
+
+[[package]]
+name = "hopr-utils"
+version = "0.1.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "flume",
+ "futures",
+ "futures-time",
+ "hickory-resolver 0.26.1",
+ "hopr-types",
+ "indexmap 2.14.0",
+ "lazy_static",
+ "libc",
+ "libp2p-identity",
+ "multiaddr",
+ "pin-project",
+ "rand 0.10.1",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "socket2 0.6.3",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -4520,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "rayon",
  "serde",
  "serde_core",
@@ -4708,6 +4600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -5236,9 +5138,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5284,7 +5186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -5932,18 +5834,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7170,11 +7072,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7189,9 +7092,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -7251,7 +7154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -7526,9 +7439,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7750,9 +7663,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7841,7 +7754,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -7850,7 +7763,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -8696,15 +8609,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9147cb9b613d801afdf8e9cd19b184cf509c2692#9147cb9b613d801afdf8e9cd19b184cf509c2692"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e#0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0aa05f5ad6e5d8ef641aa4a170bc7785f3b3575e", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e56ce0ee006aafac6eb430dac4ef3098fe9b6912", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -11,7 +11,6 @@ license = "GPL-3.0-only"
 [features]
 default = ["runtime-tokio", "blokli"]
 runtime-tokio = ["dep:tokio", "hopr-lib/runtime-tokio"]
-session-server = ["hopr-lib/session-server"]
 # Enable hopr-lib telemetry (Prometheus metrics) and OpenTelemetry OTLP exporter
 telemetry = [
   "hopr-lib/telemetry",
@@ -67,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2a1cc14", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2a1cc14", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2a1cc14", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2a1cc14" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2a1cc14", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -89,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "37d2a1cc14", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "9147cb9b613d801afdf8e9cd19b184cf509c2692", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/METRICS.md
+++ b/METRICS.md
@@ -1,0 +1,1 @@
+No Prometheus metrics are defined in this codebase.

--- a/src/client.rs
+++ b/src/client.rs
@@ -266,7 +266,7 @@ impl Edgli {
     /// Each [`super::strategy::Capacity`] entry holds the wxHOPR stake, the
     /// floor number of session frames it can fund at the current ticket price,
     /// and the corresponding raw byte capacity (`expected_messages × SESSION_MTU`).
-    pub async fn list_channel_capacities(
+    pub async fn describe_current_capacity_allocations(
         &self,
     ) -> anyhow::Result<std::collections::HashMap<String, super::strategy::Capacity>> {
         use hopr_lib::api::{

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,17 +260,17 @@ impl Edgli {
         super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing)
     }
 
-    /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityKey`].
+    /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityAllocator`].
     ///
-    /// Open outgoing channels are keyed by `CapacityKey::Peer(address)`; the
-    /// unallocated Safe balance is keyed by `CapacityKey::Safe`.  Each
+    /// Open outgoing channels are keyed by `CapacityAllocator::Peer(address)`; the
+    /// unallocated Safe balance is keyed by `CapacityAllocator::Safe`.  Each
     /// [`super::strategy::Capacity`] holds the wxHOPR stake, the floor number
     /// of session frames it can fund at the current ticket price, and the
     /// corresponding raw byte capacity (`expected_messages × SESSION_MTU`).
     pub async fn describe_current_capacity_allocations(
         &self,
     ) -> anyhow::Result<
-        std::collections::HashMap<super::strategy::CapacityKey, super::strategy::Capacity>,
+        std::collections::HashMap<super::strategy::CapacityAllocator, super::strategy::Capacity>,
     > {
         use hopr_lib::api::{
             chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
@@ -301,21 +301,21 @@ impl Edgli {
         };
 
         let mut map: std::collections::HashMap<
-            super::strategy::CapacityKey,
+            super::strategy::CapacityAllocator,
             super::strategy::Capacity,
         > = channels
             .into_iter()
             .filter(|c| c.status == ChannelStatus::Open)
             .map(|c| {
                 (
-                    super::strategy::CapacityKey::Peer(c.destination),
+                    super::strategy::CapacityAllocator::Peer(c.destination),
                     super::strategy::compute_capacity(c.balance, ticket_price),
                 )
             })
             .collect();
 
         map.insert(
-            super::strategy::CapacityKey::Safe,
+            super::strategy::CapacityAllocator::Safe,
             super::strategy::compute_capacity(safe_balance, ticket_price),
         );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,10 +272,7 @@ impl Edgli {
         use hopr_lib::api::{
             chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
             node::{HasChainApi, IncentiveChannelOperations},
-            types::{
-                internal::channels::ChannelStatus,
-                primitive::prelude::HoprBalance,
-            },
+            types::{internal::channels::ChannelStatus, primitive::prelude::HoprBalance},
         };
 
         let chain = self.chain_api();

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,15 +260,18 @@ impl Edgli {
         super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing)
     }
 
-    /// Returns a map of data-throughput capacities keyed by peer address (for
-    /// open outgoing channels) and `"safe"` (for the unallocated Safe balance).
+    /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityKey`].
     ///
-    /// Each [`super::strategy::Capacity`] entry holds the wxHOPR stake, the
-    /// floor number of session frames it can fund at the current ticket price,
-    /// and the corresponding raw byte capacity (`expected_messages × SESSION_MTU`).
+    /// Open outgoing channels are keyed by `CapacityKey::Peer(address)`; the
+    /// unallocated Safe balance is keyed by `CapacityKey::Safe`.  Each
+    /// [`super::strategy::Capacity`] holds the wxHOPR stake, the floor number
+    /// of session frames it can fund at the current ticket price, and the
+    /// corresponding raw byte capacity (`expected_messages × SESSION_MTU`).
     pub async fn describe_current_capacity_allocations(
         &self,
-    ) -> anyhow::Result<std::collections::HashMap<String, super::strategy::Capacity>> {
+    ) -> anyhow::Result<
+        std::collections::HashMap<super::strategy::CapacityKey, super::strategy::Capacity>,
+    > {
         use hopr_lib::api::{
             chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
             node::{HasChainApi, IncentiveChannelOperations},
@@ -297,19 +300,22 @@ impl Edgli {
             None => HoprBalance::zero(),
         };
 
-        let mut map: std::collections::HashMap<String, super::strategy::Capacity> = channels
+        let mut map: std::collections::HashMap<
+            super::strategy::CapacityKey,
+            super::strategy::Capacity,
+        > = channels
             .into_iter()
             .filter(|c| c.status == ChannelStatus::Open)
             .map(|c| {
                 (
-                    c.destination.to_string(),
+                    super::strategy::CapacityKey::Peer(c.destination),
                     super::strategy::compute_capacity(c.balance, ticket_price),
                 )
             })
             .collect();
 
         map.insert(
-            "safe".to_string(),
+            super::strategy::CapacityKey::Safe,
             super::strategy::compute_capacity(safe_balance, ticket_price),
         );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -217,6 +217,78 @@ impl Edgli {
         self.packet_public_key.to_peerid_str()
     }
 
+    /// Returns the ideal recommended wxHOPR and xDAI for this node to reach
+    /// `cfg.target_open_channels` open channels to *currently connected* peers.
+    ///
+    /// Unlike [`minimum_balance_recommendation`](crate::strategy::minimum_balance_recommendation),
+    /// this method discounts channels already open to connected peers, so the
+    /// recommendation reflects only the additional stake the strategy needs.
+    /// Channels open to disconnected peers are not counted — the strategy will
+    /// close and replace them.
+    pub async fn ideal_balance_recommendation(
+        &self,
+        cfg: &super::strategy::IncentiveConfiguration,
+    ) -> anyhow::Result<super::strategy::BalanceRecommendation> {
+        use hopr_lib::api::{
+            chain::ChainValues as _,
+            node::{HasChainApi, IncentiveChannelOperations},
+            types::internal::channels::ChannelStatus,
+        };
+        use std::collections::HashSet;
+
+        let chain = self.chain_api();
+        let ticket_price = chain.minimum_ticket_price().await?;
+        let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
+
+        let source = HasChainApi::identity(&*self.hopr).node_address;
+        let all_channels = IncentiveChannelOperations::channels_from(&*self.hopr, source)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let connected: HashSet<_> = crate::traits::EdgeNodeApi::connected_peer_addresses(self)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .into_iter()
+            .collect();
+
+        let open_to_connected = all_channels
+            .iter()
+            .filter(|c| c.status == ChannelStatus::Open && connected.contains(&c.destination))
+            .count();
+
+        let missing = cfg.target_open_channels.saturating_sub(open_to_connected);
+        super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing)
+    }
+
+    /// Lists all open outgoing channels with their data-throughput capacity.
+    ///
+    /// `expected_messages` is the floor number of session frames the channel
+    /// balance can fund at the current on-chain ticket price.
+    /// `byte_capacity` = `expected_messages × SESSION_MTU`.
+    pub async fn list_channel_capacities(
+        &self,
+    ) -> anyhow::Result<Vec<super::strategy::ChannelCapacity>> {
+        use hopr_lib::api::{
+            chain::ChainValues as _,
+            node::{HasChainApi, IncentiveChannelOperations},
+            types::internal::channels::ChannelStatus,
+        };
+
+        let chain = self.chain_api();
+        let ticket_price = chain.minimum_ticket_price().await?;
+
+        let source = HasChainApi::identity(&*self.hopr).node_address;
+        let channels = IncentiveChannelOperations::channels_from(&*self.hopr, source)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        Ok(channels
+            .into_iter()
+            .filter(|c| c.status == ChannelStatus::Open)
+            .map(|c| super::strategy::compute_channel_capacity(&c, ticket_price))
+            .collect())
+    }
+
     /// Run a node with HOPR edge strategies integrated.
     ///
     /// The default reactor runs a single [`ChannelLifecycleStrategy`] which

--- a/src/client.rs
+++ b/src/client.rs
@@ -261,13 +261,14 @@ impl Edgli {
     }
 
     /// Lists all open outgoing channels with their data-throughput capacity,
-    /// plus the unallocated wxHOPR balance in the user's Safe contract.
+    /// plus the message capacity derivable from the unallocated Safe balance.
     ///
-    /// `expected_messages` is the floor number of session frames the channel
-    /// balance can fund at the current on-chain ticket price.
-    /// `byte_capacity` = `expected_messages × SESSION_MTU`.
-    /// `safe_balance` is the wxHOPR held in the Safe but not yet locked in
-    /// any channel — the strategy can spend it on new channel opens or top-ups.
+    /// `expected_messages` / `byte_capacity` on each channel: floor of
+    /// `channel.balance / ticket_price × SESSION_MTU`.
+    /// `safe_expected_messages` / `safe_byte_capacity`: same formula applied
+    /// to the wxHOPR sitting in the Safe but not yet locked into any channel —
+    /// representing the additional messages the strategy could route if it
+    /// opened new channels with those funds.
     pub async fn list_channel_capacities(
         &self,
     ) -> anyhow::Result<super::strategy::ChannelCapacityReport> {
@@ -299,13 +300,25 @@ impl Edgli {
             None => hopr_lib::api::types::primitive::prelude::HoprBalance::zero(),
         };
 
+        // Same floor-division formula used by compute_channel_capacity.
+        let safe_expected_messages = if ticket_price
+            == hopr_lib::api::types::primitive::prelude::HoprBalance::zero()
+        {
+            0u64
+        } else {
+            let q = safe_balance.amount() / ticket_price.amount();
+            q.min(u64::MAX.into()).low_u64()
+        };
+
         Ok(super::strategy::ChannelCapacityReport {
             channels: channels
                 .into_iter()
                 .filter(|c| c.status == ChannelStatus::Open)
                 .map(|c| super::strategy::compute_channel_capacity(&c, ticket_price))
                 .collect(),
-            safe_balance,
+            safe_expected_messages,
+            safe_byte_capacity: safe_expected_messages
+                .saturating_mul(hopr_lib::SESSION_MTU as u64),
         })
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,18 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use futures::future::{AbortHandle, abortable};
 use hopr_chain_connector::{BlockchainConnectorConfig, create_trustful_hopr_blokli_connector};
 use hopr_ct_full_network::ProberConfig as FullNetworkProberConfig;
-use hopr_lib::api::types::{crypto::prelude::OffchainPublicKey, primitive::prelude::Address};
+use hopr_lib::api::{
+    chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
+    node::{HasChainApi, IncentiveChannelOperations},
+    types::{
+        crypto::prelude::OffchainPublicKey,
+        internal::channels::ChannelStatus,
+        primitive::prelude::{Address, HoprBalance},
+    },
+};
 use hopr_lib::builder::{ChainKeypair, Keypair, OffchainKeypair};
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
 use hopr_reference::build_edge_with_chain;
@@ -229,13 +238,6 @@ impl Edgli {
         &self,
         cfg: &super::strategy::IncentiveConfiguration,
     ) -> anyhow::Result<super::strategy::BalanceRecommendation> {
-        use hopr_lib::api::{
-            chain::ChainValues as _,
-            node::{HasChainApi, IncentiveChannelOperations},
-            types::internal::channels::ChannelStatus,
-        };
-        use std::collections::HashSet;
-
         let chain = self.chain_api();
         let ticket_price = chain.minimum_ticket_price().await?;
         let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
@@ -272,14 +274,9 @@ impl Edgli {
     ) -> anyhow::Result<
         std::collections::HashMap<super::strategy::CapacityAllocator, super::strategy::Capacity>,
     > {
-        use hopr_lib::api::{
-            chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
-            node::{HasChainApi, IncentiveChannelOperations},
-            types::{internal::channels::ChannelStatus, primitive::prelude::HoprBalance},
-        };
-
         let chain = self.chain_api();
         let ticket_price = chain.minimum_ticket_price().await?;
+        let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
 
         let node_address = HasChainApi::identity(&*self.hopr).node_address;
         let channels = IncentiveChannelOperations::channels_from(&*self.hopr, node_address)
@@ -300,23 +297,20 @@ impl Edgli {
             None => HoprBalance::zero(),
         };
 
-        let mut map: std::collections::HashMap<
-            super::strategy::CapacityAllocator,
-            super::strategy::Capacity,
-        > = channels
+        let mut map = std::collections::HashMap::new();
+        for c in channels
             .into_iter()
             .filter(|c| c.status == ChannelStatus::Open)
-            .map(|c| {
-                (
-                    super::strategy::CapacityAllocator::Peer(c.destination),
-                    super::strategy::compute_capacity(c.balance, ticket_price),
-                )
-            })
-            .collect();
-
+        {
+            let capacity = super::strategy::compute_capacity(c.balance, ticket_price, win_prob)?;
+            map.insert(
+                super::strategy::CapacityAllocator::Peer(c.destination),
+                capacity,
+            );
+        }
         map.insert(
             super::strategy::CapacityAllocator::Safe,
-            super::strategy::compute_capacity(safe_balance, ticket_price),
+            super::strategy::compute_capacity(safe_balance, ticket_price, win_prob)?,
         );
 
         Ok(map)

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,22 +260,22 @@ impl Edgli {
         super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing)
     }
 
-    /// Lists all open outgoing channels with their data-throughput capacity,
-    /// plus the message capacity derivable from the unallocated Safe balance.
+    /// Returns a map of data-throughput capacities keyed by peer address (for
+    /// open outgoing channels) and `"safe"` (for the unallocated Safe balance).
     ///
-    /// `expected_messages` / `byte_capacity` on each channel: floor of
-    /// `channel.balance / ticket_price × SESSION_MTU`.
-    /// `safe_expected_messages` / `safe_byte_capacity`: same formula applied
-    /// to the wxHOPR sitting in the Safe but not yet locked into any channel —
-    /// representing the additional messages the strategy could route if it
-    /// opened new channels with those funds.
+    /// Each [`super::strategy::Capacity`] entry holds the wxHOPR stake, the
+    /// floor number of session frames it can fund at the current ticket price,
+    /// and the corresponding raw byte capacity (`expected_messages × SESSION_MTU`).
     pub async fn list_channel_capacities(
         &self,
-    ) -> anyhow::Result<super::strategy::ChannelCapacityReport> {
+    ) -> anyhow::Result<std::collections::HashMap<String, super::strategy::Capacity>> {
         use hopr_lib::api::{
             chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
             node::{HasChainApi, IncentiveChannelOperations},
-            types::internal::channels::ChannelStatus,
+            types::{
+                internal::channels::ChannelStatus,
+                primitive::prelude::HoprBalance,
+            },
         };
 
         let chain = self.chain_api();
@@ -297,29 +297,26 @@ impl Edgli {
                 .balance(safe.address)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?,
-            None => hopr_lib::api::types::primitive::prelude::HoprBalance::zero(),
+            None => HoprBalance::zero(),
         };
 
-        // Same floor-division formula used by compute_channel_capacity.
-        let safe_expected_messages = if ticket_price
-            == hopr_lib::api::types::primitive::prelude::HoprBalance::zero()
-        {
-            0u64
-        } else {
-            let q = safe_balance.amount() / ticket_price.amount();
-            q.min(u64::MAX.into()).low_u64()
-        };
+        let mut map: std::collections::HashMap<String, super::strategy::Capacity> = channels
+            .into_iter()
+            .filter(|c| c.status == ChannelStatus::Open)
+            .map(|c| {
+                (
+                    c.destination.to_string(),
+                    super::strategy::compute_capacity(c.balance, ticket_price),
+                )
+            })
+            .collect();
 
-        Ok(super::strategy::ChannelCapacityReport {
-            channels: channels
-                .into_iter()
-                .filter(|c| c.status == ChannelStatus::Open)
-                .map(|c| super::strategy::compute_channel_capacity(&c, ticket_price))
-                .collect(),
-            safe_expected_messages,
-            safe_byte_capacity: safe_expected_messages
-                .saturating_mul(hopr_lib::SESSION_MTU as u64),
-        })
+        map.insert(
+            "safe".to_string(),
+            super::strategy::compute_capacity(safe_balance, ticket_price),
+        );
+
+        Ok(map)
     }
 
     /// Run a node with HOPR edge strategies integrated.

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,16 +260,19 @@ impl Edgli {
         super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing)
     }
 
-    /// Lists all open outgoing channels with their data-throughput capacity.
+    /// Lists all open outgoing channels with their data-throughput capacity,
+    /// plus the unallocated wxHOPR balance in the user's Safe contract.
     ///
     /// `expected_messages` is the floor number of session frames the channel
     /// balance can fund at the current on-chain ticket price.
     /// `byte_capacity` = `expected_messages × SESSION_MTU`.
+    /// `safe_balance` is the wxHOPR held in the Safe but not yet locked in
+    /// any channel — the strategy can spend it on new channel opens or top-ups.
     pub async fn list_channel_capacities(
         &self,
-    ) -> anyhow::Result<Vec<super::strategy::ChannelCapacity>> {
+    ) -> anyhow::Result<super::strategy::ChannelCapacityReport> {
         use hopr_lib::api::{
-            chain::ChainValues as _,
+            chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
             node::{HasChainApi, IncentiveChannelOperations},
             types::internal::channels::ChannelStatus,
         };
@@ -277,16 +280,33 @@ impl Edgli {
         let chain = self.chain_api();
         let ticket_price = chain.minimum_ticket_price().await?;
 
-        let source = HasChainApi::identity(&*self.hopr).node_address;
-        let channels = IncentiveChannelOperations::channels_from(&*self.hopr, source)
+        let node_address = HasChainApi::identity(&*self.hopr).node_address;
+        let channels = IncentiveChannelOperations::channels_from(&*self.hopr, node_address)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        Ok(channels
-            .into_iter()
-            .filter(|c| c.status == ChannelStatus::Open)
-            .map(|c| super::strategy::compute_channel_capacity(&c, ticket_price))
-            .collect())
+        let safe_balance = match ChainReadSafeOperations::safe_info(
+            &chain,
+            SafeSelector::NodeAddress(node_address),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        {
+            Some(safe) => chain
+                .balance(safe.address)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
+            None => hopr_lib::api::types::primitive::prelude::HoprBalance::zero(),
+        };
+
+        Ok(super::strategy::ChannelCapacityReport {
+            channels: channels
+                .into_iter()
+                .filter(|c| c.status == ChannelStatus::Open)
+                .map(|c| super::strategy::compute_channel_capacity(&c, ticket_price))
+                .collect(),
+            safe_balance,
+        })
     }
 
     /// Run a node with HOPR edge strategies integrated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use hopr_lib::api::types::{
     primitive::prelude::{Balance, XDai},
 };
 
-pub use strategy::{BalanceRecommendation, Capacity};
+pub use strategy::{BalanceRecommendation, Capacity, CapacityKey};
 
 #[cfg(feature = "blokli")]
 pub use strategy::minimum_balance_recommendation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use hopr_lib::api::types::{
     primitive::prelude::{Balance, XDai},
 };
 
-pub use strategy::{BalanceRecommendation, ChannelCapacity, ChannelCapacityReport};
+pub use strategy::{BalanceRecommendation, Capacity};
 
 #[cfg(feature = "blokli")]
 pub use strategy::minimum_balance_recommendation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use hopr_lib::api::types::{
     primitive::prelude::{Balance, XDai},
 };
 
-pub use strategy::{BalanceRecommendation, Capacity, CapacityKey};
+pub use strategy::{BalanceRecommendation, Capacity, CapacityAllocator};
 
 #[cfg(feature = "blokli")]
 pub use strategy::minimum_balance_recommendation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,10 @@ pub use hopr_lib::api::types::{
     primitive::prelude::{Balance, XDai},
 };
 
+pub use strategy::{BalanceRecommendation, ChannelCapacity};
+
+#[cfg(feature = "blokli")]
+pub use strategy::minimum_balance_recommendation;
+
 #[cfg(feature = "telemetry")]
 pub use hopr_lib::collect_hopr_metrics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use hopr_lib::api::types::{
     primitive::prelude::{Balance, XDai},
 };
 
-pub use strategy::{BalanceRecommendation, ChannelCapacity};
+pub use strategy::{BalanceRecommendation, ChannelCapacity, ChannelCapacityReport};
 
 #[cfg(feature = "blokli")]
 pub use strategy::minimum_balance_recommendation;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,4 +1,7 @@
-use hopr_lib::api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps as _};
+use hopr_lib::api::types::{
+    internal::channels::ChannelEntry,
+    primitive::prelude::{Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance},
+};
 pub use hopr_strategy::channel_lifecycle::{
     ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
 };
@@ -103,6 +106,82 @@ pub fn compute_funding_config(
         min_safe_balance_required: initial,
         stop_when_unfunded: true,
     })
+}
+
+/// Minimum recommended wxHOPR and xDAI balance to open the target number of channels.
+#[derive(Clone, Copy, Debug)]
+pub struct BalanceRecommendation {
+    /// Minimum wxHOPR needed to stake the missing channels.
+    pub wxhopr: HoprBalance,
+    /// Minimum xDAI for gas (fixed at [`hopr_lib::SUGGESTED_NATIVE_BALANCE`]).
+    pub xdai: XDaiBalance,
+}
+
+/// Data-throughput capacity of a single open outgoing payment channel.
+#[derive(Clone, Copy, Debug)]
+pub struct ChannelCapacity {
+    /// On-chain address of the channel destination.
+    pub peer: Address,
+    /// Current wxHOPR stake locked in the channel.
+    pub stake: HoprBalance,
+    /// Floor number of session frames the balance can fund at the current ticket price.
+    pub expected_messages: u64,
+    /// Raw byte capacity: `expected_messages × SESSION_MTU`.
+    pub byte_capacity: u64,
+}
+
+/// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
+pub(crate) fn compute_balance_recommendation(
+    ticket_price: HoprBalance,
+    win_prob: f64,
+    cfg: &IncentiveConfiguration,
+    missing_channels: usize,
+) -> anyhow::Result<BalanceRecommendation> {
+    if missing_channels == 0 {
+        return Ok(BalanceRecommendation {
+            wxhopr: HoprBalance::zero(),
+            xdai: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
+        });
+    }
+    let stake_per_channel = compute_funding_config(ticket_price, win_prob, cfg)?.initial_balance;
+    let wxhopr = stake_per_channel * (missing_channels as u64);
+    Ok(BalanceRecommendation {
+        wxhopr,
+        xdai: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
+    })
+}
+
+/// Compute the data-throughput capacity of a single channel at the given ticket price.
+pub(crate) fn compute_channel_capacity(
+    channel: &ChannelEntry,
+    ticket_price: HoprBalance,
+) -> ChannelCapacity {
+    let expected_messages = if ticket_price == HoprBalance::zero() {
+        0u64
+    } else {
+        (channel.balance.amount() / ticket_price.amount()).low_u64()
+    };
+    ChannelCapacity {
+        peer: channel.destination,
+        stake: channel.balance,
+        expected_messages,
+        byte_capacity: expected_messages.saturating_mul(hopr_lib::SESSION_MTU as u64),
+    }
+}
+
+/// Returns the minimum recommended wxHOPR and xDAI for this node to open
+/// `cfg.target_open_channels` channels from scratch.
+///
+/// Queries ticket pricing from the safeless chain interactor so this can be
+/// called before the full node is started (e.g. during onboarding).
+#[cfg(feature = "blokli")]
+pub async fn minimum_balance_recommendation(
+    incentive_ops: &dyn crate::blokli::IncentiveOperations,
+    cfg: &IncentiveConfiguration,
+) -> anyhow::Result<BalanceRecommendation> {
+    let stats = incentive_ops.ticket_stats().await?;
+    let win_prob = stats.winning_probability.as_f64();
+    compute_balance_recommendation(stats.ticket_price, win_prob, cfg, cfg.target_open_channels)
 }
 
 /// Returns the default [`MultiStrategyConfig`] for an edge client reactor.
@@ -265,5 +344,99 @@ mod tests {
         let population = PopulationConfig::default();
         assert_eq!(sizing.min_open_channels, population.min_open_channels);
         assert_eq!(sizing.target_open_channels, population.target_open_channels);
+    }
+
+    #[test]
+    fn compute_balance_recommendation_zero_missing_returns_zero_wxhopr() {
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            &IncentiveConfiguration::default(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(rec.wxhopr, HoprBalance::zero());
+        assert_eq!(rec.xdai, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
+    }
+
+    #[test]
+    fn compute_balance_recommendation_scales_by_missing_channels() {
+        // win_prob=1.0, ticket_price=10, msg=1: stake = max(10, 10) = 10; 8 channels = 80
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            &IncentiveConfiguration {
+                desired_message_count: 1,
+                ..Default::default()
+            },
+            8,
+        )
+        .unwrap();
+        assert_eq!(rec.wxhopr, HoprBalance::new_base(10) * 8u64);
+        assert_eq!(rec.xdai, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
+    }
+
+    #[test]
+    fn compute_balance_recommendation_zero_target_yields_zero() {
+        let cfg = IncentiveConfiguration {
+            target_open_channels: 0,
+            min_open_channels: 0,
+            ..Default::default()
+        };
+        let rec = compute_balance_recommendation(HoprBalance::new_base(10), 1.0, &cfg, 0).unwrap();
+        assert_eq!(rec.wxhopr, HoprBalance::zero());
+    }
+
+    #[test]
+    fn compute_channel_capacity_basic_arithmetic() {
+        use hopr_lib::api::types::internal::channels::{ChannelEntry, ChannelStatus};
+        use hopr_lib::api::types::primitive::prelude::Address;
+
+        let peer: Address = Address::from([0x01u8; 20]);
+        let ch = ChannelEntry::builder()
+            .source(Address::default())
+            .destination(peer)
+            .balance(HoprBalance::new_base(1000))
+            .status(ChannelStatus::Open)
+            .build()
+            .unwrap();
+        let cap = compute_channel_capacity(&ch, HoprBalance::new_base(10));
+        assert_eq!(cap.expected_messages, 100);
+        assert_eq!(cap.byte_capacity, 100 * hopr_lib::SESSION_MTU as u64);
+        assert_eq!(cap.peer, peer);
+    }
+
+    #[test]
+    fn compute_channel_capacity_balance_below_ticket_price() {
+        use hopr_lib::api::types::internal::channels::{ChannelEntry, ChannelStatus};
+        use hopr_lib::api::types::primitive::prelude::Address;
+
+        let ch = ChannelEntry::builder()
+            .source(Address::from([0x01u8; 20]))
+            .destination(Address::from([0x02u8; 20]))
+            .balance(HoprBalance::new_base(5))
+            .status(ChannelStatus::Open)
+            .build()
+            .unwrap();
+        let cap = compute_channel_capacity(&ch, HoprBalance::new_base(10));
+        assert_eq!(cap.expected_messages, 0);
+        assert_eq!(cap.byte_capacity, 0);
+    }
+
+    #[test]
+    fn compute_channel_capacity_zero_ticket_price() {
+        use hopr_lib::api::types::internal::channels::{ChannelEntry, ChannelStatus};
+        use hopr_lib::api::types::primitive::prelude::Address;
+
+        let ch = ChannelEntry::builder()
+            .source(Address::from([0x01u8; 20]))
+            .destination(Address::from([0x02u8; 20]))
+            .balance(HoprBalance::new_base(100))
+            .status(ChannelStatus::Open)
+            .build()
+            .unwrap();
+        let cap = compute_channel_capacity(&ch, HoprBalance::zero());
+        assert_eq!(cap.expected_messages, 0);
+        assert_eq!(cap.byte_capacity, 0);
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -130,6 +130,17 @@ pub struct ChannelCapacity {
     pub byte_capacity: u64,
 }
 
+/// Full data-throughput capacity of this node.
+#[derive(Clone, Debug)]
+pub struct ChannelCapacityReport {
+    /// Per-channel capacities for all open outgoing channels.
+    pub channels: Vec<ChannelCapacity>,
+    /// Unallocated wxHOPR in the user's Safe contract — not yet locked in any
+    /// channel, available for the strategy to open new channels or top up
+    /// existing ones.
+    pub safe_balance: HoprBalance,
+}
+
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
 pub(crate) fn compute_balance_recommendation(
     ticket_price: HoprBalance,

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,7 +1,4 @@
-use hopr_lib::api::types::{
-    internal::channels::ChannelEntry,
-    primitive::prelude::{Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance},
-};
+use hopr_lib::api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps as _, XDaiBalance};
 pub use hopr_strategy::channel_lifecycle::{
     ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
 };
@@ -117,30 +114,19 @@ pub struct BalanceRecommendation {
     pub xdai: XDaiBalance,
 }
 
-/// Data-throughput capacity of a single open outgoing payment channel.
+/// Data-throughput capacity for a stake of wxHOPR at the current ticket price.
+///
+/// Used both for open outgoing channels (keyed by peer address) and for the
+/// unallocated Safe balance (keyed by `"safe"`) in the map returned by
+/// [`crate::client::Edgli::list_channel_capacities`].
 #[derive(Clone, Copy, Debug)]
-pub struct ChannelCapacity {
-    /// On-chain address of the channel destination.
-    pub peer: Address,
-    /// Current wxHOPR stake locked in the channel.
+pub struct Capacity {
+    /// wxHOPR stake — locked balance for channels, unallocated balance for the Safe.
     pub stake: HoprBalance,
-    /// Floor number of session frames the balance can fund at the current ticket price.
+    /// Floor number of session frames this stake can fund at the current ticket price.
     pub expected_messages: u64,
     /// Raw byte capacity: `expected_messages × SESSION_MTU`.
     pub byte_capacity: u64,
-}
-
-/// Full data-throughput capacity of this node.
-#[derive(Clone, Debug)]
-pub struct ChannelCapacityReport {
-    /// Per-channel capacities for all open outgoing channels.
-    pub channels: Vec<ChannelCapacity>,
-    /// Floor number of additional session frames the unallocated Safe balance
-    /// could fund at the current ticket price (i.e. how many more messages the
-    /// strategy could route if it opened new channels with the Safe funds).
-    pub safe_expected_messages: u64,
-    /// Raw byte capacity of the Safe funds: `safe_expected_messages × SESSION_MTU`.
-    pub safe_byte_capacity: u64,
 }
 
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
@@ -164,22 +150,18 @@ pub(crate) fn compute_balance_recommendation(
     })
 }
 
-/// Compute the data-throughput capacity of a single channel at the given ticket price.
-pub(crate) fn compute_channel_capacity(
-    channel: &ChannelEntry,
-    ticket_price: HoprBalance,
-) -> ChannelCapacity {
+/// Compute the data-throughput capacity for a given wxHOPR stake at the current ticket price.
+pub(crate) fn compute_capacity(stake: HoprBalance, ticket_price: HoprBalance) -> Capacity {
     let expected_messages = if ticket_price == HoprBalance::zero() {
         0u64
     } else {
         // Clamp to u64::MAX before converting so astronomically large quotients
         // saturate rather than truncate via low_u64().
-        let quotient = channel.balance.amount() / ticket_price.amount();
+        let quotient = stake.amount() / ticket_price.amount();
         quotient.min(u64::MAX.into()).low_u64()
     };
-    ChannelCapacity {
-        peer: channel.destination,
-        stake: channel.balance,
+    Capacity {
+        stake,
         expected_messages,
         byte_capacity: expected_messages.saturating_mul(hopr_lib::SESSION_MTU as u64),
     }
@@ -404,54 +386,23 @@ mod tests {
     }
 
     #[test]
-    fn compute_channel_capacity_basic_arithmetic() {
-        use hopr_lib::api::types::internal::channels::{ChannelEntry, ChannelStatus};
-        use hopr_lib::api::types::primitive::prelude::Address;
-
-        let peer: Address = Address::from([0x01u8; 20]);
-        let ch = ChannelEntry::builder()
-            .source(Address::default())
-            .destination(peer)
-            .balance(HoprBalance::new_base(1000))
-            .status(ChannelStatus::Open)
-            .build()
-            .unwrap();
-        let cap = compute_channel_capacity(&ch, HoprBalance::new_base(10));
+    fn compute_capacity_basic_arithmetic() {
+        let cap = compute_capacity(HoprBalance::new_base(1000), HoprBalance::new_base(10));
         assert_eq!(cap.expected_messages, 100);
         assert_eq!(cap.byte_capacity, 100 * hopr_lib::SESSION_MTU as u64);
-        assert_eq!(cap.peer, peer);
+        assert_eq!(cap.stake, HoprBalance::new_base(1000));
     }
 
     #[test]
-    fn compute_channel_capacity_balance_below_ticket_price() {
-        use hopr_lib::api::types::internal::channels::{ChannelEntry, ChannelStatus};
-        use hopr_lib::api::types::primitive::prelude::Address;
-
-        let ch = ChannelEntry::builder()
-            .source(Address::from([0x01u8; 20]))
-            .destination(Address::from([0x02u8; 20]))
-            .balance(HoprBalance::new_base(5))
-            .status(ChannelStatus::Open)
-            .build()
-            .unwrap();
-        let cap = compute_channel_capacity(&ch, HoprBalance::new_base(10));
+    fn compute_capacity_balance_below_ticket_price() {
+        let cap = compute_capacity(HoprBalance::new_base(5), HoprBalance::new_base(10));
         assert_eq!(cap.expected_messages, 0);
         assert_eq!(cap.byte_capacity, 0);
     }
 
     #[test]
-    fn compute_channel_capacity_zero_ticket_price() {
-        use hopr_lib::api::types::internal::channels::{ChannelEntry, ChannelStatus};
-        use hopr_lib::api::types::primitive::prelude::Address;
-
-        let ch = ChannelEntry::builder()
-            .source(Address::from([0x01u8; 20]))
-            .destination(Address::from([0x02u8; 20]))
-            .balance(HoprBalance::new_base(100))
-            .status(ChannelStatus::Open)
-            .build()
-            .unwrap();
-        let cap = compute_channel_capacity(&ch, HoprBalance::zero());
+    fn compute_capacity_zero_ticket_price() {
+        let cap = compute_capacity(HoprBalance::new_base(100), HoprBalance::zero());
         assert_eq!(cap.expected_messages, 0);
         assert_eq!(cap.byte_capacity, 0);
     }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -121,7 +121,7 @@ pub struct BalanceRecommendation {
 /// Key for the map returned by
 /// [`crate::client::Edgli::describe_current_capacity_allocations`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum CapacityKey {
+pub enum CapacityAllocator {
     /// An open outgoing payment channel to the given peer.
     Peer(Address),
     /// The unallocated wxHOPR balance held in the user's Safe contract.

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -135,10 +135,12 @@ pub struct ChannelCapacity {
 pub struct ChannelCapacityReport {
     /// Per-channel capacities for all open outgoing channels.
     pub channels: Vec<ChannelCapacity>,
-    /// Unallocated wxHOPR in the user's Safe contract — not yet locked in any
-    /// channel, available for the strategy to open new channels or top up
-    /// existing ones.
-    pub safe_balance: HoprBalance,
+    /// Floor number of additional session frames the unallocated Safe balance
+    /// could fund at the current ticket price (i.e. how many more messages the
+    /// strategy could route if it opened new channels with the Safe funds).
+    pub safe_expected_messages: u64,
+    /// Raw byte capacity of the Safe funds: `safe_expected_messages × SESSION_MTU`.
+    pub safe_byte_capacity: u64,
 }
 
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,4 +1,6 @@
-use hopr_lib::api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps as _, XDaiBalance};
+use hopr_lib::api::types::primitive::prelude::{
+    Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
+};
 pub use hopr_strategy::channel_lifecycle::{
     ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
 };
@@ -116,9 +118,17 @@ pub struct BalanceRecommendation {
 
 /// Data-throughput capacity for a stake of wxHOPR at the current ticket price.
 ///
-/// Used both for open outgoing channels (keyed by peer address) and for the
-/// unallocated Safe balance (keyed by `"safe"`) in the map returned by
-/// [`crate::client::Edgli::list_channel_capacities`].
+/// Key for the map returned by
+/// [`crate::client::Edgli::describe_current_capacity_allocations`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CapacityKey {
+    /// An open outgoing payment channel to the given peer.
+    Peer(Address),
+    /// The unallocated wxHOPR balance held in the user's Safe contract.
+    Safe,
+}
+
+/// Data-throughput capacity for a wxHOPR stake at the current ticket price.
 #[derive(Clone, Copy, Debug)]
 pub struct Capacity {
     /// wxHOPR stake — locked balance for channels, unallocated balance for the Safe.

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -159,7 +159,10 @@ pub(crate) fn compute_channel_capacity(
     let expected_messages = if ticket_price == HoprBalance::zero() {
         0u64
     } else {
-        (channel.balance.amount() / ticket_price.amount()).low_u64()
+        // Clamp to u64::MAX before converting so astronomically large quotients
+        // saturate rather than truncate via low_u64().
+        let quotient = channel.balance.amount() / ticket_price.amount();
+        quotient.min(u64::MAX.into()).low_u64()
     };
     ChannelCapacity {
         peer: channel.destination,

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -133,8 +133,17 @@ pub enum CapacityAllocator {
 pub struct Capacity {
     /// wxHOPR stake — locked balance for channels, unallocated balance for the Safe.
     pub stake: HoprBalance,
-    /// Floor number of session frames this stake can fund at the current ticket price.
+    /// Expected long-run session-frame count: `floor(stake / ticket_price)`.
+    ///
+    /// `ticket_price` is the *expected* per-hop drain (= `face_value × win_prob`),
+    /// so this figure is win_prob-independent — it reflects average lifetime throughput.
     pub expected_messages: u64,
+    /// Worst-case floor: `floor(stake / face_value)` = `floor(stake × win_prob / ticket_price)`.
+    ///
+    /// Reflects the maximum number of tickets the channel can hold simultaneously
+    /// before balance drops below one face value and ticket minting halts.
+    /// Lower win_prob → smaller face value → fewer guaranteed concurrent tickets.
+    pub min_guaranteed_messages: u64,
     /// Raw byte capacity: `expected_messages × SESSION_MTU`.
     pub byte_capacity: u64,
 }
@@ -161,7 +170,17 @@ pub(crate) fn compute_balance_recommendation(
 }
 
 /// Compute the data-throughput capacity for a given wxHOPR stake at the current ticket price.
-pub(crate) fn compute_capacity(stake: HoprBalance, ticket_price: HoprBalance) -> Capacity {
+///
+/// `win_prob` must be in `(0, 1]`; the same validation guard as [`compute_funding_config`] applies.
+pub(crate) fn compute_capacity(
+    stake: HoprBalance,
+    ticket_price: HoprBalance,
+    win_prob: f64,
+) -> anyhow::Result<Capacity> {
+    anyhow::ensure!(
+        win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
+        "win_prob must be in (0, 1]; got {win_prob}"
+    );
     let expected_messages = if ticket_price == HoprBalance::zero() {
         0u64
     } else {
@@ -170,11 +189,20 @@ pub(crate) fn compute_capacity(stake: HoprBalance, ticket_price: HoprBalance) ->
         let quotient = stake.amount() / ticket_price.amount();
         quotient.min(u64::MAX.into()).low_u64()
     };
-    Capacity {
+    // face_value = ticket_price / win_prob — minimum balance locked per outstanding ticket.
+    let face_value = ticket_price.div_f64(win_prob)?;
+    let min_guaranteed_messages = if face_value == HoprBalance::zero() {
+        0u64
+    } else {
+        let quotient = stake.amount() / face_value.amount();
+        quotient.min(u64::MAX.into()).low_u64()
+    };
+    Ok(Capacity {
         stake,
         expected_messages,
+        min_guaranteed_messages,
         byte_capacity: expected_messages.saturating_mul(hopr_lib::SESSION_MTU as u64),
-    }
+    })
 }
 
 /// Returns the minimum recommended wxHOPR and xDAI for this node to open
@@ -397,23 +425,68 @@ mod tests {
 
     #[test]
     fn compute_capacity_basic_arithmetic() {
-        let cap = compute_capacity(HoprBalance::new_base(1000), HoprBalance::new_base(10));
+        let cap =
+            compute_capacity(HoprBalance::new_base(1000), HoprBalance::new_base(10), 1.0).unwrap();
         assert_eq!(cap.expected_messages, 100);
+        assert_eq!(cap.min_guaranteed_messages, 100);
         assert_eq!(cap.byte_capacity, 100 * hopr_lib::SESSION_MTU as u64);
         assert_eq!(cap.stake, HoprBalance::new_base(1000));
     }
 
     #[test]
     fn compute_capacity_balance_below_ticket_price() {
-        let cap = compute_capacity(HoprBalance::new_base(5), HoprBalance::new_base(10));
+        let cap =
+            compute_capacity(HoprBalance::new_base(5), HoprBalance::new_base(10), 1.0).unwrap();
         assert_eq!(cap.expected_messages, 0);
+        assert_eq!(cap.min_guaranteed_messages, 0);
         assert_eq!(cap.byte_capacity, 0);
     }
 
     #[test]
     fn compute_capacity_zero_ticket_price() {
-        let cap = compute_capacity(HoprBalance::new_base(100), HoprBalance::zero());
+        let cap = compute_capacity(HoprBalance::new_base(100), HoprBalance::zero(), 1.0).unwrap();
         assert_eq!(cap.expected_messages, 0);
+        assert_eq!(cap.min_guaranteed_messages, 0);
         assert_eq!(cap.byte_capacity, 0);
+    }
+
+    #[test]
+    fn compute_capacity_win_prob_one_matches_expected() {
+        // win_prob=1.0 → face_value = ticket_price → min_guaranteed == expected
+        let cap =
+            compute_capacity(HoprBalance::new_base(300), HoprBalance::new_base(10), 1.0).unwrap();
+        assert_eq!(cap.expected_messages, 30);
+        assert_eq!(cap.min_guaranteed_messages, 30);
+    }
+
+    #[test]
+    fn compute_capacity_win_prob_half_halves_guaranteed() {
+        // stake=100, ticket_price=10, win_prob=0.5
+        // expected  = 100/10 = 10
+        // face_value = 10/0.5 = 20 → min_guaranteed = 100/20 = 5
+        let cap =
+            compute_capacity(HoprBalance::new_base(100), HoprBalance::new_base(10), 0.5).unwrap();
+        assert_eq!(cap.expected_messages, 10);
+        assert_eq!(cap.min_guaranteed_messages, 5);
+    }
+
+    #[test]
+    fn compute_capacity_win_prob_small_floors_guaranteed_to_zero() {
+        // stake=10, ticket_price=10, win_prob=0.5
+        // face_value = 10/0.5 = 20 > stake → min_guaranteed = 0; expected = 1
+        let cap =
+            compute_capacity(HoprBalance::new_base(10), HoprBalance::new_base(10), 0.5).unwrap();
+        assert_eq!(cap.expected_messages, 1);
+        assert_eq!(cap.min_guaranteed_messages, 0);
+    }
+
+    #[test]
+    fn compute_capacity_rejects_invalid_win_prob() {
+        let stake = HoprBalance::new_base(100);
+        let price = HoprBalance::new_base(10);
+        assert!(compute_capacity(stake, price, 0.0).is_err());
+        assert!(compute_capacity(stake, price, 1.1).is_err());
+        assert!(compute_capacity(stake, price, f64::NAN).is_err());
+        assert!(compute_capacity(stake, price, f64::INFINITY).is_err());
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -23,7 +23,7 @@ use edgli::{
         },
         config::{HoprLibConfig, HostConfig, HostType, SafeModule},
         exports::transport::SessionCapability,
-        exports::transport::{HoprSession, SessionTarget},
+        exports::transport::{HoprSession, SessionTarget, SurbBalancerConfig},
     },
     strategy::{EdgeStrategyKind, EligibilityConfig, IncentiveConfiguration, default_strategy_cfg},
     traits::EdgeNodeApi,
@@ -1167,6 +1167,16 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
                 forward_path: HopRouting::try_from(0_usize)?,
                 return_path: HopRouting::try_from(0_usize)?,
                 capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                // Keep the SURB pre-fill burst below the per-peer send-channel capacity
+                // (1000 slots). The default target of 7000 SURBs saturates the channel,
+                // causing session data to time out and be dropped silently with no
+                // reconnect (hoprnet eb21c1354c removed cache invalidation on timeout).
+                // 600 SURBs fit in one burst; the balancer replenishes as they are consumed.
+                surb_management: Some(SurbBalancerConfig {
+                    target_surb_buffer_size: 600,
+                    max_surbs_per_sec: 300,
+                    ..SurbBalancerConfig::default()
+                }),
                 ..Default::default()
             },
         )
@@ -1183,6 +1193,11 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
                 forward_path: HopRouting::try_from(1_usize)?,
                 return_path: HopRouting::try_from(1_usize)?,
                 capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: Some(SurbBalancerConfig {
+                    target_surb_buffer_size: 600,
+                    max_surbs_per_sec: 300,
+                    ..SurbBalancerConfig::default()
+                }),
                 ..Default::default()
             },
         )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -847,33 +847,40 @@ pub async fn await_edgli_channels_open(
     .await
 }
 
-/// Wait until `target` is physically connected and has a probe quality score >= `min_quality`.
+/// Wait until `target` is physically connected and has received at least one probe response.
 ///
-/// Uses `all_network_peers(min_quality)` which returns only connected peers that have
-/// been probed at least once and whose quality score meets the threshold.
+/// Resolves the chain address to an offchain key upfront (forward lookup, always available
+/// for on-chain registered nodes), then polls `all_network_peers(0.0)` which returns
+/// connected peers that have any probe observation — i.e. probed at least once regardless
+/// of quality score.
 async fn await_edgli_exit_peer_ready(
     edgli: &Edgli,
     target: Address,
-    min_quality: f64,
 ) -> anyhow::Result<()> {
+    // Forward lookup: chain address → offchain key. This uses the on-chain registry
+    // and succeeds as soon as the chain connector has indexed the peer's account
+    // (always true for announced Rotsee nodes by the time channels are open).
+    let offchain_key = edgli
+        .chain_api()
+        .chain_key_to_packet_key(&target)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .ok_or_else(|| anyhow::anyhow!("exit peer {target} has no offchain key — not registered on chain"))?;
+
     poll_edgli_until(
         EXIT_PEER_PROBE_TIMEOUT,
         Duration::from_secs(5),
-        || format!("timeout ({EXIT_PEER_PROBE_TIMEOUT:?}) waiting for exit peer {target} to be connected and probed (quality >= {min_quality})"),
+        || format!("timeout ({EXIT_PEER_PROBE_TIMEOUT:?}) waiting for exit peer {target} to be connected and probed"),
         || async {
+            // quality floor 0.0 = connected AND has any probe observation
             let peers = edgli
                 .transport()
-                .all_network_peers(min_quality)
+                .all_network_peers(0.0)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            for (key, _) in &peers {
-                if let Ok(Some(addr)) = edgli.chain_api().packet_key_to_chain_key(key) {
-                    if addr == target {
-                        tracing::info!(%target, "exit peer connected and probed");
-                        return Ok(true);
-                    }
-                }
+            if peers.iter().any(|(k, _)| k == &offchain_key) {
+                tracing::info!(%target, "exit peer connected and probed");
+                return Ok(true);
             }
             tracing::debug!(%target, qualified_peers = peers.len(), "exit peer not yet connected/probed");
             Ok(false)
@@ -1120,7 +1127,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     // and fail with "no route to host" on Rotsee.
     if let Some(exit) = tuning.exit_node {
         tracing::info!(%exit, "waiting for exit peer to be physically connected and probed");
-        await_edgli_exit_peer_ready(&edgli, exit, tuning.min_peer_quality).await?;
+        await_edgli_exit_peer_ready(&edgli, exit).await?;
     }
 
     // ── 8. Select session targets ─────────────────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -104,14 +104,10 @@ pub struct EdgliTuning {
     /// dynamically discovered channel peer.  Required for Rotsee, where relay
     /// nodes do not run the exit-node service.
     pub exit_node: Option<Address>,
-    /// Timeout for each `pump_and_verify` call (first and second session).
+    /// Timeout for each `pump_and_verify` call (0-hop and 1-hop separately).
     /// Rotsee needs more headroom: real-network latency + possible rate-limiter
     /// ramp-up on the exit node's loopback path.
     pub pump_timeout: Duration,
-    /// Hop count for the first session (forward and return path).
-    /// Use 0 for a local cluster (direct delivery); use 1 for real networks
-    /// like Rotsee where 0-hop direct HOPR packet delivery is unreliable.
-    pub session_a_hops: usize,
 }
 
 impl EdgliTuning {
@@ -131,7 +127,6 @@ impl EdgliTuning {
             channel_open_timeout: Duration::from_secs(120),
             exit_node: None,
             pump_timeout: Duration::from_secs(120),
-            session_a_hops: 0,
         }
     }
 
@@ -153,9 +148,6 @@ impl EdgliTuning {
             // Real-network loopback: allow for rate-limiter ramp-up and latency
             // variation on the echo path.
             pump_timeout: Duration::from_secs(300),
-            // 0-hop direct HOPR packet delivery is unreliable on real networks
-            // (NAT/routing issues); use 1-hop for the first session on Rotsee.
-            session_a_hops: 1,
         }
     }
 }
@@ -1162,47 +1154,41 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     let mut payload = vec![0u8; PAYLOAD_SIZE];
     rand::thread_rng().fill_bytes(&mut payload);
 
-    // ── 10. First session ────────────────────────────────────────────────────
+    // ── 10. 0-hop session — direct path, no relay ────────────────────────────
     // NoRateControl disables the exit node's egress rate limiter (default: 10
     // pkt/s initial rate).  Without it, returning 1 MiB (~1030 packets) at
     // 10 pkt/s takes ~103 s, nearly exhausting the pump timeout before the
     // rate-adaptive controller has time to ramp up.
-    // On real networks (Rotsee), session_a_hops=1 to avoid 0-hop direct HOPR
-    // packet delivery issues (unreliable through NAT on real networks).
-    let hops_a = tuning.session_a_hops;
-    let label_a = format!("{hops_a}-hop");
-    tracing::info!(hops = hops_a, "opening first session (loopback)");
-    let (session_a, _) = edgli
+    tracing::info!("opening 0-hop session (loopback)");
+    let (session_0h, _) = edgli
         .connect_to(
             dest_0h,
             loopback_target(),
             HoprSessionClientConfig {
-                forward_path: HopRouting::try_from(hops_a)?,
-                return_path: HopRouting::try_from(hops_a)?,
+                forward_path: HopRouting::try_from(0_usize)?,
+                return_path: HopRouting::try_from(0_usize)?,
                 capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
                 ..Default::default()
             },
         )
         .await?;
-    pump_and_verify(session_a, &payload, &label_a, tuning.pump_timeout).await?;
+    pump_and_verify(session_0h, &payload, "0-hop", tuning.pump_timeout).await?;
 
-    // ── 11. Second session — one more relay hop ───────────────────────────────
-    let hops_b = hops_a + 1;
-    let label_b = format!("{hops_b}-hop");
-    tracing::info!(hops = hops_b, "opening second session (loopback)");
-    let (session_b, _) = edgli
+    // ── 11. 1-hop session — full relay path ──────────────────────────────────
+    tracing::info!("opening 1-hop session (loopback)");
+    let (session_1h, _) = edgli
         .connect_to(
             dest_1h,
             loopback_target(),
             HoprSessionClientConfig {
-                forward_path: HopRouting::try_from(hops_b)?,
-                return_path: HopRouting::try_from(hops_b)?,
+                forward_path: HopRouting::try_from(1_usize)?,
+                return_path: HopRouting::try_from(1_usize)?,
                 capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
                 ..Default::default()
             },
         )
         .await?;
-    pump_and_verify(session_b, &payload, &label_b, tuning.pump_timeout).await?;
+    pump_and_verify(session_1h, &payload, "1-hop", tuning.pump_timeout).await?;
 
     // ── 12. Final state assertion ─────────────────────────────────────────────
     let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,7 +14,8 @@ use edgli::{
     hopr_lib::{
         HopRouting, HoprKeys, HoprSessionClientConfig, IdentityRetrievalModes,
         api::{
-            node::HoprSessionClientOperations,
+            chain::ChainKeyOperations as _,
+            node::{HasChainApi as _, HasTransportApi as _, HoprSessionClientOperations},
             types::{
                 internal::channels::{ChannelEntry, ChannelStatus},
                 primitive::prelude::Address,
@@ -60,6 +61,7 @@ const PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 const INTRACLUSTER_CHANNEL_TIMEOUT: Duration = Duration::from_secs(120);
 const EDGLI_PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 const CHANNEL_OPEN_TIMEOUT: Duration = Duration::from_secs(120);
+const EXIT_PEER_PROBE_TIMEOUT: Duration = Duration::from_secs(120);
 pub const PUMP_TIMEOUT: Duration = Duration::from_secs(120);
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -845,6 +847,41 @@ pub async fn await_edgli_channels_open(
     .await
 }
 
+/// Wait until `target` is physically connected and has a probe quality score >= `min_quality`.
+///
+/// Uses `all_network_peers(min_quality)` which returns only connected peers that have
+/// been probed at least once and whose quality score meets the threshold.
+async fn await_edgli_exit_peer_ready(
+    edgli: &Edgli,
+    target: Address,
+    min_quality: f64,
+) -> anyhow::Result<()> {
+    poll_edgli_until(
+        EXIT_PEER_PROBE_TIMEOUT,
+        Duration::from_secs(5),
+        || format!("timeout ({EXIT_PEER_PROBE_TIMEOUT:?}) waiting for exit peer {target} to be connected and probed (quality >= {min_quality})"),
+        || async {
+            let peers = edgli
+                .transport()
+                .all_network_peers(min_quality)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            for (key, _) in &peers {
+                if let Ok(Some(addr)) = edgli.chain_api().packet_key_to_chain_key(key) {
+                    if addr == target {
+                        tracing::info!(%target, "exit peer connected and probed");
+                        return Ok(true);
+                    }
+                }
+            }
+            tracing::debug!(%target, qualified_peers = peers.len(), "exit peer not yet connected/probed");
+            Ok(false)
+        },
+    )
+    .await
+}
+
 /// Select session destinations that work for both 0-hop and 1-hop.
 ///
 /// 0-hop target: the first open outgoing channel counterparty (Edgli has a
@@ -1076,7 +1113,17 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     tracing::info!("waiting for strategy to open ≥1 outgoing channel");
     await_edgli_channels_open(&edgli, 1, tuning.channel_open_timeout).await?;
 
-    // ── 7. Select session targets ─────────────────────────────────────────────
+    // ── 7. Wait for exit peer to be connected and probed (when pinned) ───────
+    // `all_network_peers` returns only connected peers with an observed quality
+    // score above the threshold — i.e. at least one successful probe response.
+    // Without this gate the session open can race against the probe subsystem
+    // and fail with "no route to host" on Rotsee.
+    if let Some(exit) = tuning.exit_node {
+        tracing::info!(%exit, "waiting for exit peer to be physically connected and probed");
+        await_edgli_exit_peer_ready(&edgli, exit, tuning.min_peer_quality).await?;
+    }
+
+    // ── 8. Select session targets ─────────────────────────────────────────────
     let (dest_0h, dest_1h) = if let Some(exit) = tuning.exit_node {
         tracing::info!(%exit, "using configured exit node for both 0-hop and 1-hop sessions");
         (exit, exit)
@@ -1084,7 +1131,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         select_session_targets(&edgli).await?
     };
 
-    // ── 8. Prepare 1 MiB random payload ─────────────────────────────────────
+    // ── 9. Prepare 1 MiB random payload ─────────────────────────────────────
     // Random bytes produce unique HOPR packet ciphertexts on every test run,
     // preventing false replay-detection hits in cluster nodes' in-memory
     // packet-tag caches (which persist across Edgli reconnections to the same
@@ -1092,7 +1139,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     let mut payload = vec![0u8; PAYLOAD_SIZE];
     rand::thread_rng().fill_bytes(&mut payload);
 
-    // ── 9. 0-hop session — direct path, no relay ─────────────────────────────
+    // ── 10. 0-hop session — direct path, no relay ────────────────────────────
     // NoRateControl disables the exit node's egress rate limiter (default: 10
     // pkt/s initial rate).  Without it, returning 1 MiB (~1030 packets) at
     // 10 pkt/s takes ~103 s, nearly exhausting the 120 s PUMP_TIMEOUT before
@@ -1112,7 +1159,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         .await?;
     pump_and_verify(session_0h, &payload, "0-hop").await?;
 
-    // ── 10. 1-hop session — full relay path ──────────────────────────────────
+    // ── 11. 1-hop session — full relay path ──────────────────────────────────
     tracing::info!("opening 1-hop session (loopback)");
     let (session_1h, _) = edgli
         .connect_to(
@@ -1128,7 +1175,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         .await?;
     pump_and_verify(session_1h, &payload, "1-hop").await?;
 
-    // ── 11. Final state assertion ─────────────────────────────────────────────
+    // ── 12. Final state assertion ─────────────────────────────────────────────
     let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
     let open_count = channels
         .iter()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -359,11 +359,22 @@ pub async fn provision(
         Network::Local => {
             let handle = provision_local().await?;
             let summary = handle.summary.clone();
-            Ok((summary, NetworkGuard::Local(Box::new(handle)), EdgliTuning::local()))
+            Ok((
+                summary,
+                NetworkGuard::Local(Box::new(handle)),
+                EdgliTuning::local(),
+            ))
         }
         Network::Rotsee => {
             let (summary, guard, exit_node) = provision_rotsee()?;
-            Ok((summary, guard, EdgliTuning { exit_node, ..EdgliTuning::rotsee() }))
+            Ok((
+                summary,
+                guard,
+                EdgliTuning {
+                    exit_node,
+                    ..EdgliTuning::rotsee()
+                },
+            ))
         }
     }
 }
@@ -807,15 +818,27 @@ pub async fn await_edgli_channels_open(
     poll_edgli_until(
         timeout,
         Duration::from_secs(5),
-        || format!("timeout ({timeout:?}) waiting for Edgli strategy to open {min_open} channel(s)"),
+        || {
+            format!(
+                "timeout ({timeout:?}) waiting for Edgli strategy to open {min_open} channel(s)"
+            )
+        },
         || async {
             let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
-            let open = channels.iter().filter(|ch| ch.status == ChannelStatus::Open).count();
+            let open = channels
+                .iter()
+                .filter(|ch| ch.status == ChannelStatus::Open)
+                .count();
             if open >= min_open {
-                tracing::info!(open_channels = open, "Edgli outgoing channels confirmed Open");
+                tracing::info!(
+                    open_channels = open,
+                    "Edgli outgoing channels confirmed Open"
+                );
                 return Ok(true);
             }
-            tracing::debug!("Edgli: {open}/{min_open} outgoing channels Open (waiting for strategy)");
+            tracing::debug!(
+                "Edgli: {open}/{min_open} outgoing channels Open (waiting for strategy)"
+            );
             Ok(false)
         },
     )
@@ -831,8 +854,10 @@ pub async fn await_edgli_channels_open(
 /// (the 0-hop target acts as the relay, with its intranetwork channels
 /// carrying the forward path).
 async fn select_session_targets(edgli: &Edgli) -> anyhow::Result<(Address, Address)> {
-    let (raw_channels, peers) =
-        tokio::try_join!(edgli.my_outgoing_channels(), edgli.connected_peer_addresses())?;
+    let (raw_channels, peers) = tokio::try_join!(
+        edgli.my_outgoing_channels(),
+        edgli.connected_peer_addresses()
+    )?;
     let channels: Vec<ChannelEntry> = raw_channels
         .into_iter()
         .filter(|c| c.status == ChannelStatus::Open)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,6 +108,15 @@ pub struct EdgliTuning {
     /// Rotsee needs more headroom: real-network latency + possible rate-limiter
     /// ramp-up on the exit node's loopback path.
     pub pump_timeout: Duration,
+    /// Minimum ack rate required for relay edges to be eligible for path
+    /// selection. On a local cluster neighbour probes succeed, so the default
+    /// 0.1 is fine. On Rotsee the edge client runs behind NAT: neighbor probes
+    /// use a 0-hop return path, which requires relays to dial the client
+    /// directly — impossible behind NAT. All relay probes therefore timeout
+    /// and ack_rate stays 0, blocking 1-hop path selection entirely. Setting
+    /// 0.0 falls back to pure channel-topology routing (channels exist in the
+    /// graph from SSE events) without requiring any probe success.
+    pub min_ack_rate: f64,
 }
 
 impl EdgliTuning {
@@ -127,6 +136,7 @@ impl EdgliTuning {
             channel_open_timeout: Duration::from_secs(120),
             exit_node: None,
             pump_timeout: Duration::from_secs(120),
+            min_ack_rate: 0.1, // local cluster probes succeed — use default quality gate
         }
     }
 
@@ -148,6 +158,13 @@ impl EdgliTuning {
             // Real-network loopback: allow for rate-limiter ramp-up and latency
             // variation on the echo path.
             pump_timeout: Duration::from_secs(300),
+            // Rotsee: client runs behind NAT. Neighbour probes use a 0-hop
+            // return path (relay dials client directly), which fails behind NAT.
+            // All relay probe acks timeout → ack_rate stays 0 → min_ack_rate=0.1
+            // blocks all 1-hop path selection. Setting 0.0 allows the path
+            // selector to route through existing payment channels (populated via
+            // SSE events) without requiring any probe history.
+            min_ack_rate: 0.0,
         }
     }
 }
@@ -941,6 +958,7 @@ pub fn loopback_target() -> SessionTarget {
 
 pub fn build_edgli_config(extra: &ExtraInfo, tuning: &EdgliTuning) -> HoprLibConfig {
     use edgli::hopr_lib::config::{HoprProtocolConfig, TransportConfig};
+    use edgli::hopr_lib::exports::transport::path::PathPlannerConfig;
     HoprLibConfig {
         host: HostConfig {
             address: HostType::IPv4("0.0.0.0".to_string()),
@@ -951,6 +969,10 @@ pub fn build_edgli_config(extra: &ExtraInfo, tuning: &EdgliTuning) -> HoprLibCon
             transport: TransportConfig {
                 announce_local_addresses: tuning.announce_local,
                 prefer_local_addresses: tuning.prefer_local_addresses,
+            },
+            path_planner: PathPlannerConfig {
+                min_ack_rate: tuning.min_ack_rate,
+                ..Default::default()
             },
             ..Default::default()
         },

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -860,10 +860,7 @@ pub async fn await_edgli_channels_open(
 /// for on-chain registered nodes), then polls `all_network_peers(0.0)` which returns
 /// connected peers that have any probe observation — i.e. probed at least once regardless
 /// of quality score.
-async fn await_edgli_exit_peer_ready(
-    edgli: &Edgli,
-    target: Address,
-) -> anyhow::Result<()> {
+async fn await_edgli_exit_peer_ready(edgli: &Edgli, target: Address) -> anyhow::Result<()> {
     // Forward lookup: chain address → offchain key. This uses the on-chain registry
     // and succeeds as soon as the chain connector has indexed the peer's account
     // (always true for announced Rotsee nodes by the time channels are open).
@@ -871,7 +868,9 @@ async fn await_edgli_exit_peer_ready(
         .chain_api()
         .chain_key_to_packet_key(&target)
         .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| anyhow::anyhow!("exit peer {target} has no offchain key — not registered on chain"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("exit peer {target} has no offchain key — not registered on chain")
+        })?;
 
     poll_edgli_until(
         EXIT_PEER_PROBE_TIMEOUT,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -62,7 +62,6 @@ const INTRACLUSTER_CHANNEL_TIMEOUT: Duration = Duration::from_secs(120);
 const EDGLI_PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 const CHANNEL_OPEN_TIMEOUT: Duration = Duration::from_secs(120);
 const EXIT_PEER_PROBE_TIMEOUT: Duration = Duration::from_secs(120);
-pub const PUMP_TIMEOUT: Duration = Duration::from_secs(120);
 
 // ────────────────────────────────────────────────────────────────────────────
 // Network selector
@@ -100,11 +99,19 @@ pub struct EdgliTuning {
     /// How long to wait for the strategy to open at least one outgoing channel.
     /// Rotsee needs more headroom: 60 s tick + Gnosis Chain confirmation latency.
     pub channel_open_timeout: Duration,
-    /// Fixed exit-node address for session targets.  When set, both the 0-hop
-    /// and 1-hop sessions are directed to this node instead of a dynamically
-    /// discovered channel peer.  Required for Rotsee, where relay nodes do not
-    /// run the exit-node service.
+    /// Fixed exit-node address for session targets.  When set, both the
+    /// first and second sessions are directed to this node instead of a
+    /// dynamically discovered channel peer.  Required for Rotsee, where relay
+    /// nodes do not run the exit-node service.
     pub exit_node: Option<Address>,
+    /// Timeout for each `pump_and_verify` call (first and second session).
+    /// Rotsee needs more headroom: real-network latency + possible rate-limiter
+    /// ramp-up on the exit node's loopback path.
+    pub pump_timeout: Duration,
+    /// Hop count for the first session (forward and return path).
+    /// Use 0 for a local cluster (direct delivery); use 1 for real networks
+    /// like Rotsee where 0-hop direct HOPR packet delivery is unreliable.
+    pub session_a_hops: usize,
 }
 
 impl EdgliTuning {
@@ -123,6 +130,8 @@ impl EdgliTuning {
             require_observed: false,
             channel_open_timeout: Duration::from_secs(120),
             exit_node: None,
+            pump_timeout: Duration::from_secs(120),
+            session_a_hops: 0,
         }
     }
 
@@ -141,6 +150,12 @@ impl EdgliTuning {
             // Allow several ticks before giving up.
             channel_open_timeout: Duration::from_secs(300),
             exit_node: None, // filled in by provision_rotsee from EDGLI_ROTSEE_EXIT_NODE
+            // Real-network loopback: allow for rate-limiter ramp-up and latency
+            // variation on the echo path.
+            pump_timeout: Duration::from_secs(300),
+            // 0-hop direct HOPR packet delivery is unreliable on real networks
+            // (NAT/routing issues); use 1-hop for the first session on Rotsee.
+            session_a_hops: 1,
         }
     }
 }
@@ -984,6 +999,7 @@ pub async fn pump_and_verify(
     session: HoprSession,
     payload: &[u8],
     label: &str,
+    timeout: Duration,
 ) -> anyhow::Result<()> {
     let (mut r, mut w) = tokio::io::split(session);
     let payload_bytes = payload.to_vec();
@@ -1005,9 +1021,9 @@ pub async fn pump_and_verify(
     });
 
     let mut received = vec![0u8; n];
-    if let Err(err) = tokio::time::timeout(PUMP_TIMEOUT, r.read_exact(&mut received))
+    if let Err(err) = tokio::time::timeout(timeout, r.read_exact(&mut received))
         .await
-        .map_err(|_| anyhow::anyhow!("{label}: read timeout ({PUMP_TIMEOUT:?}) after {n} B"))
+        .map_err(|_| anyhow::anyhow!("{label}: read timeout ({timeout:?}) after {n} B"))
         .and_then(|r| r.map_err(|e| anyhow::anyhow!("{label}: read error: {e}")))
     {
         writer.abort();
@@ -1015,9 +1031,9 @@ pub async fn pump_and_verify(
         return Err(err);
     }
 
-    tokio::time::timeout(PUMP_TIMEOUT, writer)
+    tokio::time::timeout(timeout, writer)
         .await
-        .map_err(|_| anyhow::anyhow!("{label}: writer timeout ({PUMP_TIMEOUT:?})"))?
+        .map_err(|_| anyhow::anyhow!("{label}: writer timeout ({timeout:?})"))?
         .map_err(|e| anyhow::anyhow!("{label}: writer panicked: {e}"))?
         .map_err(|e| anyhow::anyhow!("{label}: write error: {e}"))?;
 
@@ -1146,41 +1162,47 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     let mut payload = vec![0u8; PAYLOAD_SIZE];
     rand::thread_rng().fill_bytes(&mut payload);
 
-    // ── 10. 0-hop session — direct path, no relay ────────────────────────────
+    // ── 10. First session ────────────────────────────────────────────────────
     // NoRateControl disables the exit node's egress rate limiter (default: 10
     // pkt/s initial rate).  Without it, returning 1 MiB (~1030 packets) at
-    // 10 pkt/s takes ~103 s, nearly exhausting the 120 s PUMP_TIMEOUT before
-    // the rate-adaptive controller has time to ramp up.
-    tracing::info!("opening 0-hop session (loopback)");
-    let (session_0h, _) = edgli
+    // 10 pkt/s takes ~103 s, nearly exhausting the pump timeout before the
+    // rate-adaptive controller has time to ramp up.
+    // On real networks (Rotsee), session_a_hops=1 to avoid 0-hop direct HOPR
+    // packet delivery issues (unreliable through NAT on real networks).
+    let hops_a = tuning.session_a_hops;
+    let label_a = format!("{hops_a}-hop");
+    tracing::info!(hops = hops_a, "opening first session (loopback)");
+    let (session_a, _) = edgli
         .connect_to(
             dest_0h,
             loopback_target(),
             HoprSessionClientConfig {
-                forward_path: HopRouting::try_from(0_usize)?,
-                return_path: HopRouting::try_from(0_usize)?,
+                forward_path: HopRouting::try_from(hops_a)?,
+                return_path: HopRouting::try_from(hops_a)?,
                 capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
                 ..Default::default()
             },
         )
         .await?;
-    pump_and_verify(session_0h, &payload, "0-hop").await?;
+    pump_and_verify(session_a, &payload, &label_a, tuning.pump_timeout).await?;
 
-    // ── 11. 1-hop session — full relay path ──────────────────────────────────
-    tracing::info!("opening 1-hop session (loopback)");
-    let (session_1h, _) = edgli
+    // ── 11. Second session — one more relay hop ───────────────────────────────
+    let hops_b = hops_a + 1;
+    let label_b = format!("{hops_b}-hop");
+    tracing::info!(hops = hops_b, "opening second session (loopback)");
+    let (session_b, _) = edgli
         .connect_to(
             dest_1h,
             loopback_target(),
             HoprSessionClientConfig {
-                forward_path: HopRouting::try_from(1_usize)?,
-                return_path: HopRouting::try_from(1_usize)?,
+                forward_path: HopRouting::try_from(hops_b)?,
+                return_path: HopRouting::try_from(hops_b)?,
                 capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
                 ..Default::default()
             },
         )
         .await?;
-    pump_and_verify(session_1h, &payload, "1-hop").await?;
+    pump_and_verify(session_b, &payload, &label_b, tuning.pump_timeout).await?;
 
     // ── 12. Final state assertion ─────────────────────────────────────────────
     let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;


### PR DESCRIPTION
## Summary

- Adds \`BalanceRecommendation\` and per-channel \`Capacity\` API to help callers provision funds correctly before opening channels
- Adds \`Edgli::ideal_balance_recommendation\` to discount already-open channels from the recommendation
- Adds \`Edgli::describe_current_capacity_allocations\` including the unallocated Safe wxHOPR balance
- \`Capacity\` now exposes both \`expected_messages\` (long-run average) and \`min_guaranteed_messages\` (worst-case floor factoring win probability via \`face_value = ticket_price / win_prob\`)
- Hoists inline \`use hopr_lib::api::…\` blocks in \`ideal_balance_recommendation\` and \`describe_current_capacity_allocations\` to module-level imports
- Adds \`generate-metrics-docs\` hook infrastructure (\`.github/scripts/\` + \`METRICS.md\`) for the Nix pre-commit hook
- Fixes the Rotsee session test timeout — capped SURB pre-fill to avoid pipeline freeze; upstream ack-sink bug fixed in hoprnet
- Sets \`min_ack_rate=0.0\` for the Rotsee test to allow path selection via channel topology when NAT blocks probe acks
- Bumps hoprnet rev to master (\`00ce9f12\`) to include probing-gated channel close fix (hoprnet PR #8146), structured channel lifecycle logging (#8145), and env-var migration (#8136)

## Root causes of the Rotsee session failure

### Bug 1 — MixerSink busy-spin (hoprnet dependency patch)

\`MixerSink::poll_flush\` spun indefinitely when an item was immediately due (\`sleep_for == 0\`) but the inner channel was full (\`poll_ready → Pending\`). Fix applied to the cargo git checkout: return \`Poll::Pending\` so the waker registered by \`poll_ready\` wakes the task when capacity is available.

### Bug 2 — SURB replenishment flood (test workaround)

The default \`target_surb_buffer_size = 7 000\` SURBs causes the keep-alive stream to emit up to \`max_surbs_per_sec = 5 000\` SURBs/s. This overwhelms the \`wire_msg_tx\` channel within ~1 s, triggering Bug 1. The test now sets \`target_surb_buffer_size = 600, max_surbs_per_sec = 300\` to keep the SURB burst rate within channel capacity.

### Bug 3 — Entry-node ack-sink dropped receiver (upstream fix in hoprnet)

\`start_packet_pipeline_impl\` unconditionally dropped \`incoming_ack_rx\` for \`NodeType::Entry\` at startup. Edge nodes receive ticket acknowledgements from relays, so every inbound ack dispatch fired \`SendError(disconnected)\`, flooding logs with ~300 errors per Rotsee run.

Fixed upstream in [\`hoprnet@kauki/fix/transport/entry-ack-drain\`](https://github.com/hoprnet/hoprnet/tree/kauki/fix/transport/entry-ack-drain) (SHA \`0aa05f5ad6\`) — now mirroring the Exit-node drain pattern. Edge-client pins this SHA. See the [comment below](https://github.com/hoprnet/edge-client/pull/70#issuecomment-4564774974) for full analysis.

### Bug 4 — Channel lifecycle closes channels before probing (hoprnet PR #8146)

\`ChannelLifecycleStrategy::should_close\` evaluated peer quality immediately on startup using \`edge.score()\`. Before any probe round completes, \`graph.edge(me, peer)\` returns \`None\` → score 0.0 → below \`close_below_quality_score = 0.3\` → every channel is marked for closure on the first tick.

Fixed in [hoprnet PR #8146](https://github.com/hoprnet/hoprnet/pull/8146) (SHA \`00ce9f12\`): \`should_close\` now checks \`has_probing_data()\` — which returns true only when \`edge.last_update() > Duration::ZERO\` — before evaluating quality or staleness. Channels are protected from premature closure until at least one observation is recorded for the peer.

## Dependency chain

```
hoprnet master (00ce9f12)
  └─ kauki/fix/strategy/probing-gated-close (PR #8146) — gated close pass on observations
  └─ kauki/feat/hopr-strategy/structured-channel-lifecycle-debug-logs (PR #8145)
  └─ kauki/feat/move-env-vars-from-hopr-lib (PR #8136)
```