### PR TITLE
chore(ci): replace hoprnet self-hosted runners with Depot runners

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -19,7 +19,7 @@ jobs:
       unit_coverage: true
       unconditional: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -19,7 +19,7 @@ jobs:
       unit_coverage: true
       unconditional: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-16
+      runner: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -24,6 +24,6 @@ jobs:
       security-events: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -24,6 +24,6 @@ jobs:
       security-events: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner: depot-ubuntu-24.04-16
+      runner: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#lib-edgli-x86_64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
     permissions:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#lib-edgli-x86_64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -79,7 +79,7 @@ jobs:
       deps: false
       audit_command: "nix build -L .#checks.x86_64-linux.audit"
       runner_small: depot-ubuntu-24.04
-      runner_large: depot-ubuntu-24.04-16
+      runner_large: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
@@ -91,7 +91,7 @@ jobs:
       unit_test_command: "nix develop -c cargo nextest run --no-tests=pass"
       unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-16
+      runner: depot-ubuntu-24.04-8
       test_timeout: 30
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -103,11 +103,11 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#lib-edgli-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#lib-edgli-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
   validate-pr-title:
     name: Validate title
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     permissions:
       pull-requests: read
     steps:
@@ -42,7 +42,7 @@ jobs:
   label:
     name: Add labels
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
       issues: write
@@ -78,8 +78,8 @@ jobs:
       lint_command: "nix build -L .#checks.x86_64-linux.clippy"
       deps: false
       audit_command: "nix build -L .#checks.x86_64-linux.audit"
-      runner_small: self-hosted-hoprnet-small
-      runner_large: self-hosted-hoprnet-bigger
+      runner_small: depot-ubuntu-24.04
+      runner_large: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
@@ -91,7 +91,7 @@ jobs:
       unit_test_command: "nix develop -c cargo nextest run --no-tests=pass"
       unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-16
       test_timeout: 30
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -103,11 +103,11 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#lib-edgli-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#lib-edgli-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#lib-edgli-x86_64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#lib-edgli-x86_64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
     permissions:
@@ -39,7 +39,7 @@ jobs:
     name: Close release
     needs:
       - build-library
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

- Replaces all \`self-hosted-hoprnet-small\` runner labels with \`depot-ubuntu-24.04\`
- Replaces all \`self-hosted-hoprnet-bigger\` runner labels with \`depot-ubuntu-24.04-8\`
- Leaves \`macos-15-xlarge\` unchanged (GitHub-hosted, not a hoprnet runner)

Affects \`pr.yaml\`, \`branches.yaml\`, \`merge.yaml\`, \`release.yaml\`, and \`checks-zizmor.yaml\`.

Fixes CI being stuck in queue due to hoprnet self-hosted runners being offline.