### PR TITLE
chore(deps): bump hoprnet rev to fix msg-ingress receiver-gone crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3553,8 +3553,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+version = "4.0.3-rc.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3755,8 +3755,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+version = "0.28.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=00ce9f124bc25d99cc5681f2f96d4386b9f972c1#00ce9f124bc25d99cc5681f2f96d4386b9f972c1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.3-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3755,8 +3755,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+version = "0.28.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3796,8 +3796,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-mixer"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+version = "0.4.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.2.2"
+version = "3.2.4"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3553,8 +3553,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.3-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+version = "4.0.2-rc.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=cf0dab3751559bbbde79521b682325393d50b63f#cf0dab3751559bbbde79521b682325393d50b63f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.2.0"
+version = "3.2.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "00ce9f124bc25d99cc5681f2f96d4386b9f972c1", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.2.1"
+version = "3.2.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.2.2"
+version = "3.2.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "cf0dab3751559bbbde79521b682325393d50b63f", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
   "runtime-tokio",
   "testing",
 ] }


### PR DESCRIPTION
Bump hoprnet git rev to `e143b5c7` (master), picking up upstream fixes via the chain:

- hoprnet/hoprnet#8148: drain `on_incoming_data_rx` on consumer drop — prevents `SessionsManagement(0)` crash when the relay's session receiver is dropped before the forwarding pipeline finishes
- hoprnet PR #8132: eliminate `MixerSink::poll_flush` busy-spin (pegged executor thread when mpsc was saturated)
- hoprnet: share mixer heap across wire-sink clones (per-destination clones had separate delay queues, defeating cross-destination mixing)
- hoprnet: enable `transport-announce-quic` in `hopr-reference/runtime-tokio`

**Version:** `3.2.0` → `3.2.4`