### PR TITLE
feat: expose channel allowlist via strategy configuration

### DIFF
--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -23,22 +23,9 @@ pub struct MultiStrategyConfig {
 
 /// Top-level incentive parameters for the channel lifecycle strategy reactor.
 ///
-/// Bundles channel funding sizing with population topology so callers
-/// have a single config knob for the reactor. Designed to accommodate
-/// future incentive extensions beyond the current channel lifecycle strategy.
-///
-/// ## Routing-mode aware channel targeting
-///
-/// When destinations are configured with explicit relay paths (`path = { intermediates = [...] }`),
-/// set `channel_allowlist` to the set of first-relayer addresses collected from those destinations.
-/// The channel lifecycle strategy will then open and maintain channels **exclusively** to those
-/// addresses, ignoring all other peers.
-///
-/// When `channel_allowlist` is `None` (the default), the strategy selects peers by quality score
-/// and opens channels freely across the network.
-///
-/// Callers should choose one mode or the other — mixing hop-based and explicit-path destinations
-/// is not supported and the behaviour is unspecified.
+/// Covers channel funding sizing, population topology, and optional address targeting.
+/// Set `channel_allowlist` when using explicit-path routing to restrict channel opening
+/// to the required relayer addresses; leave it `None` for quality-score-based peer selection.
 #[derive(Debug, Clone, smart_default::SmartDefault)]
 pub struct IncentiveConfiguration {
     /// Number of forwarded packets the initial channel stake is sized to cover.
@@ -61,13 +48,9 @@ pub struct IncentiveConfiguration {
     #[default = 8]
     pub target_open_channels: usize,
 
-    /// Restrict channel opening to this explicit set of peer addresses.
-    ///
-    /// When `Some`, the channel lifecycle strategy will only open channels to addresses
-    /// in this set. All other peers are skipped regardless of quality score.
-    /// Intended for explicit-path routing where channels must reach specific relayers.
-    ///
-    /// When `None` (default), channels are opened to any eligible peer by quality score.
+    /// When `Some`, channels are opened exclusively to these addresses; all other peers
+    /// are skipped regardless of quality score. Use this for explicit-path routing to
+    /// ensure channels exist to the required relayers. Default: `None` (open to any peer).
     #[default(None)]
     pub channel_allowlist: Option<HashSet<Address>>,
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use hopr_lib::api::types::primitive::prelude::{
     Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
 };
@@ -24,7 +26,20 @@ pub struct MultiStrategyConfig {
 /// Bundles channel funding sizing with population topology so callers
 /// have a single config knob for the reactor. Designed to accommodate
 /// future incentive extensions beyond the current channel lifecycle strategy.
-#[derive(Debug, Clone, Copy, smart_default::SmartDefault)]
+///
+/// ## Routing-mode aware channel targeting
+///
+/// When destinations are configured with explicit relay paths (`path = { intermediates = [...] }`),
+/// set `channel_allowlist` to the set of first-relayer addresses collected from those destinations.
+/// The channel lifecycle strategy will then open and maintain channels **exclusively** to those
+/// addresses, ignoring all other peers.
+///
+/// When `channel_allowlist` is `None` (the default), the strategy selects peers by quality score
+/// and opens channels freely across the network.
+///
+/// Callers should choose one mode or the other — mixing hop-based and explicit-path destinations
+/// is not supported and the behaviour is unspecified.
+#[derive(Debug, Clone, smart_default::SmartDefault)]
 pub struct IncentiveConfiguration {
     /// Number of forwarded packets the initial channel stake is sized to cover.
     ///
@@ -45,6 +60,16 @@ pub struct IncentiveConfiguration {
     /// Target number of open outgoing channels to open towards. Default: 8.
     #[default = 8]
     pub target_open_channels: usize,
+
+    /// Restrict channel opening to this explicit set of peer addresses.
+    ///
+    /// When `Some`, the channel lifecycle strategy will only open channels to addresses
+    /// in this set. All other peers are skipped regardless of quality score.
+    /// Intended for explicit-path routing where channels must reach specific relayers.
+    ///
+    /// When `None` (default), channels are opened to any eligible peer by quality score.
+    #[default(None)]
+    pub channel_allowlist: Option<HashSet<Address>>,
 }
 
 impl IncentiveConfiguration {
@@ -240,6 +265,10 @@ pub async fn default_strategy_cfg(
         population: PopulationConfig {
             min_open_channels: sizing.min_open_channels,
             target_open_channels: sizing.target_open_channels,
+            ..Default::default()
+        },
+        eligibility: EligibilityConfig {
+            allowlist: sizing.channel_allowlist,
             ..Default::default()
         },
         ..Default::default()

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -501,4 +501,25 @@ mod tests {
         assert!(compute_capacity(stake, price, f64::NAN).is_err());
         assert!(compute_capacity(stake, price, f64::INFINITY).is_err());
     }
+
+    #[test]
+    fn incentive_configuration_default_allowlist_is_none() {
+        assert!(IncentiveConfiguration::default().channel_allowlist.is_none());
+    }
+
+    #[test]
+    fn eligibility_config_uses_channel_allowlist() {
+        use std::collections::HashSet;
+        let addr = Address::default();
+        let allowlist = HashSet::from([addr]);
+        let sizing = IncentiveConfiguration {
+            channel_allowlist: Some(allowlist.clone()),
+            ..Default::default()
+        };
+        let eligibility = EligibilityConfig {
+            allowlist: sizing.channel_allowlist.clone(),
+            ..Default::default()
+        };
+        assert_eq!(eligibility.allowlist, Some(allowlist));
+    }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -504,7 +504,11 @@ mod tests {
 
     #[test]
     fn incentive_configuration_default_allowlist_is_none() {
-        assert!(IncentiveConfiguration::default().channel_allowlist.is_none());
+        assert!(
+            IncentiveConfiguration::default()
+                .channel_allowlist
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -237,21 +237,21 @@ pub async fn minimum_balance_recommendation(
 #[cfg(feature = "runtime-tokio")]
 pub async fn default_strategy_cfg(
     node: &crate::client::Edgli,
-    sizing: IncentiveConfiguration,
+    sizing: &IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {
     sizing.validate()?;
     let chain = node.chain_api();
     let ticket_price = chain.minimum_ticket_price().await?;
     let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
     let cfg = ChannelLifecycleConfig {
-        funding: compute_funding_config(ticket_price, win_prob, &sizing)?,
+        funding: compute_funding_config(ticket_price, win_prob, sizing)?,
         population: PopulationConfig {
             min_open_channels: sizing.min_open_channels,
             target_open_channels: sizing.target_open_channels,
             ..Default::default()
         },
         eligibility: EligibilityConfig {
-            allowlist: sizing.channel_allowlist,
+            allowlist: sizing.channel_allowlist.clone(),
             ..Default::default()
         },
         ..Default::default()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1123,6 +1123,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         desired_message_count: (session_packets as u64) * 1_000,
         min_open_channels: 1,
         target_open_channels: CLUSTER_SIZE,
+        ..Default::default()
     };
     let mut strat_cfg = default_strategy_cfg(&edgli, sizing).await?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1125,7 +1125,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         target_open_channels: CLUSTER_SIZE,
         ..Default::default()
     };
-    let mut strat_cfg = default_strategy_cfg(&edgli, sizing).await?;
+    let mut strat_cfg = default_strategy_cfg(&edgli, &sizing).await?;
 
     for kind in &mut strat_cfg.strategies {
         let EdgeStrategyKind::ChannelLifecycle(lc) = kind;


### PR DESCRIPTION
This will be used to enable fixed channel funding with the channellifecyclestrategy