### PR TITLE
feat(edgli): set edge-client mixer defaults (0ms min, 1ms range)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "futures",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3797,13 +3797,15 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "futures",
  "futures-timer",
  "hopr-types",
+ "humantime-serde",
  "lazy_static",
  "parking_lot",
+ "serde",
  "smart-default",
  "thiserror 2.0.18",
  "tracing",
@@ -3812,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3831,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3856,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3889,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3956,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,17 @@ async fn main() -> anyhow::Result<()> {
         .into());
     }
 
-    let cfg: HoprLibConfig = serde_yaml::from_str(&std::fs::read_to_string(args.config)?)?;
+    let mut cfg: HoprLibConfig = serde_yaml::from_str(&std::fs::read_to_string(args.config)?)?;
+    // Edge-client specific mixer defaults (0 ms min, 1 ms range); env vars override.
+    let read_ms = |var: &str, default_ms: u64| -> std::time::Duration {
+        std::env::var(var)
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(std::time::Duration::from_millis)
+            .unwrap_or_else(|| std::time::Duration::from_millis(default_ms))
+    };
+    cfg.protocol.mixer.min_delay = read_ms("HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS", 0);
+    cfg.protocol.mixer.delay_range = read_ms("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS", 1);
 
     // Find or create an identity
     let hopr_keys: HoprKeys = IdentityRetrievalModes::FromFile {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -957,7 +957,7 @@ pub fn loopback_target() -> SessionTarget {
 // ────────────────────────────────────────────────────────────────────────────
 
 pub fn build_edgli_config(extra: &ExtraInfo, tuning: &EdgliTuning) -> HoprLibConfig {
-    use edgli::hopr_lib::config::{HoprProtocolConfig, TransportConfig};
+    use edgli::hopr_lib::config::{HoprProtocolConfig, MixerConfig, TransportConfig};
     use edgli::hopr_lib::exports::transport::path::PathPlannerConfig;
     HoprLibConfig {
         host: HostConfig {
@@ -972,6 +972,11 @@ pub fn build_edgli_config(extra: &ExtraInfo, tuning: &EdgliTuning) -> HoprLibCon
             },
             path_planner: PathPlannerConfig {
                 min_ack_rate: tuning.min_ack_rate,
+                ..Default::default()
+            },
+            mixer: MixerConfig {
+                min_delay: std::time::Duration::ZERO,
+                delay_range: std::time::Duration::from_millis(1),
                 ..Default::default()
             },
             ..Default::default()

--- a/tests/mixer_config.rs
+++ b/tests/mixer_config.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use hopr_lib::config::{HoprLibConfig, MixerConfig};
+
+#[test]
+fn mixer_section_round_trips_through_yaml() {
+    let mut cfg = HoprLibConfig::default();
+    cfg.protocol.mixer = MixerConfig {
+        min_delay: Duration::from_millis(1),
+        delay_range: Duration::from_millis(25),
+        capacity: 2_048,
+        ..Default::default()
+    };
+    let yaml = serde_yaml::to_string(&cfg).unwrap();
+    assert!(!yaml.contains("metric_delay_window"));
+    let parsed: HoprLibConfig = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(cfg, parsed);
+}
+
+#[test]
+fn missing_mixer_section_deserialises_as_default() {
+    let yaml = "host:\n  address:\n    IPv4: \"1.2.3.4\"\n  port: 9091\n";
+    let parsed: HoprLibConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(parsed.protocol.mixer, MixerConfig::default());
+}
+
+/// Verifies the edge-client specific mixer override: 0 ms min and 1 ms range,
+/// matching the hardcoded values applied in main.rs after YAML deserialisation.
+#[test]
+fn edge_client_mixer_defaults() {
+    let edge_mixer = MixerConfig {
+        min_delay: Duration::ZERO,
+        delay_range: Duration::from_millis(1),
+        ..Default::default()
+    };
+    assert_ne!(edge_mixer, MixerConfig::default(), "edge-client mixer differs from hoprnet default");
+    assert_eq!(edge_mixer.min_delay, Duration::ZERO);
+    assert_eq!(edge_mixer.delay_range, Duration::from_millis(1));
+}

--- a/tests/mixer_config.rs
+++ b/tests/mixer_config.rs
@@ -19,8 +19,7 @@ fn mixer_section_round_trips_through_yaml() {
 
 #[test]
 fn missing_mixer_section_deserialises_as_default() {
-    let yaml = "host:\n  address:\n    IPv4: \"1.2.3.4\"\n  port: 9091\n";
-    let parsed: HoprLibConfig = serde_yaml::from_str(yaml).unwrap();
+    let parsed: HoprLibConfig = serde_yaml::from_str("{}").unwrap();
     assert_eq!(parsed.protocol.mixer, MixerConfig::default());
 }
 
@@ -33,7 +32,11 @@ fn edge_client_mixer_defaults() {
         delay_range: Duration::from_millis(1),
         ..Default::default()
     };
-    assert_ne!(edge_mixer, MixerConfig::default(), "edge-client mixer differs from hoprnet default");
+    assert_ne!(
+        edge_mixer,
+        MixerConfig::default(),
+        "edge-client mixer differs from hoprnet default"
+    );
     assert_eq!(edge_mixer.min_delay, Duration::ZERO);
     assert_eq!(edge_mixer.delay_range, Duration::from_millis(1));
 }


### PR DESCRIPTION
## Summary

- After YAML deserialization, applies edge-client specific mixer defaults: `min_delay=0ms`, `delay_range=1ms`. `HOPR_INTERNAL_MIXER_*` env vars override these values.
- `tests/common/mod.rs`: `build_edgli_config` sets `MixerConfig{1ms}` so integration tests match production behavior
- Adds `tests/mixer_config.rs`: YAML round-trip tests + edge-client default assertion
- Bumps hoprnet rev to `8c04d91a` (typed `MixerConfig` on `HoprProtocolConfig`, merged)

## Rationale

Edge-client runs inside the mixnet as an entry node; its own packet mixer needs much lower latency (1 ms spread) than relay nodes (20 ms).

## Depends on

- hoprnet/hoprnet#8152 ✅ merged
- hoprnet/hoprd#52