### PR TITLE
feat(build): enable aarch64 AES hardware acceleration via target-feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -25,8 +25,11 @@ LDFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 # compile time instead of the runtime-dispatched aes::soft::fixslice path.
 # Benchmarks show ~10× key-schedule improvement on Apple Silicon.
 # See: hoprnet/edge-client#82
-[target.'cfg(all(target_arch = "aarch64", target_vendor = "apple"))']
-rustflags = ["-C", "target-feature=+aes,+neon"]
+[target.aarch64-apple-darwin]
+rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes,+neon"]
 
-[target.'cfg(all(target_arch = "aarch64", not(target_vendor = "apple")))']
-rustflags = ["-C", "target-feature=+aes"]
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,4 +26,4 @@ LDFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 # Benchmarks show ~10× key-schedule improvement on Apple Silicon.
 # See: hoprnet/edge-client#82
 [target.aarch64-apple-darwin]
-rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes,+neon"]
+rustflags = ["--cfg=aes_armv8", "-Ctarget-feature=+aes,+neon"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,3 +20,13 @@ JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,narenas:4,tcache_max:65536,dirt
 CFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 CPPFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 LDFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
+
+# Enable hardware AES intrinsics on aarch64 — selects aes::armv8 backend at
+# compile time instead of the runtime-dispatched aes::soft::fixslice path.
+# Benchmarks show ~10× key-schedule improvement on Apple Silicon.
+# See: hoprnet/edge-client#82
+[target.'cfg(all(target_arch = "aarch64", target_vendor = "apple"))']
+rustflags = ["-C", "target-feature=+aes,+neon"]
+
+[target.'cfg(all(target_arch = "aarch64", not(target_vendor = "apple")))']
+rustflags = ["-C", "target-feature=+aes"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,9 +27,3 @@ LDFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 # See: hoprnet/edge-client#82
 [target.aarch64-apple-darwin]
 rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes,+neon"]
-
-[target.aarch64-unknown-linux-gnu]
-rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes"]
-
-[target.aarch64-unknown-linux-musl]
-rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.2.4"
+version = "3.3.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."


### PR DESCRIPTION
## Summary

- Adds `--cfg aes_armv8` and `-C target-feature=+aes,+neon` to `.cargo/config.toml` for the `aarch64-apple-darwin` target (Apple Silicon only)
- Selects `aes::armv8::encdec` hardware backend at compile time instead of `aes::soft::fixslice`
- Restricted to `aarch64-apple-darwin` where the AES crypto extension is guaranteed; `aarch64-unknown-linux-*` is excluded because older ARM cores (Cortex-A53 and earlier) lack the extension

**Why `--cfg aes_armv8` and not just `target-feature=+aes`:**  
The `aes` crate v0.8.4 uses a custom cfg flag `aes_armv8` (not `target_feature`) to select the `armv8` backend module. `target-feature=+aes` makes the instructions available but the crate still compiles `soft::fixslice` unless `--cfg aes_armv8` is explicitly set.

**Binary verification (Apple M-series):**
```
$ nm target/release/edgli | c++filt | grep "^[^ ]* [tT] aes::"
0000000100aad748 t aes::armv8::encdec::encrypt8::h7f63a7f50a2cbfaf
```
One `armv8` symbol, zero `soft::fixslice` symbols — hardware path confirmed.

Closes #82