### PR TITLE
fix(ci): enforce nix fmt --ci via Format matrix entry

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@2002c3d074e48378468372a6de710f88377c94e2 # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       format: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -75,6 +75,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      format: true
       lint_command: "nix build -L .#checks.x86_64-linux.clippy"
       deps: false
       audit_command: "nix build -L .#checks.x86_64-linux.audit"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -75,7 +75,6 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      format: true
       lint_command: "nix build -L .#checks.x86_64-linux.clippy"
       deps: false
       audit_command: "nix build -L .#checks.x86_64-linux.audit"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,24 +70,12 @@ jobs:
           if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
             gh pr edit "$PR_NUMBER" --add-label "external"
           fi
-  format:
-    name: Format
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # workflow-checks-v1
-    with:
-      source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      pre_commit: false
-      deps: false
-      audit: false
-      lint: true
-      lint_command: "nix fmt && git diff --exit-code"
-      disable_sudo: false
-    secrets:
-      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@2002c3d074e48378468372a6de710f88377c94e2 # workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      format: true
       lint_command: "nix build -L .#checks.x86_64-linux.clippy"
       deps: false
       audit_command: "nix build -L .#checks.x86_64-linux.audit"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,10 +72,9 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      format: true
       lint_command: "nix build -L .#checks.x86_64-linux.clippy"
       deps: false
       audit_command: "nix build -L .#checks.x86_64-linux.audit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.2.4"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-signal",


### PR DESCRIPTION
## Summary

- Removes the standalone \`format:\` job workaround that abused the \`Lint\` matrix entry with \`nix fmt && git diff --exit-code\`
- Replaces it with \`format: true\` on the existing \`checks:\` job, using the new first-class \`Format\` matrix entry from [hopr-workflows#77](https://github.com/hoprnet/hopr-workflows/pull/77) (merged, tagged \`workflow-checks-v2\`)
- The \`Format\` job runs \`nix fmt -- --ci\` (treefmt: \`--no-cache --fail-on-change\`) as the first step so cheap formatting violations surface before heavier Clippy/Lint jobs
- Fixed \`Cargo.lock\` version mismatch: edgli was bumped \`3.2.4 → 3.3.0\` in Cargo.toml by PR #83 but the lock file was not updated, causing \`cargo check --locked\` to fail in the Nix build

---
**Latest:** Added missing `format: true` to the `checks:` job (fixes Copilot inline comment).