### PR TITLE
fix(prober): remove probe_connected_only override, pin hoprnet HOL-blocking fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,8 +3478,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+version = "0.21.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3744,17 +3744,17 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.30.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+version = "0.31.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
- "async-lock",
  "async-trait",
  "async_channel_io",
  "bytes",
  "cfg-if",
  "dashmap",
+ "flume",
  "futures",
  "futures-time",
  "halfbrown",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3947,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossfire"
+version = "3.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
+dependencies = [
+ "crossbeam-utils",
+ "embed-collections",
+ "futures-core",
+ "parking_lot",
+ "smallvec",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,6 +2614,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embed-collections"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
 
 [[package]]
 name = "embedded-io"
@@ -3479,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3510,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3533,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3550,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3589,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3608,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3621,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3682,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3697,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3723,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3745,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.31.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3753,8 +3772,8 @@ dependencies = [
  "async_channel_io",
  "bytes",
  "cfg-if",
+ "crossfire",
  "dashmap",
- "flume",
  "futures",
  "futures-time",
  "halfbrown",
@@ -3786,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3802,8 +3821,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+version = "0.9.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3816,6 +3835,7 @@ dependencies = [
  "libp2p-stream",
  "multiaddr",
  "pin-project",
+ "quinn-udp",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3823,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3848,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3879,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3947,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3745,10 +3745,11 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.30.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "ahash",
  "anyhow",
+ "async-lock",
  "async-trait",
  "async_channel_io",
  "bytes",
@@ -3785,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3802,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3822,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3847,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3878,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3946,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -515,7 +515,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -733,7 +733,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c49aad21c0d9dac90f52c45894e7f23a7201d0264c07a4546c1df603ca3158"
+checksum = "4ecdfbd15f4ff885b4aaea1630d1e318f15462c85971b0bb3150b228b7792d60"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1538,7 +1538,7 @@ dependencies = [
  "launchdarkly-sdk-transport",
  "parking_lot",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -2189,7 +2189,7 @@ checksum = "f2e722e1560ed4e4260cf35ac5fafc422aa7682c919db5a14209e4afad4446c2"
 dependencies = [
  "cynic-proc-macros",
  "ref-cast",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "static_assertions",
@@ -2543,7 +2543,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.32.1",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2721,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.17.3"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "070ad6e8a7c86db50406471a7eab99b4b24b73a0991a2432484b989e9db1a985"
+checksum = "96df8cfa11d3c8e4e1a48b81c9c600ecbe8c11d1326f41e1524cc4d42f7bf6d9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2860,21 +2860,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3493,8 +3478,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+version = "0.21.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3519,12 +3504,13 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3547,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3563,8 +3549,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+version = "4.0.2-rc.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3603,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3622,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3635,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3665,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3696,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3711,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3737,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3758,8 +3744,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+version = "0.30.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3799,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3815,8 +3801,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+version = "0.9.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3828,6 +3814,7 @@ dependencies = [
  "libp2p",
  "libp2p-stream",
  "multiaddr",
+ "pin-project",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3835,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3860,10 +3847,9 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
- "arrayvec",
  "async-trait",
  "flagset",
  "futures",
@@ -3873,7 +3859,6 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-transport-tag-allocator",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3893,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3961,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -3990,9 +3975,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -4105,22 +4090,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4653,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "launchdarkly-sdk-transport"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48629e54c0e45cb102a333271f363eb521e7785d54e5047a5d1c6f2770c765"
+checksum = "a048341aa360a768a7d91ebf6232a574f355ada0724acff2df7c5d8dc1e04c98"
 dependencies = [
  "bytes",
  "futures",
@@ -5313,23 +5282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5545,48 +5497,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -5626,7 +5540,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry 0.32.0",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -5641,7 +5555,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk 0.32.1",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -6502,9 +6416,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6517,49 +6431,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6571,12 +6446,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -7127,18 +7004,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -7762,16 +7627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8192,12 +8047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8334,9 +8183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3072,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
  "serde_core",
@@ -3454,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33fb0c32d216e93e58a050edea339bc8ed5bd8fe844bf893b849fc402824412"
+checksum = "2a6e98ff52f636edc8e3d76844831dfd53cd92146488cc721c0f7bb837fd8052"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3493,8 +3493,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.21.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3502,11 +3502,11 @@ dependencies = [
  "async-trait",
  "atomic_enum",
  "blokli-client",
+ "const-hex",
  "dashmap",
  "futures",
  "futures-concurrency",
  "futures-time",
- "hex",
  "hopr-api",
  "hopr-utils",
  "moka",
@@ -3523,15 +3523,15 @@ dependencies = [
 
 [[package]]
 name = "hopr-crypto-packet"
-version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "1.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "bimap",
+ "const-hex",
  "curve25519-dalek",
  "elliptic-curve",
  "flagset",
- "generic-array 1.4.1",
- "hex",
+ "generic-array 1.4.3",
  "hopr-types",
  "hopr-utils",
  "k256",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3580,7 +3580,6 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-network-graph",
- "hopr-session-server-forwarder",
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
@@ -3604,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3614,6 +3613,8 @@ dependencies = [
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
+ "rand 0.10.1",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3621,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3633,8 +3634,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "4.7.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3642,7 +3643,7 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "cfg_eval",
- "hex",
+ "const-hex",
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
@@ -3664,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3695,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3708,28 +3709,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-session-server-forwarder"
-version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
-dependencies = [
- "async-trait",
- "hopr-api",
- "hopr-transport-session",
- "hopr-utils",
- "serde",
- "serde_with",
- "smart-default",
- "thiserror 2.0.18",
- "tokio",
- "tokio-retry",
- "tracing",
- "validator",
-]
-
-[[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3742,6 +3724,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "moka",
+ "multiaddr",
  "parking_lot",
  "serde",
  "serde_with",
@@ -3754,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3775,8 +3758,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.29.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3792,7 +3775,6 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
- "hopr-ticket-manager",
  "hopr-transport-mixer",
  "hopr-transport-probe",
  "hopr-transport-session",
@@ -3817,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3834,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3852,14 +3834,14 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.7.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "async-trait",
+ "const-hex",
  "futures",
  "futures-concurrency",
- "hex",
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
@@ -3878,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3911,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3922,26 +3904,27 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e82a6426de74cdef7bbef15f651ce546ab39fc77ef1dc4002247b6bbf034fc"
+checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
 dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "arrayvec",
  "async-trait",
  "bigdecimal",
  "blake3",
  "chacha20 0.9.1",
  "chrono",
  "cipher 0.4.4",
+ "const-hex",
  "ctr",
  "curve25519-dalek",
  "digest 0.10.7",
  "ed25519-dalek",
  "float-cmp",
- "generic-array 1.4.1",
- "hex",
+ "generic-array 1.4.3",
  "hex-literal",
  "hopr-bindings",
  "k256",
@@ -3978,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=123168c4c022f9583467f5be7fb7d8ae6af67074#123168c4c022f9583467f5be7fb7d8ae6af67074"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4857,15 +4840,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
- "quick-protobuf",
+ "prost",
  "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
@@ -5130,7 +5113,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
  "syn 2.0.117",
 ]
 
@@ -6158,7 +6141,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6478,14 +6461,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -6496,7 +6479,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -6507,9 +6490,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -7160,9 +7143,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7180,9 +7163,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -7789,17 +7772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
-dependencies = [
- "pin-project-lite",
- "rand 0.10.1",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8054,9 +8026,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -8173,9 +8145,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["runtime-tokio", "blokli"]
-runtime-tokio = ["dep:tokio", "hopr-lib/runtime-tokio", "hopr-transport-p2p/runtime-tokio"]
+runtime-tokio = ["dep:tokio", "hopr-lib/runtime-tokio", "hopr-transport-p2p/runtime-tokio", "hopr-transport-p2p/transport-quic"]
 # Enable hopr-lib telemetry (Prometheus metrics) and OpenTelemetry OTLP exporter
 telemetry = [
   "hopr-lib/telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,12 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["runtime-tokio", "blokli"]
-runtime-tokio = ["dep:tokio", "hopr-lib/runtime-tokio", "hopr-transport-p2p/runtime-tokio", "hopr-transport-p2p/transport-quic"]
+runtime-tokio = [
+  "dep:tokio",
+  "hopr-lib/runtime-tokio",
+  "hopr-transport-p2p/runtime-tokio",
+  "hopr-transport-p2p/transport-quic",
+]
 # Enable hopr-lib telemetry (Prometheus metrics) and OpenTelemetry OTLP exporter
 telemetry = [
   "hopr-lib/telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,20 +66,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["runtime-tokio", "blokli"]
-runtime-tokio = ["dep:tokio", "hopr-lib/runtime-tokio"]
+runtime-tokio = ["dep:tokio", "hopr-lib/runtime-tokio", "hopr-transport-p2p/runtime-tokio"]
 # Enable hopr-lib telemetry (Prometheus metrics) and OpenTelemetry OTLP exporter
 telemetry = [
   "hopr-lib/telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,20 +66,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.3.0"
+version = "3.3.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -66,20 +66,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,20 +66,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,20 +66,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "123168c4c022f9583467f5be7fb7d8ae6af67074", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -196,7 +196,6 @@ impl Edgli {
         let probe_cfg = FullNetworkProberConfig {
             interval: std::time::Duration::from_secs(3),
             shuffle_ttl: std::time::Duration::from_secs(3),
-            probe_connected_only: false,
             ..Default::default()
         };
         probe_cfg.validate_against_probe_timeout(cfg.protocol.probe.timeout)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use hopr_lib;
 #[cfg(feature = "blokli")]
 pub use blokli::*;
 pub use hopr_chain_connector::BlockchainConnectorConfig;
+pub use hopr_lib::exports::transport::path::PathPlannerConfig;
 
 #[cfg(feature = "runtime-tokio")]
 pub use client::*;


### PR DESCRIPTION
## Summary

- Pin hoprnet deps to `kauki/fix/transport/stream-egress-hol-blocking` branch (HOL-blocking fix, hoprnet#8202)
- Rebase on hoprnet#8204 (non-blocking flume drop-oldest ring buffer for per-peer egress)
- Remove `probe_connected_only: false` override from prober config
- Propagate `hopr-transport-p2p/runtime-tokio` to fix startup panic (`InactiveNetwork::build` requires runtime-tokio)
- Propagate `hopr-transport-p2p/transport-quic` to enable `libp2p/quic` — without this all quic-v1 multiaddr dials fail with `MultiaddrNotSupported`
- Re-export `PathPlannerConfig` at the `edgli` crate root so consumers can override `cfg.protocol.path_planner` (e.g. `latency_halflife`) before calling `Edgli::new()` without a direct hoprnet dependency

Depends on: https://github.com/hoprnet/hoprnet/pull/8202, https://github.com/hoprnet/hoprnet/pull/8204