### PR TITLE
refactor(deps): migrate hopr-reference → hopr-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,8 +2525,10 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-lib",
- "hopr-reference",
+ "hopr-network-graph",
  "hopr-strategy",
+ "hopr-ticket-manager",
+ "hopr-transport-p2p",
  "lazy_static",
  "mimalloc",
  "nix 0.29.0",
@@ -3485,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3515,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3538,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3555,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3566,18 +3568,28 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
+ "hex-literal",
  "hopr-api",
+ "hopr-chain-connector",
+ "hopr-ct-full-network",
+ "hopr-network-graph",
+ "hopr-session-server-forwarder",
+ "hopr-ticket-manager",
  "hopr-transport",
+ "hopr-transport-p2p",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
+ "rand 0.10.1",
+ "rstest",
  "serde",
  "serde_with",
  "smart-default",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "validator",
 ]
@@ -3585,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3602,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3615,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3645,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3676,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3689,20 +3701,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-reference"
-version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+name = "hopr-session-server-forwarder"
+version = "0.1.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
- "anyhow",
- "futures",
+ "async-trait",
  "hopr-api",
- "hopr-chain-connector",
- "hopr-ct-full-network",
- "hopr-lib",
- "hopr-network-graph",
- "hopr-ticket-manager",
- "hopr-transport-p2p",
+ "hopr-transport-session",
+ "hopr-utils",
+ "serde",
+ "serde_with",
+ "smart-default",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-retry",
  "tracing",
  "validator",
 ]
@@ -3710,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3734,8 +3746,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+version = "0.5.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3756,8 +3768,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+version = "0.28.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3798,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3815,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3834,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3859,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3892,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3959,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -6462,6 +6474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6585,6 +6603,35 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -7700,6 +7747,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
   "runtime-tokio",
 ] }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
+hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,20 +66,20 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
   "runtime-tokio",
 ] }
-hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
-  "runtime-tokio",
-] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
   "strategy-channel-lifecycle",
 ] }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ opentelemetry_sdk = { version = "0.31.0", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
   "runtime-tokio",
 ] }
-hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
+hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
   "strategy-channel-lifecycle",
 ] }
 
@@ -88,7 +88,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use hopr_lib::api::{
 };
 use hopr_lib::builder::{ChainKeypair, Keypair, OffchainKeypair};
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
-use hopr_reference::build_edge_with_chain;
+use hopr_node::build_edge_with_chain;
 use strum::{AsRefStr, Display, EnumString};
 use tracing::info;
 
@@ -23,7 +23,7 @@ use crate::errors::EdgliError;
 use crate::new_blokli_client;
 
 /// The concrete HOPR edge node type used by this client.
-pub type HoprEdgeClient = hopr_reference::EdgeHopr;
+pub type HoprEdgeClient = hopr_node::EdgeHopr;
 
 /// Represents the initialization states of the Edgli client.
 /// Each state corresponds to a step in the `new()` function.
@@ -179,7 +179,7 @@ impl Edgli {
         };
 
         visitor(EdgliInitState::CreatingNode);
-        info!("Building HOPR edge node via hopr-reference");
+        info!("Building HOPR edge node via hopr-node");
 
         visitor(EdgliInitState::StartingNode);
         let node = build_edge_with_chain(

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,7 +27,11 @@ use crate::new_blokli_client;
 
 /// The concrete HOPR edge node type used by this client.
 pub type HoprEdgeClient = hopr_lib::Hopr<
-    Arc<hopr_chain_connector::HoprBlockchainSafeConnector<hopr_chain_connector::blokli_client::BlokliClient>>,
+    Arc<
+        hopr_chain_connector::HoprBlockchainSafeConnector<
+            hopr_chain_connector::blokli_client::BlokliClient,
+        >,
+    >,
     SharedChannelGraph,
     HoprNetwork,
     (),
@@ -221,14 +225,16 @@ impl Edgli {
                 .with_graph(move |_ctx| graph)
                 .with_network(move |ctx| {
                     Box::pin(async move {
-                        let peer_discovery_rx = ctx
-                            .take_peer_discovery_rx()
-                            .ok_or(hopr_lib::errors::HoprLibError::BuilderError(
+                        let peer_discovery_rx = ctx.take_peer_discovery_rx().ok_or(
+                            hopr_lib::errors::HoprLibError::BuilderError(
                                 "peer_discovery_rx already taken",
-                            ))?;
-                        let multiaddresses = vec![(&ctx.cfg.host)
-                            .try_into()
-                            .map_err(hopr_lib::errors::HoprLibError::TransportError)?];
+                            ),
+                        )?;
+                        let multiaddresses = vec![
+                            (&ctx.cfg.host)
+                                .try_into()
+                                .map_err(hopr_lib::errors::HoprLibError::TransportError)?,
+                        ];
                         let nb = HoprLibp2pNetworkBuilder::new(
                             peer_discovery_rx
                                 .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use futures::StreamExt;
 use futures::future::{AbortHandle, abortable};
 use hopr_chain_connector::{BlockchainConnectorConfig, create_trustful_hopr_blokli_connector};
 use hopr_ct_full_network::ProberConfig as FullNetworkProberConfig;
@@ -13,9 +14,11 @@ use hopr_lib::api::{
         primitive::prelude::{Address, HoprBalance},
     },
 };
-use hopr_lib::builder::{ChainKeypair, Keypair, OffchainKeypair};
+use hopr_lib::builder::{ChainKeypair, HoprBuilder, Keypair, OffchainKeypair};
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
-use hopr_node::build_edge_with_chain;
+use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
+use hopr_ticket_manager::ticket_factory_from_chain;
+use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
 use strum::{AsRefStr, Display, EnumString};
 use tracing::info;
 
@@ -23,7 +26,12 @@ use crate::errors::EdgliError;
 use crate::new_blokli_client;
 
 /// The concrete HOPR edge node type used by this client.
-pub type HoprEdgeClient = hopr_node::EdgeHopr;
+pub type HoprEdgeClient = hopr_lib::Hopr<
+    Arc<hopr_chain_connector::HoprBlockchainSafeConnector<hopr_chain_connector::blokli_client::BlokliClient>>,
+    SharedChannelGraph,
+    HoprNetwork,
+    (),
+>;
 
 /// Represents the initialization states of the Edgli client.
 /// Each state corresponds to a step in the `new()` function.
@@ -179,25 +187,72 @@ impl Edgli {
         };
 
         visitor(EdgliInitState::CreatingNode);
-        info!("Building HOPR edge node via hopr-node");
+        info!("Building HOPR edge node directly via HoprBuilder");
+
+        let probe_cfg = FullNetworkProberConfig {
+            interval: std::time::Duration::from_secs(3),
+            shuffle_ttl: std::time::Duration::from_secs(3),
+            probe_connected_only: false,
+            ..Default::default()
+        };
+        probe_cfg.validate_against_probe_timeout(cfg.protocol.probe.timeout)?;
+
+        let ticket_factory = ticket_factory_from_chain(&chain_connector)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to seed ticket factory: {e}"))?;
+
+        let path_cfg = cfg.protocol.path_planner;
+        let graph: SharedChannelGraph = Arc::new(ChannelGraph::with_edge_params(
+            *packet_key.public(),
+            path_cfg.edge_penalty,
+            path_cfg.min_ack_rate,
+        ));
+        let graph_for_ct = graph.clone();
+        let safe_address = cfg.safe_module.safe_address;
+        let module_address = cfg.safe_module.module_address;
 
         visitor(EdgliInitState::StartingNode);
-        let node = build_edge_with_chain(
-            chain_key,
-            packet_key,
-            cfg,
-            // Probe all graph nodes every 3 s regardless of connection state.
-            // At startup no peers are `Connected(true)` yet, so `probe_connected_only: true`
-            // (the library default) would send no probes and stall graph convergence.
-            Some(FullNetworkProberConfig {
-                interval: std::time::Duration::from_secs(3),
-                shuffle_ttl: std::time::Duration::from_secs(3),
-                probe_connected_only: false,
-                ..Default::default()
-            }),
-            chain_connector,
-        )
-        .await?;
+        let node = Arc::new(
+            HoprBuilder
+                .with_identity(chain_key, packet_key)
+                .with_config(cfg)
+                .with_safe_module(&safe_address, &module_address)
+                .with_chain_api(move |_ctx| chain_connector)
+                .with_graph(move |_ctx| graph)
+                .with_network(move |ctx| {
+                    Box::pin(async move {
+                        let peer_discovery_rx = ctx
+                            .take_peer_discovery_rx()
+                            .ok_or(hopr_lib::errors::HoprLibError::BuilderError(
+                                "peer_discovery_rx already taken",
+                            ))?;
+                        let multiaddresses = vec![(&ctx.cfg.host)
+                            .try_into()
+                            .map_err(hopr_lib::errors::HoprLibError::TransportError)?];
+                        let nb = HoprLibp2pNetworkBuilder::new(
+                            peer_discovery_rx
+                                .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
+                        );
+                        nb.build(
+                            &ctx.packet_key,
+                            multiaddresses,
+                            "/hopr/mix/1.1.0",
+                            ctx.cfg.protocol.transport.prefer_local_addresses,
+                        )
+                        .await
+                        .map_err(|e| hopr_lib::errors::HoprLibError::GeneralError(e.to_string()))
+                    })
+                })
+                .with_cover_traffic(move |ctx| {
+                    hopr_ct_full_network::FullNetworkDiscovery::new(
+                        *ctx.packet_key.public(),
+                        probe_cfg,
+                        graph_for_ct,
+                    )
+                })
+                .build_edge(ticket_factory)
+                .await?,
+        );
 
         visitor(EdgliInitState::Ready);
         Ok(Self {


### PR DESCRIPTION
Adapts to call `HoprBuilder` directly (deleted in hoprnet/hoprnet#8176). Bumps the hoprnet rev accordingly.

**Depends on:** hoprnet/hoprnet#8174, hoprnet/hoprnet#8175, hoprnet/hoprnet#8176