### PR TITLE
feat: filter out locall addresses for node annoucements by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
+checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
+checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
+checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -262,22 +262,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -298,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
+checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -338,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -353,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
+checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -379,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -392,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f2f7dac66147d165063c670dabca7b34807428130bef4583a7976523140f8d"
+checksum = "2ab58d45ceaabba867fc05f018f58e4640df2e6424b4c759d45f66cf075ad8fe"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -442,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
+checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -505,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -528,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
+checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -540,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
+checksum = "9f89d27756bf3effdac25d07692724e840ce90ca1ff956a6b47dd2ae1612f597"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -552,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
+checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -567,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
+checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -599,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -614,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
+checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -703,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -726,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
+checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -758,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1044,9 +1045,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -1463,9 +1464,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -1645,9 +1646,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2098,15 +2099,16 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossfire"
-version = "3.1.16"
+version = "3.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
+checksum = "111ce8f7abfbac38b4bc4f32a3a2dda1a8034b873c90c7899f302cc9dbbc05ec"
 dependencies = [
  "crossbeam-utils",
- "embed-collections",
  "futures-core",
  "parking_lot",
+ "pointers",
  "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -2321,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2551,10 +2553,11 @@ dependencies = [
  "hopr-transport-p2p",
  "lazy_static",
  "mimalloc",
+ "multiaddr",
  "nix 0.31.3",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "rand 0.10.2",
  "reqwest",
  "serde",
@@ -2614,12 +2617,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "embed-collections"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
 
 [[package]]
 name = "embedded-io"
@@ -3033,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
  "gloo-timers",
 ]
@@ -3145,9 +3142,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3458,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6e98ff52f636edc8e3d76844831dfd53cd92146488cc721c0f7bb837fd8052"
+checksum = "e3161efd861baef8d2ca18cddf9fe8699ad36d737635132ce41486a28c2d0c89"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3479,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.8.0"
+version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e63087ec94960a191199c4392a30895694a88de04ad5b23804733b729251b"
+checksum = "1afa8766e3b7c9ac7f770e5330bb08f91af6db385a1b388239814fc03f7c171a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3497,8 +3494,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.22.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3529,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3552,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3569,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3608,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3627,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3640,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3669,8 +3666,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3701,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3716,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3742,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3763,8 +3760,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.31.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.32.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3805,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3822,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3835,19 +3832,20 @@ dependencies = [
  "libp2p-stream",
  "multiaddr",
  "pin-project",
- "quinn-udp",
+ "quinn-udp 0.6.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.8.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
  "const-hex",
+ "crossfire",
  "futures",
  "futures-concurrency",
  "hopr-api",
@@ -3867,11 +3865,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.23.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
+ "crossfire",
  "flagset",
  "futures",
  "futures-time",
@@ -3899,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3910,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
+checksum = "c842b389c9b2b84349733cb67712ae0699f6a6b756670e742206cd7ac447acd2"
 dependencies = [
  "aes",
  "anyhow",
@@ -3938,9 +3937,9 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "num_enum",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "poly1305",
  "primitive-types 0.14.0",
  "rand 0.10.2",
@@ -3966,11 +3965,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-utils"
-version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.2.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "arrayvec",
  "auto_impl",
+ "crossfire",
  "flume",
  "futures",
  "futures-time",
@@ -3986,7 +3986,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
@@ -4131,7 +4131,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4437,7 +4437,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -5002,7 +5002,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
 ]
@@ -5525,20 +5525,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -5560,7 +5546,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -5571,10 +5557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror 2.0.18",
@@ -5585,12 +5571,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897906366b17a89bec845f6051e0c3474049402a09a0711eea180941293bd013"
+checksum = "b4fe57ea90b12f643a366aa7c4fa5cfb54bd1cf252f55368337e40534b278a68"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smartstring",
 ]
 
@@ -5600,26 +5586,11 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.32.0",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
  "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5631,7 +5602,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -5850,6 +5821,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pointers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcdc93847ad24990939cce6e1804361e903efcb5f99daa5abd87943a9d6d7ba"
 
 [[package]]
 name = "polling"
@@ -6153,10 +6130,10 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6194,9 +6171,21 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.5.10",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7215,9 +7204,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -7273,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -7630,7 +7619,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -7733,7 +7722,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ cfg-if = "1.0.4"
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 console-subscriber = { version = "0.5.0", optional = true }
 futures = "0.3.32"
+multiaddr = "0.18.2"
 lazy_static = "1.5.0"
 signal-hook = "0.4.4"
 serde_yaml = { version = "0.9.34" }
@@ -71,20 +72,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -93,7 +94,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/README.md
+++ b/README.md
@@ -37,17 +37,16 @@ Embed the client by constructing an `Edgli` instance. Initialization is reported
 through a visitor callback that receives `EdgliInitState` transitions.
 
 ```rust
-use std::path::Path;
-
 use edgli::{Edgli, EdgliInitState, hopr_lib::{HoprKeys, config::HoprLibConfig}};
 
-async fn run(cfg: HoprLibConfig, db: &Path, keys: HoprKeys) -> anyhow::Result<()> {
+async fn run(cfg: HoprLibConfig, keys: HoprKeys) -> anyhow::Result<()> {
     let edgli = Edgli::new(
         cfg,
-        db,
         keys,
-        None, // blokli URL (optional)
-        None, // BlockchainConnectorConfig (optional)
+        None,  // blokli URL (optional)
+        None,  // blokli DNS override (optional)
+        None,  // BlockchainConnectorConfig (optional)
+        false, // probe_local_addresses: filter non-public peer addresses
         |state: EdgliInitState| tracing::info!(?state, "init"),
     )
     .await?;
@@ -132,9 +131,9 @@ Key inputs handed to `Edgli::new`:
 - **Loopback address rejected.** `Edgli::new` refuses to announce a loopback
   host unless `protocol.transport.prefer_local_addresses = true`.
 - **Local peers not probed.** By default non-public (private, loopback,
-  link-local) peer addresses from announcements are filtered before dialing. Pass
-  `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or the
-  `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
+  link-local) peer addresses from announcements are filtered before dialing.
+  Pass `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or
+  the `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
   same-host test cluster).
 - **Profiling.** Build with
   `RUSTFLAGS="--cfg tokio_unstable" cargo build --features prof` and attach

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Key inputs handed to `Edgli::new`:
   when `RUST_LOG` is unset.
 - **Loopback address rejected.** `Edgli::new` refuses to announce a loopback
   host unless `protocol.transport.prefer_local_addresses = true`.
+- **Local peers not probed.** By default private/local (RFC-1918) peer
+  addresses from announcements are filtered before dialing. Pass
+  `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or the
+  `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
+  same-host test cluster).
 - **Profiling.** Build with
   `RUSTFLAGS="--cfg tokio_unstable" cargo build --features prof` and attach
   `tokio-console`.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Key inputs handed to `Edgli::new`:
   when `RUST_LOG` is unset.
 - **Loopback address rejected.** `Edgli::new` refuses to announce a loopback
   host unless `protocol.transport.prefer_local_addresses = true`.
-- **Local peers not probed.** By default private/local (RFC-1918) peer
-  addresses from announcements are filtered before dialing. Pass
+- **Local peers not probed.** By default non-public (private, loopback,
+  link-local) peer addresses from announcements are filtered before dialing. Pass
   `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or the
   `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
   same-host test cluster).

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,10 +20,10 @@ use hopr_lib::api::{
 use hopr_lib::builder::{ChainKeypair, HoprBuilder, Keypair, OffchainKeypair};
 use hopr_lib::exports::network::types::addr::is_public_address;
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
-use multiaddr::Multiaddr;
 use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
 use hopr_ticket_manager::ticket_factory_from_chain;
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
+use multiaddr::Multiaddr;
 use strum::{AsRefStr, Display, EnumString};
 use tracing::info;
 
@@ -599,6 +599,8 @@ mod tests {
             ma("/ip4/192.168.1.5/tcp/9091"),
             ma("/ip4/10.0.0.2/tcp/9091"),
             ma("/ip4/127.0.0.1/tcp/9091"),
+            ma("/ip6/::1/tcp/9091"),
+            ma("/ip6/fc00::1/tcp/9091"),
         ];
 
         assert_eq!(probeable_addresses(addrs, false), vec![public]);
@@ -610,6 +612,8 @@ mod tests {
             ma("/ip4/8.8.8.8/tcp/9091"),
             ma("/ip4/192.168.1.5/tcp/9091"),
             ma("/ip4/127.0.0.1/tcp/9091"),
+            ma("/ip6/::1/tcp/9091"),
+            ma("/ip6/fc00::1/tcp/9091"),
         ];
 
         assert_eq!(probeable_addresses(addrs.clone(), true), addrs);
@@ -620,6 +624,8 @@ mod tests {
         let addrs = vec![
             ma("/ip4/192.168.1.5/tcp/9091"),
             ma("/ip4/10.0.0.2/tcp/9091"),
+            ma("/ip6/::1/tcp/9091"),
+            ma("/ip6/fc00::1/tcp/9091"),
         ];
 
         assert!(probeable_addresses(addrs, false).is_empty());

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,7 +18,9 @@ use hopr_lib::api::{
     },
 };
 use hopr_lib::builder::{ChainKeypair, HoprBuilder, Keypair, OffchainKeypair};
+use hopr_lib::exports::network::types::addr::is_public_address;
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
+use multiaddr::Multiaddr;
 use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
 use hopr_ticket_manager::ticket_factory_from_chain;
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
@@ -110,6 +112,19 @@ pub enum EdgliInitState {
     Ready,
 }
 
+/// Filters an announcement's multiaddresses down to those worth dialing.
+///
+/// Private/local (RFC-1918, loopback, link-local) peer addresses are dropped
+/// unless `probe_local_addresses` is set, in which case local addresses are
+/// dialed too.
+fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Vec<Multiaddr> {
+    if probe_local_addresses {
+        addrs
+    } else {
+        addrs.into_iter().filter(is_public_address).collect()
+    }
+}
+
 /// Spawns an abortable task that drives a user-supplied closure over the running node.
 ///
 /// Returns an [`AbortHandle`] that stops the closure task when aborted.
@@ -121,6 +136,7 @@ pub async fn run_hopr_edge_node_with<F, T>(
     blokli_url: Option<String>,
     blokli_dns_override: Option<(IpAddr, Option<u16>)>,
     blokli_connector_config: Option<BlockchainConnectorConfig>,
+    probe_local_addresses: bool,
     f: F,
     visitor: impl Fn(EdgliInitState) + Send + 'static,
 ) -> anyhow::Result<AbortHandle>
@@ -134,6 +150,7 @@ where
         blokli_url,
         blokli_dns_override,
         blokli_connector_config,
+        probe_local_addresses,
         visitor,
     )
     .await?;
@@ -180,6 +197,9 @@ impl Edgli {
     /// * `blokli_url` – optional Blokli client URL; defaults to the production endpoint
     /// * `blokli_dns_override` – optional DNS override for the Blokli client
     /// * `blokli_connector_config` – optional connector config overrides
+    /// * `probe_local_addresses` – when `true`, probe private/local (RFC-1918)
+    ///   peer addresses from announcements; when `false` (default) they are
+    ///   filtered out before dialing
     /// * `visitor` – called at each [`EdgliInitState`] transition for progress reporting
     pub async fn new(
         cfg: HoprLibConfig,
@@ -187,6 +207,7 @@ impl Edgli {
         blokli_url: Option<String>,
         blokli_dns_override: Option<(IpAddr, Option<u16>)>,
         blokli_connector_config: Option<BlockchainConnectorConfig>,
+        probe_local_addresses: bool,
         visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> anyhow::Result<Self> {
         visitor(EdgliInitState::ValidatingConfig);
@@ -275,10 +296,14 @@ impl Edgli {
                                 .try_into()
                                 .map_err(hopr_lib::errors::HoprLibError::TransportError)?,
                         ];
-                        let nb = HoprLibp2pNetworkBuilder::new(
-                            peer_discovery_rx
-                                .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
-                        );
+                        let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx.map(
+                            move |(peer_id, addrs)| {
+                                PeerDiscovery::Announce(
+                                    peer_id,
+                                    probeable_addresses(addrs, probe_local_addresses),
+                                )
+                            },
+                        ));
                         nb.build(
                             &ctx.packet_key,
                             multiaddresses,
@@ -560,5 +585,49 @@ mod tests {
             error.to_string(),
             "configuration error: 'invalid Blokli URL 'not a url': relative URL without a base'"
         );
+    }
+
+    fn ma(s: &str) -> Multiaddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn probeable_addresses_filters_local_by_default() {
+        let public = ma("/ip4/8.8.8.8/tcp/9091");
+        let addrs = vec![
+            public.clone(),
+            ma("/ip4/192.168.1.5/tcp/9091"),
+            ma("/ip4/10.0.0.2/tcp/9091"),
+            ma("/ip4/127.0.0.1/tcp/9091"),
+        ];
+
+        assert_eq!(probeable_addresses(addrs, false), vec![public]);
+    }
+
+    #[test]
+    fn probeable_addresses_keeps_all_when_probing_local() {
+        let addrs = vec![
+            ma("/ip4/8.8.8.8/tcp/9091"),
+            ma("/ip4/192.168.1.5/tcp/9091"),
+            ma("/ip4/127.0.0.1/tcp/9091"),
+        ];
+
+        assert_eq!(probeable_addresses(addrs.clone(), true), addrs);
+    }
+
+    #[test]
+    fn probeable_addresses_drops_all_local_to_empty() {
+        let addrs = vec![
+            ma("/ip4/192.168.1.5/tcp/9091"),
+            ma("/ip4/10.0.0.2/tcp/9091"),
+        ];
+
+        assert!(probeable_addresses(addrs, false).is_empty());
+    }
+
+    #[test]
+    fn probeable_addresses_empty_input() {
+        assert!(probeable_addresses(vec![], false).is_empty());
+        assert!(probeable_addresses(vec![], true).is_empty());
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -130,6 +130,7 @@ fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Ve
 /// Returns an [`AbortHandle`] that stops the closure task when aborted.
 /// `Edgli` is kept alive for the entire duration of `f` so that background tasks
 /// remain active until `f` completes or the returned [`AbortHandle`] is used to cancel it.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_hopr_edge_node_with<F, T>(
     cfg: HoprLibConfig,
     hopr_keys: HoprKeys,

--- a/src/client.rs
+++ b/src/client.rs
@@ -114,9 +114,9 @@ pub enum EdgliInitState {
 
 /// Filters an announcement's multiaddresses down to those worth dialing.
 ///
-/// Private/local (RFC-1918, loopback, link-local) peer addresses are dropped
-/// unless `probe_local_addresses` is set, in which case local addresses are
-/// dialed too.
+/// Non-public peer addresses (private, loopback, link-local, unspecified) are
+/// dropped unless `probe_local_addresses` is set, in which case local addresses
+/// are dialed too.
 fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Vec<Multiaddr> {
     if probe_local_addresses {
         addrs
@@ -197,9 +197,9 @@ impl Edgli {
     /// * `blokli_url` – optional Blokli client URL; defaults to the production endpoint
     /// * `blokli_dns_override` – optional DNS override for the Blokli client
     /// * `blokli_connector_config` – optional connector config overrides
-    /// * `probe_local_addresses` – when `true`, probe private/local (RFC-1918)
-    ///   peer addresses from announcements; when `false` (default) they are
-    ///   filtered out before dialing
+    /// * `probe_local_addresses` – when `true`, probe non-public (private,
+    ///   loopback, link-local) peer addresses from announcements; when `false`
+    ///   (default) they are filtered out before dialing
     /// * `visitor` – called at each [`EdgliInitState`] transition for progress reporting
     pub async fn new(
         cfg: HoprLibConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,11 @@ pub struct CliArgs {
     )]
     pub blokli_dns_override: Option<(IpAddr, Option<u16>)>,
 
-    /// Probe private/local (RFC-1918) peer addresses from announcements
+    /// Probe non-public (private, loopback, link-local) peer addresses from announcements
     #[arg(
         long,
         env = "HOPR_EDGE_PROBE_LOCAL_ADDRESSES",
-        help = "Probe private/local peer addresses received in announcements (default: filtered out)",
+        help = "Probe non-public (private/loopback/link-local) peer addresses received in announcements (default: filtered out)",
         default_value_t = false
     )]
     pub probe_local_addresses: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,15 @@ pub struct CliArgs {
         required = false
     )]
     pub blokli_dns_override: Option<(IpAddr, Option<u16>)>,
+
+    /// Probe private/local (RFC-1918) peer addresses from announcements
+    #[arg(
+        long,
+        env = "HOPR_EDGE_PROBE_LOCAL_ADDRESSES",
+        help = "Probe private/local peer addresses received in announcements (default: filtered out)",
+        default_value_t = false
+    )]
+    pub probe_local_addresses: bool,
 }
 
 fn init_logger() -> anyhow::Result<()> {
@@ -233,6 +242,7 @@ async fn main() -> anyhow::Result<()> {
         args.blokli_url,
         args.blokli_dns_override,
         None,
+        args.probe_local_addresses,
         |s| {
             info!(?s, "Initialization stage");
         },

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -91,6 +91,10 @@ pub struct EdgliTuning {
     /// on a same-host cluster.
     pub prefer_local_addresses: bool,
     pub announce_local: bool,
+    /// Whether to probe private/local peer addresses received in announcements.
+    /// True only on a same-host cluster, where peers reach each other over
+    /// RFC-1918 addresses.
+    pub probe_local: bool,
     /// Channel-lifecycle strategy tick interval.
     pub strategy_tick: Duration,
     /// Channel-lifecycle selection policy.  Determines which peers qualify for
@@ -135,6 +139,7 @@ impl EdgliTuning {
             },
             prefer_local_addresses: true,
             announce_local: true,
+            probe_local: true,
             strategy_tick: Duration::from_secs(10),
             selector: SelectorProfile::LowLatency,
             channel_open_timeout: Duration::from_secs(120),
@@ -150,6 +155,7 @@ impl EdgliTuning {
             connector_cfg: BlockchainConnectorConfig::default(),
             prefer_local_addresses: false,
             announce_local: false,
+            probe_local: false,
             strategy_tick: Duration::from_secs(30),
             // Rotsee peers have ~150-200 ms RTT; latency_score caps at 0.3 for
             // that range, so even a perfect probe rate yields at most 0.30.
@@ -1118,6 +1124,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         Some(summary.blokli_url.clone()),
         None,
         Some(tuning.connector_cfg),
+        tuning.probe_local,
         |s: EdgliInitState| tracing::info!(?s, "edgli init"),
     )
     .await?;


### PR DESCRIPTION
This PR changes edge client default behaviour. By default now node announcements will not contain local network addresses.
This functionality can be overridden, if local addresses are expected by:
- `--probe-local-addresses`, or
- `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`

Besides that, this PR bumps hoprnet to newest version

Tested locally with edge client + localcuster, and IPs set to 127.0.0.1