### PR TITLE
chore: enable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended",
     "schedule:earlyMondays",
     "group:allNonMajor",
-    "group:allDigest",
+    "group:allDigest"
   ],
   "prCreation": "not-pending",
   "semanticCommits": "enabled",

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     "schedule:earlyMondays",
     "group:allNonMajor",
     "group:allDigest",
-    ":disableDependencyDashboard"
   ],
   "prCreation": "not-pending",
   "semanticCommits": "enabled",


### PR DESCRIPTION
This is to manually check why nix flakes are not updated by renovate