### PR TITLE
Em/repro session crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "aes-gcm"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
+ "aes 0.8.4",
  "cipher 0.4.4",
- "ctr",
+ "ctr 0.9.2",
  "ghash",
  "subtle",
 ]
@@ -145,7 +156,7 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
- "k256",
+ "k256 0.13.4",
  "once_cell",
  "rand 0.8.6",
  "secp256k1 0.30.0",
@@ -255,7 +266,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
- "k256",
+ "k256 0.13.4",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -403,7 +414,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "k256",
+ "k256 0.13.4",
  "libc",
  "rand 0.8.6",
  "serde_json",
@@ -428,7 +439,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
- "k256",
+ "k256 0.13.4",
  "keccak-asm",
  "paste",
  "proptest",
@@ -608,8 +619,8 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
- "k256",
+ "elliptic-curve 0.13.8",
+ "k256 0.13.4",
  "thiserror 2.0.18",
 ]
 
@@ -624,7 +635,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
- "k256",
+ "k256 0.13.4",
  "rand 0.8.6",
  "thiserror 2.0.18",
 ]
@@ -849,6 +860,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1018,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,10 +1059,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1351,6 +1421,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "babyjubjub-ec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e657c11493f07dd18f0c6055b58e77ca71e30ed34f2804468b22f89e36dc0a"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "elliptic-curve 0.14.1",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hash2curve",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serde",
+ "serdect 0.4.3",
+ "sha2 0.11.0",
+ "subtle",
+ "taceo-ark-babyjubjub",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1463,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base256emoji"
@@ -1485,17 +1583,17 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1533,7 +1631,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hex",
- "hopr-types",
+ "hopr-types 1.11.2",
  "http",
  "indexmap 2.14.0",
  "launchdarkly-sdk-transport",
@@ -1716,11 +1814,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -1734,7 +1833,7 @@ dependencies = [
  "aead",
  "chacha20 0.9.1",
  "cipher 0.4.4",
- "poly1305",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -1765,12 +1864,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -2016,6 +2115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2235,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,11 +2263,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2159,12 +2282,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -2177,8 +2310,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
- "rand_core 0.6.4",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version 0.4.1",
  "serde",
  "subtle",
@@ -2372,6 +2521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,13 +2611,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2497,13 +2656,29 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "serdect 0.2.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "serdect 0.4.3",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2512,9 +2687,19 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "serde",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "serdect 0.4.3",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -2523,12 +2708,28 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "merlin",
- "rand_core 0.6.4",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "keccak",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "strobe-rs",
  "subtle",
  "zeroize",
 ]
@@ -2551,6 +2752,7 @@ dependencies = [
  "hopr-strategy",
  "hopr-ticket-manager",
  "hopr-transport-p2p",
+ "hopr-types 2.0.0",
  "lazy_static",
  "mimalloc",
  "multiaddr",
@@ -2603,17 +2805,38 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array 0.14.7",
- "group",
- "hkdf",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.3",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
+ "serdect 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -2791,10 +3014,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -3078,7 +3317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
- "serde_core",
  "typenum",
  "zeroize",
 ]
@@ -3158,8 +3396,20 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -3203,6 +3453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash2curve"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf40612d7d854743e7189228a6d528f0f6e8502cf6a0cb831d28a218b7f3f6"
+dependencies = [
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3480,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.1.5",
  "rayon",
 ]
@@ -3436,6 +3697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,14 +3720,14 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "hopr-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3161efd861baef8d2ca18cddf9fe8699ad36d737635132ce41486a28c2d0c89"
+checksum = "8c76f9c17f903a3a0487c7eb0766914baf94380cd7a9112043310e4bc4dc9547"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3465,7 +3735,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-concurrency",
- "hopr-types",
+ "hopr-types 2.0.0",
  "libp2p-identity",
  "multiaddr",
  "serde",
@@ -3495,7 +3765,6 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3526,30 +3795,23 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "bimap",
  "const-hex",
- "curve25519-dalek",
- "elliptic-curve",
  "flagset",
- "generic-array 1.4.3",
- "hopr-types",
+ "hopr-types 2.0.0",
  "hopr-utils",
- "k256",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
  "subtle",
  "thiserror 2.0.18",
  "tracing",
- "typenum",
 ]
 
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3566,7 +3828,6 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3605,7 +3866,6 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3624,10 +3884,9 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "hopr-crypto-packet",
- "hopr-types",
+ "hopr-types 2.0.0",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3637,7 +3896,6 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3666,8 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
+version = "1.2.2"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3680,7 +3937,7 @@ dependencies = [
  "futures-time",
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
- "hopr-types",
+ "hopr-types 2.0.0",
  "hopr-utils",
  "lazy_static",
  "parking_lot",
@@ -3698,7 +3955,6 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3713,7 +3969,6 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3994,6 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3761,7 +4015,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3802,11 +4055,10 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "futures",
  "futures-timer",
- "hopr-types",
+ "hopr-types 2.0.0",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3819,7 +4071,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3840,7 +4091,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3865,8 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3898,7 +4147,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3909,30 +4157,80 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.9.3"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c842b389c9b2b84349733cb67712ae0699f6a6b756670e742206cd7ac447acd2"
+checksum = "ffe8de530de5d86e896cc67ffa9b57496626d381112442800b18cd7b41e440c4"
 dependencies = [
- "aes",
+ "aes 0.9.1",
+ "aquamarine",
+ "arrayvec",
+ "async-trait",
+ "babyjubjub-ec",
+ "bigdecimal",
+ "blake3",
+ "chacha20 0.10.1",
+ "chrono",
+ "cipher 0.5.2",
+ "const-hex",
+ "ctr 0.10.1",
+ "curve25519-dalek 5.0.0",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0",
+ "float-cmp",
+ "generic-array 1.4.3",
+ "hash2curve",
+ "hex-literal",
+ "k256 0.14.0",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "num_enum",
+ "poly1305 0.9.1",
+ "primitive-types 0.14.0",
+ "rand 0.10.2",
+ "rayon",
+ "regex",
+ "secp256k1 0.31.1",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "smart-default",
+ "strum 0.28.0",
+ "subtle",
+ "thiserror 2.0.18",
+ "tracing",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "hopr-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24293a5ce7289056c4e01b8d91beebc8663cdcca8ffbc24d847f3f22af4f274"
+dependencies = [
+ "aes 0.9.1",
  "anyhow",
  "aquamarine",
  "arrayvec",
  "async-trait",
+ "babyjubjub-ec",
  "bigdecimal",
  "blake3",
- "chacha20 0.9.1",
+ "chacha20 0.10.1",
  "chrono",
- "cipher 0.4.4",
+ "cipher 0.5.2",
  "const-hex",
- "ctr",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-dalek",
+ "ctr 0.10.1",
+ "curve25519-dalek 5.0.0",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0",
+ "elliptic-curve 0.14.1",
  "float-cmp",
- "generic-array 1.4.3",
+ "hash2curve",
  "hex-literal",
  "hopr-bindings",
- "k256",
+ "hybrid-array",
+ "k256 0.14.0",
  "lazy_static",
  "libp2p-identity",
  "multiaddr",
@@ -3940,19 +4238,20 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
  "opentelemetry_sdk",
- "poly1305",
+ "poly1305 0.9.1",
  "primitive-types 0.14.0",
  "rand 0.10.2",
  "rayon",
  "regex",
+ "rlp 0.6.1",
  "scrypt",
  "secp256k1 0.31.1",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_with",
- "sha2 0.10.9",
- "sha3 0.10.9",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
  "smart-default",
  "strum 0.28.0",
  "subtle",
@@ -3966,7 +4265,6 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -3975,7 +4273,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hickory-resolver 0.26.1",
- "hopr-types",
+ "hopr-types 2.0.0",
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
@@ -4057,11 +4355,14 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "serde",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -4131,7 +4432,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4580,21 +4881,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
- "signature",
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.6"
+name = "k256"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpubits",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "hash2curve",
+ "primeorder",
+ "serdect 0.4.3",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -4835,8 +5143,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
- "ed25519-dalek",
- "hkdf",
+ "ed25519-dalek 2.2.0",
+ "hkdf 0.12.4",
  "multihash",
  "prost",
  "rand 0.8.6",
@@ -5173,18 +5481,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak 0.1.6",
- "rand_core 0.6.4",
- "zeroize",
-]
 
 [[package]]
 name = "mimalloc"
@@ -5711,7 +6007,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
  "hmac 0.13.0",
 ]
 
@@ -5812,8 +6108,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -5850,7 +6156,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -5862,7 +6178,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -5926,6 +6242,33 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect 0.4.3",
+ "wnaf",
 ]
 
 [[package]]
@@ -6133,7 +6476,7 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6171,7 +6514,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6184,7 +6527,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6244,7 +6587,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.1",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -6385,9 +6728,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6484,6 +6827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6508,6 +6861,16 @@ name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -6581,7 +6944,7 @@ dependencies = [
  "proptest",
  "rand 0.8.6",
  "rand 0.9.4",
- "rlp",
+ "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -6775,7 +7138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -6845,11 +7208,26 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
+ "serdect 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -7067,7 +7445,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -7090,17 +7478,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7109,8 +7487,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -7166,6 +7555,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7242,7 +7641,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.1",
@@ -7286,8 +7685,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -7300,6 +7715,19 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strobe-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83561175f0a962dea437885589480d216d8741debf853e0d36edd526344fd273"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "keccak",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "strsim"
@@ -7434,6 +7862,18 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "taceo-ark-babyjubjub"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b5a2cc31c90e79778c4f6375e5d9828171d320db3f8c911a8ad47af4a70069"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -7960,6 +8400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8010,9 +8460,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8655,6 +9105,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8675,7 +9136,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -8825,18 +9286,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
+checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
+checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
+checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -262,22 +262,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -298,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
+checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -338,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -353,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
+checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -379,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -392,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f2f7dac66147d165063c670dabca7b34807428130bef4583a7976523140f8d"
+checksum = "2ab58d45ceaabba867fc05f018f58e4640df2e6424b4c759d45f66cf075ad8fe"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -442,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
+checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -505,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -528,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
+checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -540,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
+checksum = "9f89d27756bf3effdac25d07692724e840ce90ca1ff956a6b47dd2ae1612f597"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -552,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
+checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -567,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
+checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -599,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -614,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
+checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -703,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -726,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
+checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -758,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1044,9 +1045,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -1463,9 +1464,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -1645,9 +1646,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2098,15 +2099,16 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossfire"
-version = "3.1.16"
+version = "3.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
+checksum = "111ce8f7abfbac38b4bc4f32a3a2dda1a8034b873c90c7899f302cc9dbbc05ec"
 dependencies = [
  "crossbeam-utils",
- "embed-collections",
  "futures-core",
  "parking_lot",
+ "pointers",
  "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -2321,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2551,10 +2553,11 @@ dependencies = [
  "hopr-transport-p2p",
  "lazy_static",
  "mimalloc",
+ "multiaddr",
  "nix 0.31.3",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "rand 0.10.2",
  "reqwest",
  "serde",
@@ -2614,12 +2617,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "embed-collections"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
 
 [[package]]
 name = "embedded-io"
@@ -3033,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
  "gloo-timers",
 ]
@@ -3145,9 +3142,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3458,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6e98ff52f636edc8e3d76844831dfd53cd92146488cc721c0f7bb837fd8052"
+checksum = "e3161efd861baef8d2ca18cddf9fe8699ad36d737635132ce41486a28c2d0c89"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3479,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.8.0"
+version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e63087ec94960a191199c4392a30895694a88de04ad5b23804733b729251b"
+checksum = "1afa8766e3b7c9ac7f770e5330bb08f91af6db385a1b388239814fc03f7c171a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3497,8 +3494,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.22.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3529,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3552,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3569,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3608,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3627,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3640,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3669,8 +3666,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3701,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3716,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3742,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3763,8 +3760,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.31.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.32.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3805,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3822,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3835,19 +3832,20 @@ dependencies = [
  "libp2p-stream",
  "multiaddr",
  "pin-project",
- "quinn-udp",
+ "quinn-udp 0.6.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.8.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
  "const-hex",
+ "crossfire",
  "futures",
  "futures-concurrency",
  "hopr-api",
@@ -3867,11 +3865,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.23.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "anyhow",
  "async-trait",
+ "crossfire",
  "flagset",
  "futures",
  "futures-time",
@@ -3899,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3910,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
+checksum = "c842b389c9b2b84349733cb67712ae0699f6a6b756670e742206cd7ac447acd2"
 dependencies = [
  "aes",
  "anyhow",
@@ -3938,9 +3937,9 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "num_enum",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "poly1305",
  "primitive-types 0.14.0",
  "rand 0.10.2",
@@ -3966,11 +3965,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-utils"
-version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
+version = "0.2.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ac365f2b82143fcf69adf043f6c0a38203e61f00#ac365f2b82143fcf69adf043f6c0a38203e61f00"
 dependencies = [
  "arrayvec",
  "auto_impl",
+ "crossfire",
  "flume",
  "futures",
  "futures-time",
@@ -3986,7 +3986,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
@@ -4131,7 +4131,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4437,7 +4437,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -5002,7 +5002,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
 ]
@@ -5525,20 +5525,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -5560,7 +5546,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -5571,10 +5557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror 2.0.18",
@@ -5585,12 +5571,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897906366b17a89bec845f6051e0c3474049402a09a0711eea180941293bd013"
+checksum = "b4fe57ea90b12f643a366aa7c4fa5cfb54bd1cf252f55368337e40534b278a68"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smartstring",
 ]
 
@@ -5600,26 +5586,11 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.32.0",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
  "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5631,7 +5602,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -5850,6 +5821,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pointers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcdc93847ad24990939cce6e1804361e903efcb5f99daa5abd87943a9d6d7ba"
 
 [[package]]
 name = "polling"
@@ -6153,10 +6130,10 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6194,9 +6171,21 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.5.10",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7215,9 +7204,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -7273,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -7630,7 +7619,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -7733,7 +7722,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ cfg-if = "1.0.4"
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 console-subscriber = { version = "0.5.0", optional = true }
 futures = "0.3.32"
+multiaddr = "0.18.2"
 lazy_static = "1.5.0"
 signal-hook = "0.4.4"
 serde_yaml = { version = "0.9.34" }
@@ -71,20 +72,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -93,7 +94,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,20 +72,21 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
+hopr-types = "2.0.0"
+hopr-lib = { path = "../hoprnet/hopr/hopr-lib", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
+hopr-chain-connector = { path = "../hoprnet/impls/connector", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
+hopr-ct-full-network = { path = "../hoprnet/impls/ct/full-network" }
+hopr-strategy = { path = "../hoprnet/impls/strategy", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00" }
+hopr-ticket-manager = { path = "../hoprnet/impls/ticket-manager" }
+hopr-network-graph = { path = "../hoprnet/impls/graph" }
+hopr-transport-p2p = { path = "../hoprnet/impls/transport/p2p" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -94,7 +95,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ac365f2b82143fcf69adf043f6c0a38203e61f00", features = [
+hopr-chain-connector = { path = "../hoprnet/impls/connector", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/README.md
+++ b/README.md
@@ -37,17 +37,16 @@ Embed the client by constructing an `Edgli` instance. Initialization is reported
 through a visitor callback that receives `EdgliInitState` transitions.
 
 ```rust
-use std::path::Path;
-
 use edgli::{Edgli, EdgliInitState, hopr_lib::{HoprKeys, config::HoprLibConfig}};
 
-async fn run(cfg: HoprLibConfig, db: &Path, keys: HoprKeys) -> anyhow::Result<()> {
+async fn run(cfg: HoprLibConfig, keys: HoprKeys) -> anyhow::Result<()> {
     let edgli = Edgli::new(
         cfg,
-        db,
         keys,
-        None, // blokli URL (optional)
-        None, // BlockchainConnectorConfig (optional)
+        None,  // blokli URL (optional)
+        None,  // blokli DNS override (optional)
+        None,  // BlockchainConnectorConfig (optional)
+        false, // probe_local_addresses: filter non-public peer addresses
         |state: EdgliInitState| tracing::info!(?state, "init"),
     )
     .await?;
@@ -132,9 +131,9 @@ Key inputs handed to `Edgli::new`:
 - **Loopback address rejected.** `Edgli::new` refuses to announce a loopback
   host unless `protocol.transport.prefer_local_addresses = true`.
 - **Local peers not probed.** By default non-public (private, loopback,
-  link-local) peer addresses from announcements are filtered before dialing. Pass
-  `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or the
-  `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
+  link-local) peer addresses from announcements are filtered before dialing.
+  Pass `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or
+  the `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
   same-host test cluster).
 - **Profiling.** Build with
   `RUSTFLAGS="--cfg tokio_unstable" cargo build --features prof` and attach

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Key inputs handed to `Edgli::new`:
   when `RUST_LOG` is unset.
 - **Loopback address rejected.** `Edgli::new` refuses to announce a loopback
   host unless `protocol.transport.prefer_local_addresses = true`.
+- **Local peers not probed.** By default private/local (RFC-1918) peer
+  addresses from announcements are filtered before dialing. Pass
+  `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or the
+  `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
+  same-host test cluster).
 - **Profiling.** Build with
   `RUSTFLAGS="--cfg tokio_unstable" cargo build --features prof` and attach
   `tokio-console`.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Key inputs handed to `Edgli::new`:
   when `RUST_LOG` is unset.
 - **Loopback address rejected.** `Edgli::new` refuses to announce a loopback
   host unless `protocol.transport.prefer_local_addresses = true`.
-- **Local peers not probed.** By default private/local (RFC-1918) peer
-  addresses from announcements are filtered before dialing. Pass
+- **Local peers not probed.** By default non-public (private, loopback,
+  link-local) peer addresses from announcements are filtered before dialing. Pass
   `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or the
   `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
   same-host test cluster).

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,10 +20,10 @@ use hopr_lib::api::{
 use hopr_lib::builder::{ChainKeypair, HoprBuilder, Keypair, OffchainKeypair};
 use hopr_lib::exports::network::types::addr::is_public_address;
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
-use multiaddr::Multiaddr;
 use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
 use hopr_ticket_manager::ticket_factory_from_chain;
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
+use multiaddr::Multiaddr;
 use strum::{AsRefStr, Display, EnumString};
 use tracing::info;
 
@@ -599,6 +599,8 @@ mod tests {
             ma("/ip4/192.168.1.5/tcp/9091"),
             ma("/ip4/10.0.0.2/tcp/9091"),
             ma("/ip4/127.0.0.1/tcp/9091"),
+            ma("/ip6/::1/tcp/9091"),
+            ma("/ip6/fc00::1/tcp/9091"),
         ];
 
         assert_eq!(probeable_addresses(addrs, false), vec![public]);
@@ -610,6 +612,8 @@ mod tests {
             ma("/ip4/8.8.8.8/tcp/9091"),
             ma("/ip4/192.168.1.5/tcp/9091"),
             ma("/ip4/127.0.0.1/tcp/9091"),
+            ma("/ip6/::1/tcp/9091"),
+            ma("/ip6/fc00::1/tcp/9091"),
         ];
 
         assert_eq!(probeable_addresses(addrs.clone(), true), addrs);
@@ -620,6 +624,8 @@ mod tests {
         let addrs = vec![
             ma("/ip4/192.168.1.5/tcp/9091"),
             ma("/ip4/10.0.0.2/tcp/9091"),
+            ma("/ip6/::1/tcp/9091"),
+            ma("/ip6/fc00::1/tcp/9091"),
         ];
 
         assert!(probeable_addresses(addrs, false).is_empty());

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,7 +18,9 @@ use hopr_lib::api::{
     },
 };
 use hopr_lib::builder::{ChainKeypair, HoprBuilder, Keypair, OffchainKeypair};
+use hopr_lib::exports::network::types::addr::is_public_address;
 use hopr_lib::{HoprKeys, config::HoprLibConfig};
+use multiaddr::Multiaddr;
 use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
 use hopr_ticket_manager::ticket_factory_from_chain;
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
@@ -110,6 +112,19 @@ pub enum EdgliInitState {
     Ready,
 }
 
+/// Filters an announcement's multiaddresses down to those worth dialing.
+///
+/// Private/local (RFC-1918, loopback, link-local) peer addresses are dropped
+/// unless `probe_local_addresses` is set, in which case local addresses are
+/// dialed too.
+fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Vec<Multiaddr> {
+    if probe_local_addresses {
+        addrs
+    } else {
+        addrs.into_iter().filter(is_public_address).collect()
+    }
+}
+
 /// Spawns an abortable task that drives a user-supplied closure over the running node.
 ///
 /// Returns an [`AbortHandle`] that stops the closure task when aborted.
@@ -121,6 +136,7 @@ pub async fn run_hopr_edge_node_with<F, T>(
     blokli_url: Option<String>,
     blokli_dns_override: Option<(IpAddr, Option<u16>)>,
     blokli_connector_config: Option<BlockchainConnectorConfig>,
+    probe_local_addresses: bool,
     f: F,
     visitor: impl Fn(EdgliInitState) + Send + 'static,
 ) -> anyhow::Result<AbortHandle>
@@ -134,6 +150,7 @@ where
         blokli_url,
         blokli_dns_override,
         blokli_connector_config,
+        probe_local_addresses,
         visitor,
     )
     .await?;
@@ -180,6 +197,9 @@ impl Edgli {
     /// * `blokli_url` – optional Blokli client URL; defaults to the production endpoint
     /// * `blokli_dns_override` – optional DNS override for the Blokli client
     /// * `blokli_connector_config` – optional connector config overrides
+    /// * `probe_local_addresses` – when `true`, probe private/local (RFC-1918)
+    ///   peer addresses from announcements; when `false` (default) they are
+    ///   filtered out before dialing
     /// * `visitor` – called at each [`EdgliInitState`] transition for progress reporting
     pub async fn new(
         cfg: HoprLibConfig,
@@ -187,6 +207,7 @@ impl Edgli {
         blokli_url: Option<String>,
         blokli_dns_override: Option<(IpAddr, Option<u16>)>,
         blokli_connector_config: Option<BlockchainConnectorConfig>,
+        probe_local_addresses: bool,
         visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> anyhow::Result<Self> {
         visitor(EdgliInitState::ValidatingConfig);
@@ -275,10 +296,14 @@ impl Edgli {
                                 .try_into()
                                 .map_err(hopr_lib::errors::HoprLibError::TransportError)?,
                         ];
-                        let nb = HoprLibp2pNetworkBuilder::new(
-                            peer_discovery_rx
-                                .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
-                        );
+                        let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx.map(
+                            move |(peer_id, addrs)| {
+                                PeerDiscovery::Announce(
+                                    peer_id,
+                                    probeable_addresses(addrs, probe_local_addresses),
+                                )
+                            },
+                        ));
                         nb.build(
                             &ctx.packet_key,
                             multiaddresses,
@@ -560,5 +585,49 @@ mod tests {
             error.to_string(),
             "configuration error: 'invalid Blokli URL 'not a url': relative URL without a base'"
         );
+    }
+
+    fn ma(s: &str) -> Multiaddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn probeable_addresses_filters_local_by_default() {
+        let public = ma("/ip4/8.8.8.8/tcp/9091");
+        let addrs = vec![
+            public.clone(),
+            ma("/ip4/192.168.1.5/tcp/9091"),
+            ma("/ip4/10.0.0.2/tcp/9091"),
+            ma("/ip4/127.0.0.1/tcp/9091"),
+        ];
+
+        assert_eq!(probeable_addresses(addrs, false), vec![public]);
+    }
+
+    #[test]
+    fn probeable_addresses_keeps_all_when_probing_local() {
+        let addrs = vec![
+            ma("/ip4/8.8.8.8/tcp/9091"),
+            ma("/ip4/192.168.1.5/tcp/9091"),
+            ma("/ip4/127.0.0.1/tcp/9091"),
+        ];
+
+        assert_eq!(probeable_addresses(addrs.clone(), true), addrs);
+    }
+
+    #[test]
+    fn probeable_addresses_drops_all_local_to_empty() {
+        let addrs = vec![
+            ma("/ip4/192.168.1.5/tcp/9091"),
+            ma("/ip4/10.0.0.2/tcp/9091"),
+        ];
+
+        assert!(probeable_addresses(addrs, false).is_empty());
+    }
+
+    #[test]
+    fn probeable_addresses_empty_input() {
+        assert!(probeable_addresses(vec![], false).is_empty());
+        assert!(probeable_addresses(vec![], true).is_empty());
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -130,6 +130,7 @@ fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Ve
 /// Returns an [`AbortHandle`] that stops the closure task when aborted.
 /// `Edgli` is kept alive for the entire duration of `f` so that background tasks
 /// remain active until `f` completes or the returned [`AbortHandle`] is used to cancel it.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_hopr_edge_node_with<F, T>(
     cfg: HoprLibConfig,
     hopr_keys: HoprKeys,

--- a/src/client.rs
+++ b/src/client.rs
@@ -114,9 +114,9 @@ pub enum EdgliInitState {
 
 /// Filters an announcement's multiaddresses down to those worth dialing.
 ///
-/// Private/local (RFC-1918, loopback, link-local) peer addresses are dropped
-/// unless `probe_local_addresses` is set, in which case local addresses are
-/// dialed too.
+/// Non-public peer addresses (private, loopback, link-local, unspecified) are
+/// dropped unless `probe_local_addresses` is set, in which case local addresses
+/// are dialed too.
 fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Vec<Multiaddr> {
     if probe_local_addresses {
         addrs
@@ -197,9 +197,9 @@ impl Edgli {
     /// * `blokli_url` – optional Blokli client URL; defaults to the production endpoint
     /// * `blokli_dns_override` – optional DNS override for the Blokli client
     /// * `blokli_connector_config` – optional connector config overrides
-    /// * `probe_local_addresses` – when `true`, probe private/local (RFC-1918)
-    ///   peer addresses from announcements; when `false` (default) they are
-    ///   filtered out before dialing
+    /// * `probe_local_addresses` – when `true`, probe non-public (private,
+    ///   loopback, link-local) peer addresses from announcements; when `false`
+    ///   (default) they are filtered out before dialing
     /// * `visitor` – called at each [`EdgliInitState`] transition for progress reporting
     pub async fn new(
         cfg: HoprLibConfig,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,19 +17,21 @@ pub use hopr_lib::exports::transport::path::PathPlannerConfig;
 
 /// Returns a [`PathPlannerConfig`] optimised for low-latency path selection.
 ///
-/// Uses a shorter latency half-life (`50 ms`) than the default (`100 ms`) so
+/// Uses a much shorter latency half-life (`20 ms`) than the default (`100 ms`) so
 /// paths with lower observed round-trip times receive a stronger preference
-/// during candidate scoring and pruning.  The `min_ack_rate` controls the
-/// minimum message-acknowledgement rate an edge must exhibit before it is
-/// eligible for path inclusion.
+/// during candidate scoring and pruning, and prunes candidates down to the two
+/// lowest-latency paths to reduce per-packet relay rotation (and with it the
+/// latency variance that causes frame-reassembly reordering).  The
+/// `min_ack_rate` controls the minimum message-acknowledgement rate an edge
+/// must exhibit before it is eligible for path inclusion.
 ///
 /// Pass the result as the `path_planner` argument of [`Edgli::new`] or
 /// [`run_hopr_edge_node_with`] to activate latency-optimised routing.
 pub fn latency_path_planner_config(min_ack_rate: f64) -> PathPlannerConfig {
     PathPlannerConfig {
         min_ack_rate,
-        latency_halflife: std::time::Duration::from_millis(50),
-        min_paths_anonymity_floor: 4,
+        latency_halflife: std::time::Duration::from_millis(20),
+        min_paths_anonymity_floor: 2,
         ..PathPlannerConfig::default()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,11 @@ pub struct CliArgs {
     )]
     pub blokli_dns_override: Option<(IpAddr, Option<u16>)>,
 
-    /// Probe private/local (RFC-1918) peer addresses from announcements
+    /// Probe non-public (private, loopback, link-local) peer addresses from announcements
     #[arg(
         long,
         env = "HOPR_EDGE_PROBE_LOCAL_ADDRESSES",
-        help = "Probe private/local peer addresses received in announcements (default: filtered out)",
+        help = "Probe non-public (private/loopback/link-local) peer addresses received in announcements (default: filtered out)",
         default_value_t = false
     )]
     pub probe_local_addresses: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,15 @@ pub struct CliArgs {
         required = false
     )]
     pub blokli_dns_override: Option<(IpAddr, Option<u16>)>,
+
+    /// Probe private/local (RFC-1918) peer addresses from announcements
+    #[arg(
+        long,
+        env = "HOPR_EDGE_PROBE_LOCAL_ADDRESSES",
+        help = "Probe private/local peer addresses received in announcements (default: filtered out)",
+        default_value_t = false
+    )]
+    pub probe_local_addresses: bool,
 }
 
 fn init_logger() -> anyhow::Result<()> {
@@ -233,6 +242,7 @@ async fn main() -> anyhow::Result<()> {
         args.blokli_url,
         args.blokli_dns_override,
         None,
+        args.probe_local_addresses,
         |s| {
             info!(?s, "Initialization stage");
         },

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -91,6 +91,10 @@ pub struct EdgliTuning {
     /// on a same-host cluster.
     pub prefer_local_addresses: bool,
     pub announce_local: bool,
+    /// Whether to probe private/local peer addresses received in announcements.
+    /// True only on a same-host cluster, where peers reach each other over
+    /// RFC-1918 addresses.
+    pub probe_local: bool,
     /// Channel-lifecycle strategy tick interval.
     pub strategy_tick: Duration,
     /// Channel-lifecycle selection policy.  Determines which peers qualify for
@@ -135,6 +139,7 @@ impl EdgliTuning {
             },
             prefer_local_addresses: true,
             announce_local: true,
+            probe_local: true,
             strategy_tick: Duration::from_secs(10),
             selector: SelectorProfile::LowLatency,
             channel_open_timeout: Duration::from_secs(120),
@@ -150,6 +155,7 @@ impl EdgliTuning {
             connector_cfg: BlockchainConnectorConfig::default(),
             prefer_local_addresses: false,
             announce_local: false,
+            probe_local: false,
             strategy_tick: Duration::from_secs(30),
             // Rotsee peers have ~150-200 ms RTT; latency_score caps at 0.3 for
             // that range, so even a perfect probe rate yields at most 0.30.
@@ -1118,6 +1124,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         Some(summary.blokli_url.clone()),
         None,
         Some(tuning.connector_cfg),
+        tuning.probe_local,
         |s: EdgliInitState| tracing::info!(?s, "edgli init"),
     )
     .await?;


### PR DESCRIPTION
## Sharpen latency-optimised path planner config

  With the hoprnet loopback-RTT fix in place, latency data is real for the
  first time — tighten selection to use it:

  - `latency_halflife` 50→20ms: steeper penalty for slow paths in the
    composite weight (factor at 52ms ≈ 0.28 vs 241ms ≈ 0.077).
  - `min_paths_anonymity_floor` 4→2: prune candidates to the two
    lowest-latency paths.

  Effect: less per-packet relay rotation, less latency variance, less
  frame reordering. On rotsee, forward traffic concentrated 54%→72% on the
  best relay and geo-unreasonable picks (e.g. New Delhi for PL→US traffic)
  dropped to zero.