### PR TITLE
feat: improve path planner config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3888,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4220,8 +4220,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-utils"
-version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
+version = "0.3.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,20 +72,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -94,7 +94,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,6 +272,7 @@ impl Edgli {
             *packet_key.public(),
             path_cfg.edge_penalty,
             path_cfg.min_ack_rate,
+            path_cfg.max_plausible_loopback_rtt,
         ));
         let graph_for_ct = graph.clone();
         let safe_address = cfg.safe_module.safe_address;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,19 +17,21 @@ pub use hopr_lib::exports::transport::path::PathPlannerConfig;
 
 /// Returns a [`PathPlannerConfig`] optimised for low-latency path selection.
 ///
-/// Uses a shorter latency half-life (`50 ms`) than the default (`100 ms`) so
+/// Uses a much shorter latency half-life (`20 ms`) than the default (`100 ms`) so
 /// paths with lower observed round-trip times receive a stronger preference
-/// during candidate scoring and pruning.  The `min_ack_rate` controls the
-/// minimum message-acknowledgement rate an edge must exhibit before it is
-/// eligible for path inclusion.
+/// during candidate scoring and pruning, and prunes candidates down to the two
+/// lowest-latency paths to reduce per-packet relay rotation (and with it the
+/// latency variance that causes frame-reassembly reordering).  The
+/// `min_ack_rate` controls the minimum message-acknowledgement rate an edge
+/// must exhibit before it is eligible for path inclusion.
 ///
 /// Pass the result as the `path_planner` argument of [`Edgli::new`] or
 /// [`run_hopr_edge_node_with`] to activate latency-optimised routing.
 pub fn latency_path_planner_config(min_ack_rate: f64) -> PathPlannerConfig {
     PathPlannerConfig {
         min_ack_rate,
-        latency_halflife: std::time::Duration::from_millis(50),
-        min_paths_anonymity_floor: 4,
+        latency_halflife: std::time::Duration::from_millis(20),
+        min_paths_anonymity_floor: 2,
         ..PathPlannerConfig::default()
     }
 }


### PR DESCRIPTION
Sharpen latency-optimised path planner config
With the hoprnet loopback-RTT fix in place, latency data is real for the
first time — tighten selection to use it:

latency_halflife 50→20ms: steeper penalty for slow paths in the
composite weight (factor at 52ms ≈ 0.28 vs 241ms ≈ 0.077).
min_paths_anonymity_floor 4→2: prune candidates to the two
lowest-latency paths.
Effect: less per-packet relay rotation, less latency variance, less
frame reordering. On rotsee, forward traffic concentrated 54%→72% on the
best relay and geo-unreasonable picks (e.g. New Delhi for PL→US traffic)
dropped to zero.

