### PR TITLE
feat: Add blokli DNS override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/edge-client"
 license = "GPL-3.0-only"
 
+[[bin]]
+name = "edgli"
+path = "src/main.rs"
+required-features = ["runtime-tokio", "blokli"]
+
 [features]
 default = ["runtime-tokio", "blokli"]
 runtime-tokio = [
@@ -25,7 +30,7 @@ telemetry = [
   # "dep:tracing-opentelemetry",
 ]
 testing = ["hopr-lib/testing"]
-blokli = []
+blokli = ["dep:tokio"]
 
 # To use profiling:
 # 1. Set RUSTFLAGS="--cfg tokio_unstable" before building

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,23 @@ homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/edge-client"
 license = "GPL-3.0-only"
 
+# Declared explicitly (instead of relying on src/main.rs auto-discovery) so that
+# feature-specific builds (`--no-default-features`) skip the binary instead of
+# failing to compile it: the binary drives the concrete `Edgli` client, which
+# requires both a runtime and the blokli connector.
 [[bin]]
 name = "edgli"
 path = "src/main.rs"
+required-features = ["runtime-tokio", "blokli"]
+
+# The session end-to-end tests exercise the concrete `Edgli` client through the
+# shared harness in tests/common, so they need the same features as the binary.
+[[test]]
+name = "edgli_session_e2e"
+required-features = ["runtime-tokio", "blokli"]
+
+[[test]]
+name = "edgli_session_rotsee"
 required-features = ["runtime-tokio", "blokli"]
 
 [features]
@@ -30,7 +44,7 @@ telemetry = [
   # "dep:tracing-opentelemetry",
 ]
 testing = ["hopr-lib/testing"]
-blokli = ["dep:tokio"]
+blokli = ["dep:tokio", "dep:url"]
 
 # To use profiling:
 # 1. Set RUSTFLAGS="--cfg tokio_unstable" before building
@@ -76,7 +90,7 @@ opentelemetry-otlp = { version = "0.32.0", default-features = false, features = 
 ], optional = true }
 opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
-url = "2.5.8"
+url = { version = "2.5.8", optional = true }
 
 hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "session-client",

--- a/README.md
+++ b/README.md
@@ -75,21 +75,23 @@ The same `BlokliEndpoint` is accepted by `make_incentive_operations`, so the
 on-boarding flow (balances, ticket pricing, Safe deployment, withdrawals)
 honours the override too.
 
+`BlokliEndpoint`, `BlokliDnsOverride` and `make_incentive_operations` are
+blokli-specific: they are only available with the `blokli` feature enabled
+(it is on by default).
+
 See `src/client.rs` for `run_hopr_edge_node_with` (spawn helper) and
 `Edgli::run_reactor_from_cfg` (edge strategy reactor: channel funding,
 pending-close sweeping) when the `blokli` feature is enabled.
 
 ### Feature flags
 
-| flag             | default | effect                                                    |
-| ---------------- | :-----: | --------------------------------------------------------- |
-| `runtime-tokio`  |   yes   | Tokio runtime integration                                 |
-| `prometheus`     |   yes   | Prometheus metrics via `hopr-lib`                         |
-| `blokli`         |   yes   | Blokli-backed trustful blockchain connector               |
-| `session-server` |   no    | Enables the session-server side of `hopr-lib`             |
-| `telemetry`      |   no    | OpenTelemetry OTLP export                                 |
-| `testing`        |   no    | Test-only helpers from `hopr-lib`                         |
-| `prof`           |   no    | `tokio-console` subscriber (needs `--cfg tokio_unstable`) |
+| flag            | default | effect                                                    |
+| --------------- | :-----: | --------------------------------------------------------- |
+| `runtime-tokio` |   yes   | Tokio runtime integration                                 |
+| `blokli`        |   yes   | Blokli-backed trustful blockchain connector               |
+| `telemetry`     |   no    | OpenTelemetry OTLP export                                 |
+| `testing`       |   no    | Test-only helpers from `hopr-lib`                         |
+| `prof`          |   no    | `tokio-console` subscriber (needs `--cfg tokio_unstable`) |
 
 The concrete `Edgli` client and the `edgli` binary require both `runtime-tokio`
 and `blokli`. Other feature combinations still build the feature-independent

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ on-boarding flow (balances, ticket pricing, Safe deployment, withdrawals)
 honours the override too.
 
 `BlokliEndpoint`, `BlokliDnsOverride` and `make_incentive_operations` are
-blokli-specific: they are only available with the `blokli` feature enabled
-(it is on by default).
+blokli-specific: they are only available with the `blokli` feature enabled (it
+is on by default).
 
 See `src/client.rs` for `run_hopr_edge_node_with` (spawn helper) and
 `Edgli::run_reactor_from_cfg` (edge strategy reactor: channel funding,

--- a/README.md
+++ b/README.md
@@ -57,19 +57,23 @@ async fn run(cfg: HoprLibConfig, keys: HoprKeys) -> anyhow::Result<()> {
 ```
 
 To reach Blokli when system DNS is unavailable, pin the endpoint host to a fixed
-address. The request URL is not rewritten, so the HTTP `Host` header, TLS SNI and
-certificate validation still use the original hostname:
+address. The request URL is not rewritten, so the HTTP `Host` header, TLS SNI
+and certificate validation still use the original hostname:
 
 ```rust
 use edgli::{BlokliDnsOverride, BlokliEndpoint};
 
 let endpoint = BlokliEndpoint::default()
-    .with_dns_override(Some("10.1.2.1:3002".parse::<BlokliDnsOverride>()?));
+    .with_dns_override("10.1.2.1:3002".parse::<BlokliDnsOverride>()?);
 ```
 
+IPv6 addresses with a port use bracketed socket syntax, for example
+`[::1]:3002`. An unbracketed value such as `::1:3002` is treated as an IPv6
+address without a separate port.
+
 The same `BlokliEndpoint` is accepted by `make_incentive_operations`, so the
-on-boarding flow (balances, ticket pricing, Safe deployment, withdrawals) honours
-the override too.
+on-boarding flow (balances, ticket pricing, Safe deployment, withdrawals)
+honours the override too.
 
 See `src/client.rs` for `run_hopr_edge_node_with` (spawn helper) and
 `Edgli::run_reactor_from_cfg` (edge strategy reactor: channel funding,
@@ -86,6 +90,10 @@ pending-close sweeping) when the `blokli` feature is enabled.
 | `telemetry`      |   no    | OpenTelemetry OTLP export                                 |
 | `testing`        |   no    | Test-only helpers from `hopr-lib`                         |
 | `prof`           |   no    | `tokio-console` subscriber (needs `--cfg tokio_unstable`) |
+
+The concrete `Edgli` client and the `edgli` binary require both `runtime-tokio`
+and `blokli`. Other feature combinations still build the feature-independent
+library modules.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,13 @@ Embed the client by constructing an `Edgli` instance. Initialization is reported
 through a visitor callback that receives `EdgliInitState` transitions.
 
 ```rust
-use edgli::{Edgli, EdgliInitState, hopr_lib::{HoprKeys, config::HoprLibConfig}};
+use edgli::{BlokliEndpoint, Edgli, EdgliInitState, hopr_lib::{HoprKeys, config::HoprLibConfig}};
 
 async fn run(cfg: HoprLibConfig, keys: HoprKeys) -> anyhow::Result<()> {
     let edgli = Edgli::new(
         cfg,
         keys,
-        None,  // blokli URL (optional)
-        None,  // blokli DNS override (optional)
+        BlokliEndpoint::default(), // production endpoint, system DNS
         None,  // BlockchainConnectorConfig (optional)
         false, // probe_local_addresses: filter non-public peer addresses
         |state: EdgliInitState| tracing::info!(?state, "init"),
@@ -56,6 +55,21 @@ async fn run(cfg: HoprLibConfig, keys: HoprKeys) -> anyhow::Result<()> {
     Ok(())
 }
 ```
+
+To reach Blokli when system DNS is unavailable, pin the endpoint host to a fixed
+address. The request URL is not rewritten, so the HTTP `Host` header, TLS SNI and
+certificate validation still use the original hostname:
+
+```rust
+use edgli::{BlokliDnsOverride, BlokliEndpoint};
+
+let endpoint = BlokliEndpoint::default()
+    .with_dns_override(Some("10.1.2.1:3002".parse::<BlokliDnsOverride>()?));
+```
+
+The same `BlokliEndpoint` is accepted by `make_incentive_operations`, so the
+on-boarding flow (balances, ticket pricing, Safe deployment, withdrawals) honours
+the override too.
 
 See `src/client.rs` for `run_hopr_edge_node_with` (spawn helper) and
 `Edgli::run_reactor_from_cfg` (edge strategy reactor: channel funding,
@@ -118,10 +132,11 @@ Key inputs handed to `Edgli::new`:
 
 - `HoprLibConfig` — host / transport / safe-module configuration.
 - `HoprKeys` — packet key + chain key pair.
-- `db_data_path` — persistent node DB directory. Edge clients are
-  ticket-originators only and therefore do not store received tickets.
-- `blokli_url` / `BlockchainConnectorConfig` — blokli endpoint and connector
-  tuning (both optional; defaults applied when omitted).
+- `BlokliEndpoint` — blokli service URL plus an optional DNS override that
+  bypasses system DNS for that host. `BlokliEndpoint::default()` uses the
+  production endpoint and system DNS.
+- `BlockchainConnectorConfig` — connector tuning (optional; defaults applied
+  when omitted).
 
 ## Troubleshooting
 

--- a/flake.nix
+++ b/flake.nix
@@ -257,6 +257,30 @@
               }
             );
 
+            feature-minimal = craneLib.cargoBuild (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                cargoExtraArgs = "--locked --no-default-features";
+              }
+            );
+
+            feature-runtime-tokio = craneLib.cargoBuild (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                cargoExtraArgs = "--locked --no-default-features --features runtime-tokio";
+              }
+            );
+
+            feature-blokli = craneLib.cargoBuild (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                cargoExtraArgs = "--locked --no-default-features --features blokli";
+              }
+            );
+
             # Audit dependencies
             audit = craneLib.cargoAudit {
               inherit src advisory-db;

--- a/flake.nix
+++ b/flake.nix
@@ -271,7 +271,8 @@
               commonArgs
               // {
                 inherit cargoArtifacts;
-                cargoExtraArgs = (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features --features runtime-tokio";
+                cargoExtraArgs =
+                  (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features --features runtime-tokio";
               }
             );
 
@@ -279,7 +280,8 @@
               commonArgs
               // {
                 inherit cargoArtifacts;
-                cargoExtraArgs = (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features --features blokli";
+                cargoExtraArgs =
+                  (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features --features blokli";
               }
             );
 

--- a/flake.nix
+++ b/flake.nix
@@ -257,11 +257,13 @@
               }
             );
 
+            # Append to (not replace) any cargoExtraArgs set in commonArgs so
+            # shared flags keep applying to the feature-matrix checks.
             feature-minimal = craneLib.cargoBuild (
               commonArgs
               // {
                 inherit cargoArtifacts;
-                cargoExtraArgs = "--locked --no-default-features";
+                cargoExtraArgs = (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features";
               }
             );
 
@@ -269,7 +271,7 @@
               commonArgs
               // {
                 inherit cargoArtifacts;
-                cargoExtraArgs = "--locked --no-default-features --features runtime-tokio";
+                cargoExtraArgs = (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features --features runtime-tokio";
               }
             );
 
@@ -277,7 +279,7 @@
               commonArgs
               // {
                 inherit cargoArtifacts;
-                cargoExtraArgs = "--locked --no-default-features --features blokli";
+                cargoExtraArgs = (commonArgs.cargoExtraArgs or "") + " --locked --no-default-features --features blokli";
               }
             );
 

--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use hopr_chain_connector::{
-    BlockchainConnectorConfig, HoprBlockchainBasicConnector, HoprBlokliClientConfig,
+    BlockchainConnectorConfig, HoprBlockchainBasicConnector,
     blokli_client::{
         BlokliClient, BlokliQueryClient, BlokliSubscriptionClient, BlokliTransactionClient,
     },
-    create_blokli_client, create_trustful_safeless_hopr_blokli_connector,
+    create_trustful_safeless_hopr_blokli_connector,
 };
 use hopr_lib::{
     api::{
@@ -22,14 +22,12 @@ use hopr_lib::{
 };
 use url::Url;
 
+use crate::endpoint::BlokliEndpoint;
+
 pub use hopr_lib::builder::ChainKeypair;
 
 lazy_static::lazy_static! {
     pub static ref DEFAULT_BLOKLI_URL: Url = "https://blokli.jura.gnosisvpn.io".parse().unwrap();
-}
-
-fn build_safeless_blokli_client_config(blokli_provider: Option<Url>) -> HoprBlokliClientConfig {
-    HoprBlokliClientConfig::new(blokli_provider.unwrap_or_else(|| DEFAULT_BLOKLI_URL.clone()))
 }
 
 /// Constructs a fully-wired [`IncentiveOperations`] handle backed by a Blokli client.
@@ -37,12 +35,15 @@ fn build_safeless_blokli_client_config(blokli_provider: Option<Url>) -> HoprBlok
 /// This is the only public entry point for obtaining an `IncentiveOperations` impl —
 /// the underlying [`BlokliClient`] and connector are constructed internally and
 /// never exposed to callers.
+///
+/// The endpoint's DNS override is honoured, so on-boarding works in environments
+/// where system DNS cannot resolve the Blokli host.
 pub async fn make_incentive_operations(
-    blokli_url: Option<Url>,
+    blokli_endpoint: BlokliEndpoint,
     chain_key: &ChainKeypair,
     connector_config: Option<BlockchainConnectorConfig>,
 ) -> anyhow::Result<Box<dyn IncentiveOperations>> {
-    let interactor = SafelessInteractor::new(blokli_url, chain_key, connector_config).await?;
+    let interactor = SafelessInteractor::new(blokli_endpoint, chain_key, connector_config).await?;
     Ok(Box::new(interactor))
 }
 
@@ -107,12 +108,11 @@ pub(crate) struct SafelessInteractor<C = BlokliClient> {
 
 impl SafelessInteractor<BlokliClient> {
     pub(crate) async fn new(
-        blokli_provider: Option<Url>,
+        blokli_endpoint: BlokliEndpoint,
         chain_key: &ChainKeypair,
         connector_config: Option<BlockchainConnectorConfig>,
     ) -> anyhow::Result<Self> {
-        let config = build_safeless_blokli_client_config(blokli_provider);
-        Self::new_with_client(create_blokli_client(config), chain_key, connector_config).await
+        Self::new_with_client(blokli_endpoint.build_client(), chain_key, connector_config).await
     }
 }
 
@@ -289,19 +289,6 @@ mod tests {
             DEFAULT_BLOKLI_URL.as_str(),
             "https://blokli.jura.gnosisvpn.io/"
         );
-    }
-
-    #[test]
-    fn build_safeless_blokli_client_config_uses_default_url() {
-        let config = build_safeless_blokli_client_config(None);
-        assert_eq!(config.url, *DEFAULT_BLOKLI_URL);
-    }
-
-    #[test]
-    fn build_safeless_blokli_client_config_uses_custom_url() {
-        let custom_url: Url = "https://custom.blokli.example.com".parse().unwrap();
-        let config = build_safeless_blokli_client_config(Some(custom_url.clone()));
-        assert_eq!(config.url, custom_url);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,12 +1,9 @@
 use std::collections::HashSet;
-use std::net::IpAddr;
 use std::sync::Arc;
 
 use futures::StreamExt;
 use futures::future::{AbortHandle, abortable};
-use hopr_chain_connector::{
-    BlockchainConnectorConfig, create_blokli_client, create_trustful_hopr_blokli_connector,
-};
+use hopr_chain_connector::{BlockchainConnectorConfig, create_trustful_hopr_blokli_connector};
 use hopr_ct_full_network::ProberConfig as FullNetworkProberConfig;
 use hopr_lib::api::{
     chain::{ChainReadSafeOperations, ChainValues as _, SafeSelector},
@@ -28,29 +25,9 @@ use strum::{AsRefStr, Display, EnumString};
 use tracing::info;
 
 #[cfg(feature = "blokli")]
-use crate::DEFAULT_BLOKLI_URL;
-#[cfg(feature = "blokli")]
-use hopr_chain_connector::HoprBlokliClientConfig;
+use crate::endpoint::BlokliEndpoint;
 
 use crate::errors::EdgliError;
-
-#[cfg(feature = "blokli")]
-fn build_blokli_client_config(
-    blokli_url: Option<&str>,
-    blokli_dns_override: Option<(IpAddr, Option<u16>)>,
-) -> Result<HoprBlokliClientConfig, EdgliError> {
-    let url = match blokli_url {
-        Some(url) => url
-            .parse()
-            .map_err(|e| EdgliError::ConfigError(format!("invalid Blokli URL '{url}': {e}")))?,
-        None => DEFAULT_BLOKLI_URL.clone(),
-    };
-
-    Ok(HoprBlokliClientConfig {
-        url,
-        dns_override: blokli_dns_override,
-    })
-}
 
 /// The concrete HOPR edge node type used by this client.
 pub type HoprEdgeClient = hopr_lib::Hopr<
@@ -130,12 +107,10 @@ fn probeable_addresses(addrs: Vec<Multiaddr>, probe_local_addresses: bool) -> Ve
 /// Returns an [`AbortHandle`] that stops the closure task when aborted.
 /// `Edgli` is kept alive for the entire duration of `f` so that background tasks
 /// remain active until `f` completes or the returned [`AbortHandle`] is used to cancel it.
-#[allow(clippy::too_many_arguments)]
 pub async fn run_hopr_edge_node_with<F, T>(
     cfg: HoprLibConfig,
     hopr_keys: HoprKeys,
-    blokli_url: Option<String>,
-    blokli_dns_override: Option<(IpAddr, Option<u16>)>,
+    blokli_endpoint: BlokliEndpoint,
     blokli_connector_config: Option<BlockchainConnectorConfig>,
     probe_local_addresses: bool,
     f: F,
@@ -148,8 +123,7 @@ where
     let edgli = Edgli::new(
         cfg,
         hopr_keys,
-        blokli_url,
-        blokli_dns_override,
+        blokli_endpoint,
         blokli_connector_config,
         probe_local_addresses,
         visitor,
@@ -195,8 +169,8 @@ impl Edgli {
     ///   before calling to control the routing strategy.  Use
     ///   [`crate::latency_path_planner_config`] to obtain a latency-optimised default.
     /// * `hopr_keys` – chain and packet keypairs
-    /// * `blokli_url` – optional Blokli client URL; defaults to the production endpoint
-    /// * `blokli_dns_override` – optional DNS override for the Blokli client
+    /// * `blokli_endpoint` – Blokli service URL and optional DNS override; use
+    ///   [`BlokliEndpoint::default`] for the production endpoint via system DNS
     /// * `blokli_connector_config` – optional connector config overrides
     /// * `probe_local_addresses` – when `true`, probe non-public (private,
     ///   loopback, link-local) peer addresses from announcements; when `false`
@@ -205,8 +179,7 @@ impl Edgli {
     pub async fn new(
         cfg: HoprLibConfig,
         hopr_keys: HoprKeys,
-        blokli_url: Option<String>,
-        blokli_dns_override: Option<(IpAddr, Option<u16>)>,
+        blokli_endpoint: BlokliEndpoint,
         blokli_connector_config: Option<BlockchainConnectorConfig>,
         probe_local_addresses: bool,
         visitor: impl Fn(EdgliInitState) + Send + 'static,
@@ -242,10 +215,7 @@ impl Edgli {
             let mut connector = create_trustful_hopr_blokli_connector(
                 chain_key,
                 blokli_config,
-                create_blokli_client(build_blokli_client_config(
-                    blokli_url.as_deref(),
-                    blokli_dns_override,
-                )?),
+                blokli_endpoint.build_client(),
                 cfg.safe_module.module_address,
             )
             .await?;
@@ -495,7 +465,6 @@ impl Edgli {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn init_state_as_ref_matches_to_string() {
@@ -563,34 +532,6 @@ mod tests {
                 | EdgliInitState::Ready => {}
             }
         }
-    }
-
-    #[cfg(feature = "blokli")]
-    #[test]
-    fn build_blokli_client_config_uses_default_url() {
-        let config = build_blokli_client_config(None, None).unwrap();
-        assert_eq!(config.url, *DEFAULT_BLOKLI_URL);
-        assert_eq!(config.dns_override, None);
-    }
-
-    #[cfg(feature = "blokli")]
-    #[test]
-    fn build_blokli_client_config_keeps_dns_override() {
-        let dns_override = Some((IpAddr::V4(Ipv4Addr::new(10, 1, 2, 1)), Some(3002)));
-        let config =
-            build_blokli_client_config(Some("https://blokli.example.com"), dns_override).unwrap();
-        assert_eq!(config.url.as_str(), "https://blokli.example.com/");
-        assert_eq!(config.dns_override, dns_override);
-    }
-
-    #[cfg(feature = "blokli")]
-    #[test]
-    fn build_blokli_client_config_rejects_invalid_url() {
-        let error = build_blokli_client_config(Some("not a url"), None).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "configuration error: 'invalid Blokli URL 'not a url': relative URL without a base'"
-        );
     }
 
     fn ma(s: &str) -> Multiaddr {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,0 +1,241 @@
+//! The Blokli service endpoint and its DNS-bypass configuration.
+//!
+//! This module is the only place in the crate that constructs a
+//! [`HoprBlokliClientConfig`] or calls [`create_blokli_client`]. Every path that needs a
+//! Blokli client resolves through [`BlokliEndpoint::build_client`], so a caller-supplied
+//! DNS override cannot be dropped on the way to the client.
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+
+use hopr_chain_connector::{
+    HoprBlokliClientConfig, blokli_client::BlokliClient, create_blokli_client,
+};
+use url::Url;
+
+use crate::blokli::DEFAULT_BLOKLI_URL;
+use crate::errors::EdgliError;
+
+/// DNS resolution override for the Blokli endpoint host.
+///
+/// Pins the endpoint hostname to a fixed address so no system DNS lookup is needed.
+/// The request URL is not rewritten: the HTTP `Host` header, TLS SNI and certificate
+/// validation still use the original hostname.
+///
+/// When [`Self::port`] is `None`, the endpoint URL's port (or its scheme default) is used.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BlokliDnsOverride {
+    /// IP address to connect to instead of resolving the endpoint host.
+    pub ip: IpAddr,
+    /// Optional port override.
+    pub port: Option<u16>,
+}
+
+impl BlokliDnsOverride {
+    /// Creates an override for `ip`, optionally pinning the port as well.
+    pub const fn new(ip: IpAddr, port: Option<u16>) -> Self {
+        Self { ip, port }
+    }
+}
+
+impl FromStr for BlokliDnsOverride {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Ok(ip) = value.parse::<IpAddr>() {
+            return Ok(Self { ip, port: None });
+        }
+
+        if let Ok(addr) = value.parse::<SocketAddr>() {
+            return Ok(Self {
+                ip: addr.ip(),
+                port: Some(addr.port()),
+            });
+        }
+
+        Err(format!(
+            "invalid DNS override '{value}', expected <IP_ADDRESS> or <IP_ADDRESS>:<PORT>"
+        ))
+    }
+}
+
+impl fmt::Display for BlokliDnsOverride {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.port {
+            Some(port) => write!(f, "{}", SocketAddr::new(self.ip, port)),
+            None => write!(f, "{}", self.ip),
+        }
+    }
+}
+
+/// The Blokli service endpoint: a URL plus an optional DNS-resolution override.
+///
+/// [`Default`] yields [`DEFAULT_BLOKLI_URL`] resolved through system DNS.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlokliEndpoint {
+    /// URL of the Blokli service.
+    pub url: Url,
+    /// When set, bypasses system DNS for [`Self::url`]'s host.
+    pub dns_override: Option<BlokliDnsOverride>,
+}
+
+impl Default for BlokliEndpoint {
+    fn default() -> Self {
+        Self {
+            url: DEFAULT_BLOKLI_URL.clone(),
+            dns_override: None,
+        }
+    }
+}
+
+impl BlokliEndpoint {
+    /// Creates an endpoint for `url` resolved through system DNS.
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            dns_override: None,
+        }
+    }
+
+    /// Sets the DNS override, replacing any previously configured one.
+    pub fn with_dns_override(mut self, dns_override: Option<BlokliDnsOverride>) -> Self {
+        self.dns_override = dns_override;
+        self
+    }
+
+    /// Creates an endpoint from a URL string, falling back to [`DEFAULT_BLOKLI_URL`]
+    /// when `url` is `None`.
+    pub fn parse(
+        url: Option<&str>,
+        dns_override: Option<BlokliDnsOverride>,
+    ) -> Result<Self, EdgliError> {
+        let url = match url {
+            Some(url) => url
+                .parse()
+                .map_err(|e| EdgliError::ConfigError(format!("invalid Blokli URL '{url}': {e}")))?,
+            None => DEFAULT_BLOKLI_URL.clone(),
+        };
+
+        Ok(Self { url, dns_override })
+    }
+
+    /// Converts the endpoint into the chain connector's client configuration.
+    ///
+    /// The connector represents the override as a tuple, so this is where
+    /// [`BlokliDnsOverride`] is destructured.
+    pub(crate) fn to_client_config(&self) -> HoprBlokliClientConfig {
+        HoprBlokliClientConfig {
+            url: self.url.clone(),
+            dns_override: self.dns_override.map(|o| (o.ip, o.port)),
+        }
+    }
+
+    /// Builds a Blokli client for this endpoint.
+    pub(crate) fn build_client(&self) -> BlokliClient {
+        create_blokli_client(self.to_client_config())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn parse_defaults_to_production_url() {
+        let endpoint = BlokliEndpoint::parse(None, None).unwrap();
+        assert_eq!(endpoint.url, *DEFAULT_BLOKLI_URL);
+        assert_eq!(endpoint.dns_override, None);
+    }
+
+    #[test]
+    fn parse_keeps_dns_override() {
+        let dns_override = Some(BlokliDnsOverride::new(v4(10, 1, 2, 1), Some(3002)));
+        let endpoint =
+            BlokliEndpoint::parse(Some("https://blokli.example.com"), dns_override).unwrap();
+        assert_eq!(endpoint.url.as_str(), "https://blokli.example.com/");
+        assert_eq!(endpoint.dns_override, dns_override);
+    }
+
+    #[test]
+    fn parse_rejects_invalid_url() {
+        let error = BlokliEndpoint::parse(Some("not a url"), None).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "configuration error: 'invalid Blokli URL 'not a url': relative URL without a base'"
+        );
+    }
+
+    #[test]
+    fn default_endpoint_matches_default_url() {
+        let endpoint = BlokliEndpoint::default();
+        assert_eq!(endpoint.url, *DEFAULT_BLOKLI_URL);
+        assert_eq!(endpoint.dns_override, None);
+    }
+
+    /// Regression guard: the safeless/onboarding path used to build its client through
+    /// `HoprBlokliClientConfig::new`, which hardcodes `dns_override: None`, so a
+    /// caller-supplied DNS bypass was silently discarded. Both the node path and the
+    /// safeless path now resolve through this single seam.
+    #[test]
+    fn to_client_config_propagates_dns_override() {
+        let dns_override = BlokliDnsOverride::new(v4(10, 1, 2, 1), Some(3002));
+        let endpoint = BlokliEndpoint::default().with_dns_override(Some(dns_override));
+
+        let config = endpoint.to_client_config();
+        assert_eq!(config.url, endpoint.url);
+        assert_eq!(config.dns_override, Some((v4(10, 1, 2, 1), Some(3002))));
+    }
+
+    #[test]
+    fn to_client_config_without_override_uses_system_dns() {
+        let config = BlokliEndpoint::default().to_client_config();
+        assert_eq!(config.dns_override, None);
+    }
+
+    #[test]
+    fn from_str_parses_bare_ip() {
+        let parsed: BlokliDnsOverride = "127.0.0.1".parse().unwrap();
+        assert_eq!(parsed, BlokliDnsOverride::new(v4(127, 0, 0, 1), None));
+    }
+
+    #[test]
+    fn from_str_parses_ip_and_port() {
+        let parsed: BlokliDnsOverride = "10.1.2.1:3002".parse().unwrap();
+        assert_eq!(parsed, BlokliDnsOverride::new(v4(10, 1, 2, 1), Some(3002)));
+    }
+
+    #[test]
+    fn from_str_parses_ipv6_forms() {
+        let loopback = IpAddr::V6(Ipv6Addr::LOCALHOST);
+
+        let bare: BlokliDnsOverride = "::1".parse().unwrap();
+        assert_eq!(bare, BlokliDnsOverride::new(loopback, None));
+
+        let with_port: BlokliDnsOverride = "[::1]:3002".parse().unwrap();
+        assert_eq!(with_port, BlokliDnsOverride::new(loopback, Some(3002)));
+    }
+
+    #[test]
+    fn from_str_rejects_garbage() {
+        let error = "nope".parse::<BlokliDnsOverride>().unwrap_err();
+        assert_eq!(
+            error,
+            "invalid DNS override 'nope', expected <IP_ADDRESS> or <IP_ADDRESS>:<PORT>"
+        );
+    }
+
+    #[test]
+    fn display_from_str_roundtrip() {
+        for input in ["127.0.0.1", "10.1.2.1:3002", "::1", "[::1]:3002"] {
+            let parsed: BlokliDnsOverride = input.parse().unwrap();
+            let rendered = parsed.to_string();
+            assert_eq!(rendered.parse::<BlokliDnsOverride>().unwrap(), parsed);
+        }
+    }
+}

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -17,6 +17,15 @@ use url::Url;
 use crate::blokli::DEFAULT_BLOKLI_URL;
 use crate::errors::EdgliError;
 
+/// Error returned when a [`BlokliDnsOverride`] cannot be parsed.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ParseBlokliDnsOverrideError {
+    /// The input is neither an IP address nor an IP address with a port.
+    #[error("invalid DNS override '{input}', expected <IP_ADDRESS> or <IP_ADDRESS>:<PORT>")]
+    InvalidFormat { input: String },
+}
+
 /// DNS resolution override for the Blokli endpoint host.
 ///
 /// Pins the endpoint hostname to a fixed address so no system DNS lookup is needed.
@@ -24,6 +33,8 @@ use crate::errors::EdgliError;
 /// validation still use the original hostname.
 ///
 /// When [`Self::port`] is `None`, the endpoint URL's port (or its scheme default) is used.
+/// IPv6 addresses with a port must use brackets, for example `[::1]:3002`;
+/// an unbracketed value such as `::1:3002` is parsed as an address without a port.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BlokliDnsOverride {
     /// IP address to connect to instead of resolving the endpoint host.
@@ -40,7 +51,7 @@ impl BlokliDnsOverride {
 }
 
 impl FromStr for BlokliDnsOverride {
-    type Err = String;
+    type Err = ParseBlokliDnsOverrideError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         if let Ok(ip) = value.parse::<IpAddr>() {
@@ -54,9 +65,9 @@ impl FromStr for BlokliDnsOverride {
             });
         }
 
-        Err(format!(
-            "invalid DNS override '{value}', expected <IP_ADDRESS> or <IP_ADDRESS>:<PORT>"
-        ))
+        Err(ParseBlokliDnsOverrideError::InvalidFormat {
+            input: value.to_string(),
+        })
     }
 }
 
@@ -99,17 +110,15 @@ impl BlokliEndpoint {
     }
 
     /// Sets the DNS override, replacing any previously configured one.
-    pub fn with_dns_override(mut self, dns_override: Option<BlokliDnsOverride>) -> Self {
-        self.dns_override = dns_override;
+    pub fn with_dns_override(mut self, dns_override: BlokliDnsOverride) -> Self {
+        self.dns_override = Some(dns_override);
         self
     }
 
-    /// Creates an endpoint from a URL string, falling back to [`DEFAULT_BLOKLI_URL`]
-    /// when `url` is `None`.
-    pub fn parse(
-        url: Option<&str>,
-        dns_override: Option<BlokliDnsOverride>,
-    ) -> Result<Self, EdgliError> {
+    /// Creates an endpoint from an optional URL string.
+    ///
+    /// Uses [`DEFAULT_BLOKLI_URL`] when `url` is `None`.
+    pub fn from_optional_url(url: Option<&str>) -> Result<Self, EdgliError> {
         let url = match url {
             Some(url) => url
                 .parse()
@@ -117,7 +126,10 @@ impl BlokliEndpoint {
             None => DEFAULT_BLOKLI_URL.clone(),
         };
 
-        Ok(Self { url, dns_override })
+        Ok(Self {
+            url,
+            dns_override: None,
+        })
     }
 
     /// Converts the endpoint into the chain connector's client configuration.
@@ -147,28 +159,29 @@ mod tests {
     }
 
     #[test]
-    fn parse_defaults_to_production_url() {
-        let endpoint = BlokliEndpoint::parse(None, None).unwrap();
+    fn from_optional_url_defaults_to_production_url() {
+        let endpoint = BlokliEndpoint::from_optional_url(None).unwrap();
         assert_eq!(endpoint.url, *DEFAULT_BLOKLI_URL);
         assert_eq!(endpoint.dns_override, None);
     }
 
     #[test]
-    fn parse_keeps_dns_override() {
-        let dns_override = Some(BlokliDnsOverride::new(v4(10, 1, 2, 1), Some(3002)));
+    fn from_optional_url_keeps_custom_url() {
         let endpoint =
-            BlokliEndpoint::parse(Some("https://blokli.example.com"), dns_override).unwrap();
+            BlokliEndpoint::from_optional_url(Some("https://blokli.example.com")).unwrap();
         assert_eq!(endpoint.url.as_str(), "https://blokli.example.com/");
-        assert_eq!(endpoint.dns_override, dns_override);
+        assert_eq!(endpoint.dns_override, None);
     }
 
     #[test]
-    fn parse_rejects_invalid_url() {
-        let error = BlokliEndpoint::parse(Some("not a url"), None).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "configuration error: 'invalid Blokli URL 'not a url': relative URL without a base'"
-        );
+    fn from_optional_url_rejects_invalid_url() {
+        let error = BlokliEndpoint::from_optional_url(Some("not a url")).unwrap_err();
+        match error {
+            EdgliError::ConfigError(message) => {
+                assert!(message.starts_with("invalid Blokli URL 'not a url':"));
+            }
+            other => panic!("expected configuration error, got {other}"),
+        }
     }
 
     #[test]
@@ -185,7 +198,7 @@ mod tests {
     #[test]
     fn to_client_config_propagates_dns_override() {
         let dns_override = BlokliDnsOverride::new(v4(10, 1, 2, 1), Some(3002));
-        let endpoint = BlokliEndpoint::default().with_dns_override(Some(dns_override));
+        let endpoint = BlokliEndpoint::default().with_dns_override(dns_override);
 
         let config = endpoint.to_client_config();
         assert_eq!(config.url, endpoint.url);
@@ -222,11 +235,20 @@ mod tests {
     }
 
     #[test]
+    fn from_str_treats_unbracketed_ipv6_suffix_as_address() {
+        let ip = "::1:3002".parse::<IpAddr>().unwrap();
+        let parsed: BlokliDnsOverride = "::1:3002".parse().unwrap();
+        assert_eq!(parsed, BlokliDnsOverride::new(ip, None));
+    }
+
+    #[test]
     fn from_str_rejects_garbage() {
         let error = "nope".parse::<BlokliDnsOverride>().unwrap_err();
         assert_eq!(
             error,
-            "invalid DNS override 'nope', expected <IP_ADDRESS> or <IP_ADDRESS>:<PORT>"
+            ParseBlokliDnsOverrideError::InvalidFormat {
+                input: "nope".to_string()
+            }
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// The concrete client needs both an async runtime and a blockchain connector;
+// `blokli` is currently the only supported connector.
 #[cfg(all(feature = "runtime-tokio", feature = "blokli"))]
 pub mod client;
 pub mod errors;
@@ -17,10 +19,12 @@ pub use hopr_lib;
 pub use blokli::*;
 #[cfg(feature = "blokli")]
 pub use endpoint::*;
+#[cfg(feature = "blokli")]
 pub use hopr_chain_connector::BlockchainConnectorConfig;
 pub use hopr_lib::exports::transport::path::PathPlannerConfig;
 // Re-exported so consumers constructing a `BlokliEndpoint` do not need their own
 // `url` dependency, which would have to match this crate's version to unify.
+#[cfg(feature = "blokli")]
 pub use url::Url;
 
 /// Returns a [`PathPlannerConfig`] optimised for low-latency path selection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ pub mod errors;
 #[cfg(feature = "blokli")]
 pub mod blokli;
 
+#[cfg(feature = "blokli")]
+pub mod endpoint;
+
 pub mod strategy;
 pub mod traits;
 
@@ -12,8 +15,13 @@ pub use hopr_lib;
 
 #[cfg(feature = "blokli")]
 pub use blokli::*;
+#[cfg(feature = "blokli")]
+pub use endpoint::*;
 pub use hopr_chain_connector::BlockchainConnectorConfig;
 pub use hopr_lib::exports::transport::path::PathPlannerConfig;
+// Re-exported so consumers constructing a `BlokliEndpoint` do not need their own
+// `url` dependency, which would have to match this crate's version to unify.
+pub use url::Url;
 
 /// Returns a [`PathPlannerConfig`] optimised for low-latency path selection.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "runtime-tokio")]
+#[cfg(all(feature = "runtime-tokio", feature = "blokli"))]
 pub mod client;
 pub mod errors;
 
@@ -33,8 +33,9 @@ pub use url::Url;
 /// `min_ack_rate` controls the minimum message-acknowledgement rate an edge
 /// must exhibit before it is eligible for path inclusion.
 ///
-/// Pass the result as the `path_planner` argument of [`Edgli::new`] or
-/// [`run_hopr_edge_node_with`] to activate latency-optimised routing.
+/// Pass the result as the `path_planner` configuration when constructing an
+/// edge client to activate latency-optimised routing. The concrete client is
+/// available when both the `runtime-tokio` and `blokli` features are enabled.
 pub fn latency_path_planner_config(min_ack_rate: f64) -> PathPlannerConfig {
     PathPlannerConfig {
         min_ack_rate,
@@ -44,7 +45,7 @@ pub fn latency_path_planner_config(min_ack_rate: f64) -> PathPlannerConfig {
     }
 }
 
-#[cfg(feature = "runtime-tokio")]
+#[cfg(all(feature = "runtime-tokio", feature = "blokli"))]
 pub use client::*;
 pub use traits::{EdgeNodeApi, NodeBalances};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ pub struct CliArgs {
         long,
         env = "HOPR_EDGE_BLOKLI_DNS_OVERRIDE",
         value_parser = BlokliDnsOverride::from_str,
-        help = "The DNS override for the blokli provider, with format <IP_ADDRESS>[:<PORT>]",
+        help = "The DNS override for the blokli provider; IPv6 addresses with a port must use brackets, for example [::1]:3002",
         required = false
     )]
     pub blokli_dns_override: Option<BlokliDnsOverride>,
@@ -222,8 +222,10 @@ async fn main() -> anyhow::Result<()> {
         "Starting Edgli"
     );
 
-    let blokli_endpoint =
-        BlokliEndpoint::parse(args.blokli_url.as_deref(), args.blokli_dns_override)?;
+    let mut blokli_endpoint = BlokliEndpoint::from_optional_url(args.blokli_url.as_deref())?;
+    if let Some(dns_override) = args.blokli_dns_override {
+        blokli_endpoint = blokli_endpoint.with_dns_override(dns_override);
+    }
 
     let edgli = edgli::Edgli::new(
         cfg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use async_signal::{Signal, Signals};
 use clap::Parser;
@@ -16,21 +16,7 @@ use {
     opentelemetry_sdk::trace::{RandomIdGenerator, Sampler},
 };
 
-use edgli::errors::EdgliError;
-
-fn parse_blokli_dns_override(value: &str) -> Result<(IpAddr, Option<u16>), String> {
-    if let Ok(ip) = value.parse::<IpAddr>() {
-        return Ok((ip, None));
-    }
-
-    if let Ok(addr) = value.parse::<SocketAddr>() {
-        return Ok((addr.ip(), Some(addr.port())));
-    }
-
-    Err(format!(
-        "invalid DNS override '{value}', expected <IP_ADDRESS> or <IP_ADDRESS>:<PORT>"
-    ))
-}
+use edgli::{BlokliDnsOverride, BlokliEndpoint, errors::EdgliError};
 
 // Avoid musl's default allocator due to degraded performance
 // https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance
@@ -84,11 +70,11 @@ pub struct CliArgs {
     #[arg(
         long,
         env = "HOPR_EDGE_BLOKLI_DNS_OVERRIDE",
-        value_parser = parse_blokli_dns_override,
+        value_parser = BlokliDnsOverride::from_str,
         help = "The DNS override for the blokli provider, with format <IP_ADDRESS>[:<PORT>]",
         required = false
     )]
-    pub blokli_dns_override: Option<(IpAddr, Option<u16>)>,
+    pub blokli_dns_override: Option<BlokliDnsOverride>,
 
     /// Probe non-public (private, loopback, link-local) peer addresses from announcements
     #[arg(
@@ -236,11 +222,13 @@ async fn main() -> anyhow::Result<()> {
         "Starting Edgli"
     );
 
+    let blokli_endpoint =
+        BlokliEndpoint::parse(args.blokli_url.as_deref(), args.blokli_dns_override)?;
+
     let edgli = edgli::Edgli::new(
         cfg,
         hopr_keys,
-        args.blokli_url,
-        args.blokli_dns_override,
+        blokli_endpoint,
         None,
         args.probe_local_addresses,
         |s| {
@@ -269,22 +257,4 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_blokli_dns_override;
-    use std::net::{IpAddr, Ipv4Addr};
-
-    #[test]
-    fn parses_dns_override_without_port() {
-        let parsed = parse_blokli_dns_override("127.0.0.1").unwrap();
-        assert_eq!(parsed, (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), None));
-    }
-
-    #[test]
-    fn parses_dns_override_with_port() {
-        let parsed = parse_blokli_dns_override("10.1.2.1:3002").unwrap();
-        assert_eq!(parsed, (IpAddr::V4(Ipv4Addr::new(10, 1, 2, 1)), Some(3002)));
-    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -79,7 +79,7 @@ pub trait EdgeNodeApi: Send + Sync {
     async fn connected_peer_addresses(&self) -> std::result::Result<Vec<Address>, HoprLibError>;
 }
 
-#[cfg(feature = "runtime-tokio")]
+#[cfg(all(feature = "runtime-tokio", feature = "blokli"))]
 mod impl_edgli {
     use super::*;
     use crate::client::Edgli;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1121,7 +1121,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     let edgli = Edgli::new(
         build_edgli_config(extra, &tuning),
         hopr_keys,
-        BlokliEndpoint::parse(Some(&summary.blokli_url), None)?,
+        BlokliEndpoint::from_optional_url(Some(&summary.blokli_url))?,
         Some(tuning.connector_cfg),
         tuning.probe_local,
         |s: EdgliInitState| tracing::info!(?s, "edgli init"),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use anyhow::Context as _;
 use std::{path::PathBuf, time::Duration};
 
 use edgli::{
-    Edgli, EdgliInitState, PathPlannerConfig,
+    BlokliEndpoint, Edgli, EdgliInitState, PathPlannerConfig,
     hopr_lib::{
         HopRouting, HoprKeys, HoprSessionClientConfig, IdentityRetrievalModes,
         api::{
@@ -1121,8 +1121,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     let edgli = Edgli::new(
         build_edgli_config(extra, &tuning),
         hopr_keys,
-        Some(summary.blokli_url.clone()),
-        None,
+        BlokliEndpoint::parse(Some(&summary.blokli_url), None)?,
         Some(tuning.connector_cfg),
         tuning.probe_local,
         |s: EdgliInitState| tracing::info!(?s, "edgli init"),


### PR DESCRIPTION
This allows an edgli user to configure blokli DNS override consistently.
Blokli endpoint relevant logic has been refactored into a dedicated module.