### PR TITLE
fix: include one-time key-binding fee in minimum balance recommendation

### DIFF
--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -77,9 +77,10 @@ pub trait IncentiveOperations: Send + Sync {
     /// Fetch current on-chain ticket pricing parameters.
     async fn ticket_stats(&self) -> anyhow::Result<TicketStats>;
 
-    /// Fetch the one-time key-binding fee burned from the Safe when a fresh
-    /// node announces itself on-chain. Not charged again once the account exists.
-    async fn key_binding_fee(&self) -> anyhow::Result<HoprBalance>;
+    /// Returns the one-time key-binding fee burned from the Safe when a fresh
+    /// node announces itself on-chain, verified against on-chain state: the full
+    /// fee when this key-pair has no account yet, zero once the key is bound.
+    async fn pending_key_binding_fee(&self) -> anyhow::Result<HoprBalance>;
 
     /// Fetch the WxHOPR and xDAI balances for this key-pair.
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)>;
@@ -208,10 +209,9 @@ where
         })
     }
 
-    pub async fn key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
-        ChainValues::key_binding_fee(&self.connector)
-            .await
-            .map_err(anyhow::Error::from)
+    pub async fn pending_key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
+        let me = self.chain_key.public().to_address();
+        crate::strategy::pending_key_binding_fee(self.connector.as_ref(), me).await
     }
 
     pub async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
@@ -251,8 +251,8 @@ where
         SafelessInteractor::ticket_stats(self).await
     }
 
-    async fn key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
-        SafelessInteractor::key_binding_fee(self).await
+    async fn pending_key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
+        SafelessInteractor::pending_key_binding_fee(self).await
     }
 
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
@@ -382,6 +382,43 @@ mod tests {
             connector_err.as_transaction_rejection_error().is_some(),
             "expected tx-rejection error from chain emulator, got: {connector_err:?}"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_key_binding_fee_charges_fee_when_key_not_bound() -> anyhow::Result<()> {
+        let chain_key = ChainKeypair::random();
+        let me = chain_key.public().to_address();
+        let recipient: Address = [0x22u8; 20].into();
+
+        let client = build_test_client(me, HoprBalance::new_base(100), recipient);
+        let interactor = SafelessInteractor::new_with_client(client, &chain_key, None).await?;
+
+        let fee = interactor.pending_key_binding_fee().await?;
+        assert_eq!(fee, "0.01 wxHOPR".parse::<HoprBalance>().unwrap());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_key_binding_fee_is_zero_once_key_is_bound() -> anyhow::Result<()> {
+        let chain_key = ChainKeypair::random();
+        let me = chain_key.public().to_address();
+
+        let client = BlokliTestStateBuilder::default()
+            .with_generated_accounts(
+                &[&me],
+                false,
+                XDaiBalance::new_base(10),
+                HoprBalance::new_base(100),
+            )
+            .with_hopr_network_chain_info("rotsee")
+            .build_dynamic_client(placeholder_module_addr());
+        let interactor = SafelessInteractor::new_with_client(client, &chain_key, None).await?;
+
+        let fee = interactor.pending_key_binding_fee().await?;
+        assert_eq!(fee, HoprBalance::zero());
 
         Ok(())
     }

--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -77,10 +77,12 @@ pub trait IncentiveOperations: Send + Sync {
     /// Fetch current on-chain ticket pricing parameters.
     async fn ticket_stats(&self) -> anyhow::Result<TicketStats>;
 
-    /// Returns the one-time key-binding fee burned from the Safe when a fresh
-    /// node announces itself on-chain, verified against on-chain state: the full
-    /// fee when this key-pair has no account yet, zero once the key is bound.
-    async fn pending_key_binding_fee(&self) -> anyhow::Result<HoprBalance>;
+    /// Returns the fee still owed before this key-pair can be fully up and
+    /// running, verified against on-chain state. Today that is only the one-time
+    /// key-binding fee burned from the Safe when a fresh node announces itself:
+    /// the full fee when this key-pair has no account yet, zero once the key is
+    /// bound.
+    async fn compute_fee_to_start(&self) -> anyhow::Result<HoprBalance>;
 
     /// Fetch the WxHOPR and xDAI balances for this key-pair.
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)>;
@@ -209,9 +211,9 @@ where
         })
     }
 
-    pub async fn pending_key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
+    pub async fn compute_fee_to_start(&self) -> anyhow::Result<HoprBalance> {
         let me = self.chain_key.public().to_address();
-        crate::strategy::pending_key_binding_fee(self.connector.as_ref(), me).await
+        crate::strategy::compute_fee_to_start(self.connector.as_ref(), Some(me)).await
     }
 
     pub async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
@@ -251,8 +253,8 @@ where
         SafelessInteractor::ticket_stats(self).await
     }
 
-    async fn pending_key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
-        SafelessInteractor::pending_key_binding_fee(self).await
+    async fn compute_fee_to_start(&self) -> anyhow::Result<HoprBalance> {
+        SafelessInteractor::compute_fee_to_start(self).await
     }
 
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
@@ -387,7 +389,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_key_binding_fee_charges_fee_when_key_not_bound() -> anyhow::Result<()> {
+    async fn compute_fee_to_start_charges_fee_when_key_not_bound() -> anyhow::Result<()> {
         let chain_key = ChainKeypair::random();
         let me = chain_key.public().to_address();
         let recipient: Address = [0x22u8; 20].into();
@@ -395,14 +397,14 @@ mod tests {
         let client = build_test_client(me, HoprBalance::new_base(100), recipient);
         let interactor = SafelessInteractor::new_with_client(client, &chain_key, None).await?;
 
-        let fee = interactor.pending_key_binding_fee().await?;
+        let fee = interactor.compute_fee_to_start().await?;
         assert_eq!(fee, "0.01 wxHOPR".parse::<HoprBalance>().unwrap());
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn pending_key_binding_fee_is_zero_once_key_is_bound() -> anyhow::Result<()> {
+    async fn compute_fee_to_start_is_zero_once_key_is_bound() -> anyhow::Result<()> {
         let chain_key = ChainKeypair::random();
         let me = chain_key.public().to_address();
 
@@ -417,7 +419,7 @@ mod tests {
             .build_dynamic_client(placeholder_module_addr());
         let interactor = SafelessInteractor::new_with_client(client, &chain_key, None).await?;
 
-        let fee = interactor.pending_key_binding_fee().await?;
+        let fee = interactor.compute_fee_to_start().await?;
         assert_eq!(fee, HoprBalance::zero());
 
         Ok(())

--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -77,12 +77,12 @@ pub trait IncentiveOperations: Send + Sync {
     /// Fetch current on-chain ticket pricing parameters.
     async fn ticket_stats(&self) -> anyhow::Result<TicketStats>;
 
-    /// Returns the fee still owed before this key-pair can be fully up and
-    /// running, verified against on-chain state. Today that is only the one-time
-    /// key-binding fee burned from the Safe when a fresh node announces itself:
-    /// the full fee when this key-pair has no account yet, zero once the key is
-    /// bound.
-    async fn compute_fee_to_start(&self) -> anyhow::Result<HoprBalance>;
+    /// Returns what this key-pair still owes before being fully up and running,
+    /// verified against on-chain state: the one-time key-binding fee burned from
+    /// the Safe when a fresh node announces itself (zero once the key is bound),
+    /// and the number of on-chain transactions left before channel funding can
+    /// begin (Safe deployment, Safe registration, key-binding announcement).
+    async fn compute_costs_to_start(&self) -> anyhow::Result<crate::strategy::StartupCosts>;
 
     /// Fetch the WxHOPR and xDAI balances for this key-pair.
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)>;
@@ -211,9 +211,11 @@ where
         })
     }
 
-    pub async fn compute_fee_to_start(&self) -> anyhow::Result<HoprBalance> {
+    pub async fn compute_costs_to_start(&self) -> anyhow::Result<crate::strategy::StartupCosts> {
         let me = self.chain_key.public().to_address();
-        crate::strategy::compute_fee_to_start(self.connector.as_ref(), Some(me)).await
+        let safe_deployed = self.retrieve_safe().await?.is_some();
+        crate::strategy::compute_costs_to_start(self.connector.as_ref(), Some(me), safe_deployed)
+            .await
     }
 
     pub async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
@@ -253,8 +255,8 @@ where
         SafelessInteractor::ticket_stats(self).await
     }
 
-    async fn compute_fee_to_start(&self) -> anyhow::Result<HoprBalance> {
-        SafelessInteractor::compute_fee_to_start(self).await
+    async fn compute_costs_to_start(&self) -> anyhow::Result<crate::strategy::StartupCosts> {
+        SafelessInteractor::compute_costs_to_start(self).await
     }
 
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
@@ -389,7 +391,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_fee_to_start_charges_fee_when_key_not_bound() -> anyhow::Result<()> {
+    async fn compute_costs_to_start_charges_fee_when_key_not_bound() -> anyhow::Result<()> {
         let chain_key = ChainKeypair::random();
         let me = chain_key.public().to_address();
         let recipient: Address = [0x22u8; 20].into();
@@ -397,14 +399,19 @@ mod tests {
         let client = build_test_client(me, HoprBalance::new_base(100), recipient);
         let interactor = SafelessInteractor::new_with_client(client, &chain_key, None).await?;
 
-        let fee = interactor.compute_fee_to_start().await?;
-        assert_eq!(fee, "0.01 wxHOPR".parse::<HoprBalance>().unwrap());
+        let costs = interactor.compute_costs_to_start().await?;
+        assert_eq!(
+            costs.fee_to_start,
+            "0.01 wxHOPR".parse::<HoprBalance>().unwrap()
+        );
+        // No Safe and no key binding yet: deploy + register + announce.
+        assert_eq!(costs.txs_to_start, 3);
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn compute_fee_to_start_is_zero_once_key_is_bound() -> anyhow::Result<()> {
+    async fn compute_costs_to_start_is_zero_once_key_is_bound() -> anyhow::Result<()> {
         let chain_key = ChainKeypair::random();
         let me = chain_key.public().to_address();
 
@@ -419,8 +426,10 @@ mod tests {
             .build_dynamic_client(placeholder_module_addr());
         let interactor = SafelessInteractor::new_with_client(client, &chain_key, None).await?;
 
-        let fee = interactor.compute_fee_to_start().await?;
-        assert_eq!(fee, HoprBalance::zero());
+        let costs = interactor.compute_costs_to_start().await?;
+        assert_eq!(costs.fee_to_start, HoprBalance::zero());
+        // Bound key implies registration and announcement are done.
+        assert_eq!(costs.txs_to_start, 0);
 
         Ok(())
     }

--- a/src/blokli.rs
+++ b/src/blokli.rs
@@ -77,6 +77,10 @@ pub trait IncentiveOperations: Send + Sync {
     /// Fetch current on-chain ticket pricing parameters.
     async fn ticket_stats(&self) -> anyhow::Result<TicketStats>;
 
+    /// Fetch the one-time key-binding fee burned from the Safe when a fresh
+    /// node announces itself on-chain. Not charged again once the account exists.
+    async fn key_binding_fee(&self) -> anyhow::Result<HoprBalance>;
+
     /// Fetch the WxHOPR and xDAI balances for this key-pair.
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)>;
 
@@ -204,6 +208,12 @@ where
         })
     }
 
+    pub async fn key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
+        ChainValues::key_binding_fee(&self.connector)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
     pub async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {
         let me = self.chain_key.public().to_address();
         let hopr: HoprBalance = ChainValues::balance(&self.connector, me)
@@ -239,6 +249,10 @@ where
 
     async fn ticket_stats(&self) -> anyhow::Result<TicketStats> {
         SafelessInteractor::ticket_stats(self).await
+    }
+
+    async fn key_binding_fee(&self) -> anyhow::Result<HoprBalance> {
+        SafelessInteractor::key_binding_fee(self).await
     }
 
     async fn balances(&self) -> anyhow::Result<(HoprBalance, XDaiBalance)> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -387,7 +387,14 @@ impl Edgli {
             .count();
 
         let missing = cfg.target_open_channels.saturating_sub(open_to_connected);
-        super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing)
+        // A running node has already paid the one-time key-binding fee.
+        super::strategy::compute_balance_recommendation(
+            ticket_price,
+            win_prob,
+            cfg,
+            missing,
+            HoprBalance::zero(),
+        )
     }
 
     /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityAllocator`].

--- a/src/client.rs
+++ b/src/client.rs
@@ -389,13 +389,13 @@ impl Edgli {
         let missing = cfg.target_open_channels.saturating_sub(open_to_connected);
         // Zero for a running node — hopr-lib announces during startup — but
         // verified on-chain rather than assumed.
-        let key_binding_fee = super::strategy::pending_key_binding_fee(chain, source).await?;
+        let fee_to_start = super::strategy::compute_fee_to_start(chain, Some(source)).await?;
         super::strategy::compute_balance_recommendation(
             ticket_price,
             win_prob,
             cfg,
             missing,
-            key_binding_fee,
+            fee_to_start,
         )
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -387,13 +387,15 @@ impl Edgli {
             .count();
 
         let missing = cfg.target_open_channels.saturating_sub(open_to_connected);
-        // A running node has already paid the one-time key-binding fee.
+        // Zero for a running node — hopr-lib announces during startup — but
+        // verified on-chain rather than assumed.
+        let key_binding_fee = super::strategy::pending_key_binding_fee(chain, source).await?;
         super::strategy::compute_balance_recommendation(
             ticket_price,
             win_prob,
             cfg,
             missing,
-            HoprBalance::zero(),
+            key_binding_fee,
         )
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -389,14 +389,9 @@ impl Edgli {
         let missing = cfg.target_open_channels.saturating_sub(open_to_connected);
         // Zero for a running node — hopr-lib announces during startup — but
         // verified on-chain rather than assumed.
-        let fee_to_start = super::strategy::compute_fee_to_start(chain, Some(source)).await?;
-        super::strategy::compute_balance_recommendation(
-            ticket_price,
-            win_prob,
-            cfg,
-            missing,
-            fee_to_start,
-        )
+        // A running node cannot start without a Safe, so it is always deployed here.
+        let costs = super::strategy::compute_costs_to_start(chain, Some(source), true).await?;
+        super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing, costs)
     }
 
     /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityAllocator`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use hopr_lib::api::types::{
     primitive::prelude::{Balance, XDai},
 };
 
-pub use strategy::{BalanceRecommendation, Capacity, CapacityAllocator};
+pub use strategy::{BalanceRecommendation, Capacity, CapacityAllocator, StartupCosts};
 
 #[cfg(feature = "blokli")]
 pub use strategy::minimum_balance_recommendation;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -117,14 +117,41 @@ pub fn compute_funding_config(
     })
 }
 
-/// Minimum recommended wxHOPR and xDAI balance to open the target number of channels.
+/// One-time costs still owed before this node can be fully up and running,
+/// verified against on-chain state.
+#[derive(Clone, Copy, Debug)]
+pub struct StartupCosts {
+    /// One-time fee still owed before the node can start (today the
+    /// key-binding fee); zero once the key is bound on-chain.
+    pub fee_to_start: HoprBalance,
+    /// Number of on-chain transactions still needed before channel-funding
+    /// transactions can begin: Safe + module deployment (when no Safe exists
+    /// yet), then Safe registration and the key-binding announcement (when the
+    /// key is not bound yet). Zero for a fully set-up node.
+    pub txs_to_start: u64,
+}
+
+/// Everything still needed for this node to be fully up and running.
 #[derive(Clone, Copy, Debug)]
 pub struct BalanceRecommendation {
-    /// Minimum wxHOPR needed to stake the missing channels, plus the one-time
-    /// key-binding fee when the node has not announced itself on-chain yet.
-    pub wxhopr: HoprBalance,
-    /// Minimum xDAI for gas (fixed at [`hopr_lib::SUGGESTED_NATIVE_BALANCE`]).
-    pub xdai: XDaiBalance,
+    /// wxHOPR needed to stake the missing channels.
+    pub channel_stakes: HoprBalance,
+    /// One-time fee still owed before the node can start (today the
+    /// key-binding fee); zero once the key is bound on-chain.
+    pub fee_to_start: HoprBalance,
+    /// Number of on-chain transactions still needed before channel-funding
+    /// transactions can begin; see [`StartupCosts::txs_to_start`].
+    pub txs_to_start: u64,
+    /// Maximum xDAI fee per transaction (gas)
+    /// (fixed at [`hopr_lib::SUGGESTED_NATIVE_BALANCE`]).
+    pub xdai_fee_per_tx: XDaiBalance,
+}
+
+impl BalanceRecommendation {
+    /// Total wxHOPR to fund: channel stakes plus the fee to start.
+    pub fn total_wxhopr(&self) -> HoprBalance {
+        self.channel_stakes + self.fee_to_start
+    }
 }
 
 /// Data-throughput capacity for a stake of wxHOPR at the current ticket price.
@@ -161,18 +188,18 @@ pub struct Capacity {
 
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
 ///
-/// `fee_to_start` is the fee still owed before the node can be fully up and
-/// running (today only the one-time announcement fee), added on top of the
-/// channel stakes; callers obtain it from [`compute_fee_to_start`], which
-/// returns zero when the node's key is already bound on-chain. On networks with
-/// a dust ticket price (e.g. rotsee: 100 wei tickets, 0.01 wxHOPR fee) the fee
-/// dominates the recommendation, so omitting it underfunds the node.
+/// `costs` are the one-time startup costs (fee and remaining transactions)
+/// reported as their own fields next to the channel stakes; callers obtain
+/// them from [`compute_costs_to_start`], which returns zeros for a fully
+/// set-up node. On networks with a dust ticket price (e.g. rotsee: 100 wei
+/// tickets, 0.01 wxHOPR fee) the fee dominates the recommendation, so omitting
+/// it underfunds the node.
 pub(crate) fn compute_balance_recommendation(
     ticket_price: HoprBalance,
     win_prob: f64,
     cfg: &IncentiveConfiguration,
     missing_channels: usize,
-    fee_to_start: HoprBalance,
+    costs: StartupCosts,
 ) -> anyhow::Result<BalanceRecommendation> {
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
@@ -181,8 +208,10 @@ pub(crate) fn compute_balance_recommendation(
             * (missing_channels as u64)
     };
     Ok(BalanceRecommendation {
-        wxhopr: stake + fee_to_start,
-        xdai: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
+        channel_stakes: stake,
+        fee_to_start: costs.fee_to_start,
+        txs_to_start: costs.txs_to_start,
+        xdai_fee_per_tx: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
     })
 }
 
@@ -222,18 +251,22 @@ pub(crate) fn compute_capacity(
     })
 }
 
-/// Returns the fee still owed before this user can be fully up and running,
-/// verified against on-chain state. Today that is only the one-time key-binding
-/// (announcement) fee: the full fee when no account exists for `node_address`
-/// yet, zero once the key is bound (the fee is never charged twice).
+/// Returns what this user still owes before being fully up and running,
+/// verified against on-chain state: the one-time key-binding (announcement)
+/// fee — the full fee when no account exists for `node_address` yet, zero once
+/// the key is bound (the fee is never charged twice) — and the number of
+/// on-chain transactions left before channel funding can begin (Safe + module
+/// deployment, Safe registration, key-binding announcement).
 ///
 /// `node_address` is `None` when the user has no address yet — nothing can be
-/// bound, so the full fee is owed.
+/// bound, so everything is still owed. `safe_deployed` tells whether a Safe
+/// already exists for this user; a running node always has one.
 #[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
-pub(crate) async fn compute_fee_to_start<T>(
+pub(crate) async fn compute_costs_to_start<T>(
     chain: &T,
     node_address: Option<Address>,
-) -> anyhow::Result<HoprBalance>
+    safe_deployed: bool,
+) -> anyhow::Result<StartupCosts>
 where
     T: ChainReadAccountOperations + ChainValues + Sync,
 {
@@ -246,11 +279,19 @@ where
         }
         None => false,
     };
-    if bound {
-        Ok(HoprBalance::zero())
+    let fee_to_start = if bound {
+        HoprBalance::zero()
     } else {
-        Ok(chain.key_binding_fee().await?)
-    }
+        chain.key_binding_fee().await?
+    };
+    // Startup submits: Safe + module deployment (unless one exists), then Safe
+    // registration and the key-binding announcement (skipped once the key is
+    // bound — a bound key implies a completed registration).
+    let txs_to_start = u64::from(!safe_deployed) + if bound { 0 } else { 2 };
+    Ok(StartupCosts {
+        fee_to_start,
+        txs_to_start,
+    })
 }
 
 /// Returns the minimum recommended wxHOPR and xDAI for this node to open
@@ -267,13 +308,13 @@ pub async fn minimum_balance_recommendation(
 ) -> anyhow::Result<BalanceRecommendation> {
     let stats = incentive_ops.ticket_stats().await?;
     let win_prob = stats.winning_probability.as_f64();
-    let fee_to_start = incentive_ops.compute_fee_to_start().await?;
+    let costs = incentive_ops.compute_costs_to_start().await?;
     compute_balance_recommendation(
         stats.ticket_price,
         win_prob,
         cfg,
         cfg.target_open_channels,
-        fee_to_start,
+        costs,
     )
 }
 
@@ -315,6 +356,14 @@ mod tests {
     use hopr_lib::api::types::primitive::prelude::HoprBalance;
 
     use super::*;
+
+    /// Fully set-up node: no fee owed, no startup transactions left.
+    fn no_startup_costs() -> StartupCosts {
+        StartupCosts {
+            fee_to_start: HoprBalance::zero(),
+            txs_to_start: 0,
+        }
+    }
 
     #[test]
     fn compute_funding_config_win_prob_one() {
@@ -450,16 +499,17 @@ mod tests {
             1.0,
             &IncentiveConfiguration::default(),
             0,
-            HoprBalance::zero(),
+            no_startup_costs(),
         )
         .unwrap();
-        assert_eq!(rec.wxhopr, HoprBalance::zero());
-        assert_eq!(rec.xdai, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
+        assert_eq!(rec.total_wxhopr(), HoprBalance::zero());
+        assert_eq!(rec.xdai_fee_per_tx, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
     }
 
     #[test]
-    fn compute_balance_recommendation_includes_fee_to_start() {
-        // rotsee-like: the fee dwarfs the channel stakes and must be added on top
+    fn compute_balance_recommendation_includes_startup_costs() {
+        // rotsee-like: the fee dwarfs the channel stakes and must be reported
+        // both as its own field and in the total
         let fee = HoprBalance::new_base(3);
         let rec = compute_balance_recommendation(
             HoprBalance::new_base(10),
@@ -469,10 +519,16 @@ mod tests {
                 ..Default::default()
             },
             8,
-            fee,
+            StartupCosts {
+                fee_to_start: fee,
+                txs_to_start: 3,
+            },
         )
         .unwrap();
-        assert_eq!(rec.wxhopr, HoprBalance::new_base(10) * 8u64 + fee);
+        assert_eq!(rec.channel_stakes, HoprBalance::new_base(10) * 8u64);
+        assert_eq!(rec.fee_to_start, fee);
+        assert_eq!(rec.txs_to_start, 3);
+        assert_eq!(rec.total_wxhopr(), HoprBalance::new_base(10) * 8u64 + fee);
     }
 
     #[test]
@@ -485,10 +541,16 @@ mod tests {
             1.0,
             &IncentiveConfiguration::default(),
             0,
-            fee,
+            StartupCosts {
+                fee_to_start: fee,
+                txs_to_start: 2,
+            },
         )
         .unwrap();
-        assert_eq!(rec.wxhopr, fee);
+        assert_eq!(rec.channel_stakes, HoprBalance::zero());
+        assert_eq!(rec.fee_to_start, fee);
+        assert_eq!(rec.txs_to_start, 2);
+        assert_eq!(rec.total_wxhopr(), fee);
     }
 
     #[test]
@@ -502,11 +564,14 @@ mod tests {
                 ..Default::default()
             },
             8,
-            HoprBalance::zero(),
+            no_startup_costs(),
         )
         .unwrap();
-        assert_eq!(rec.wxhopr, HoprBalance::new_base(10) * 8u64);
-        assert_eq!(rec.xdai, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
+        assert_eq!(rec.channel_stakes, HoprBalance::new_base(10) * 8u64);
+        assert_eq!(rec.fee_to_start, HoprBalance::zero());
+        assert_eq!(rec.txs_to_start, 0);
+        assert_eq!(rec.total_wxhopr(), HoprBalance::new_base(10) * 8u64);
+        assert_eq!(rec.xdai_fee_per_tx, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
     }
 
     #[test]
@@ -521,10 +586,10 @@ mod tests {
             1.0,
             &cfg,
             0,
-            HoprBalance::zero(),
+            no_startup_costs(),
         )
         .unwrap();
-        assert_eq!(rec.wxhopr, HoprBalance::zero());
+        assert_eq!(rec.total_wxhopr(), HoprBalance::zero());
     }
 
     #[test]

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -161,17 +161,18 @@ pub struct Capacity {
 
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
 ///
-/// `key_binding_fee` is the one-time announcement fee added on top of the channel
-/// stakes; callers obtain it from [`pending_key_binding_fee`], which returns zero
-/// when the node's key is already bound on-chain. On networks with a dust ticket
-/// price (e.g. rotsee: 100 wei tickets, 0.01 wxHOPR fee) the fee dominates the
-/// recommendation, so omitting it underfunds the node.
+/// `fee_to_start` is the fee still owed before the node can be fully up and
+/// running (today only the one-time announcement fee), added on top of the
+/// channel stakes; callers obtain it from [`compute_fee_to_start`], which
+/// returns zero when the node's key is already bound on-chain. On networks with
+/// a dust ticket price (e.g. rotsee: 100 wei tickets, 0.01 wxHOPR fee) the fee
+/// dominates the recommendation, so omitting it underfunds the node.
 pub(crate) fn compute_balance_recommendation(
     ticket_price: HoprBalance,
     win_prob: f64,
     cfg: &IncentiveConfiguration,
     missing_channels: usize,
-    key_binding_fee: HoprBalance,
+    fee_to_start: HoprBalance,
 ) -> anyhow::Result<BalanceRecommendation> {
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
@@ -180,7 +181,7 @@ pub(crate) fn compute_balance_recommendation(
             * (missing_channels as u64)
     };
     Ok(BalanceRecommendation {
-        wxhopr: stake + key_binding_fee,
+        wxhopr: stake + fee_to_start,
         xdai: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
     })
 }
@@ -221,21 +222,30 @@ pub(crate) fn compute_capacity(
     })
 }
 
-/// Returns the one-time key-binding fee still owed by `node_address`, verified
-/// against on-chain state: the full fee when no account exists for the address
+/// Returns the fee still owed before this user can be fully up and running,
+/// verified against on-chain state. Today that is only the one-time key-binding
+/// (announcement) fee: the full fee when no account exists for `node_address`
 /// yet, zero once the key is bound (the fee is never charged twice).
+///
+/// `node_address` is `None` when the user has no address yet — nothing can be
+/// bound, so the full fee is owed.
 #[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
-pub(crate) async fn pending_key_binding_fee<T>(
+pub(crate) async fn compute_fee_to_start<T>(
     chain: &T,
-    node_address: Address,
+    node_address: Option<Address>,
 ) -> anyhow::Result<HoprBalance>
 where
     T: ChainReadAccountOperations + ChainValues + Sync,
 {
-    let bound = chain
-        .count_accounts(AccountSelector::default().with_chain_key(node_address))
-        .await?
-        > 0;
+    let bound = match node_address {
+        Some(addr) => {
+            chain
+                .count_accounts(AccountSelector::default().with_chain_key(addr))
+                .await?
+                > 0
+        }
+        None => false,
+    };
     if bound {
         Ok(HoprBalance::zero())
     } else {
@@ -257,13 +267,13 @@ pub async fn minimum_balance_recommendation(
 ) -> anyhow::Result<BalanceRecommendation> {
     let stats = incentive_ops.ticket_stats().await?;
     let win_prob = stats.winning_probability.as_f64();
-    let key_binding_fee = incentive_ops.pending_key_binding_fee().await?;
+    let fee_to_start = incentive_ops.compute_fee_to_start().await?;
     compute_balance_recommendation(
         stats.ticket_price,
         win_prob,
         cfg,
         cfg.target_open_channels,
-        key_binding_fee,
+        fee_to_start,
     )
 }
 
@@ -448,7 +458,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_balance_recommendation_includes_key_binding_fee() {
+    fn compute_balance_recommendation_includes_fee_to_start() {
         // rotsee-like: the fee dwarfs the channel stakes and must be added on top
         let fee = HoprBalance::new_base(3);
         let rec = compute_balance_recommendation(

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -7,8 +7,10 @@ pub use hopr_strategy::channel_lifecycle::{
     ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig, SelectorProfile,
 };
 
+#[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
+use hopr_lib::api::chain::{AccountSelector, ChainReadAccountOperations, ChainValues};
 #[cfg(feature = "runtime-tokio")]
-use hopr_lib::api::{chain::ChainValues as _, node::HasChainApi as _};
+use hopr_lib::api::node::HasChainApi as _;
 
 /// Subset of strategies relevant to an edge node.
 pub enum EdgeStrategyKind {
@@ -160,9 +162,10 @@ pub struct Capacity {
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
 ///
 /// `key_binding_fee` is the one-time announcement fee added on top of the channel
-/// stakes; pass zero when the node's key is already bound on-chain. On networks
-/// with a dust ticket price (e.g. rotsee: 100 wei tickets, 0.01 wxHOPR fee) the
-/// fee dominates the recommendation, so omitting it underfunds the node.
+/// stakes; callers obtain it from [`pending_key_binding_fee`], which returns zero
+/// when the node's key is already bound on-chain. On networks with a dust ticket
+/// price (e.g. rotsee: 100 wei tickets, 0.01 wxHOPR fee) the fee dominates the
+/// recommendation, so omitting it underfunds the node.
 pub(crate) fn compute_balance_recommendation(
     ticket_price: HoprBalance,
     win_prob: f64,
@@ -218,13 +221,35 @@ pub(crate) fn compute_capacity(
     })
 }
 
+/// Returns the one-time key-binding fee still owed by `node_address`, verified
+/// against on-chain state: the full fee when no account exists for the address
+/// yet, zero once the key is bound (the fee is never charged twice).
+#[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
+pub(crate) async fn pending_key_binding_fee<T>(
+    chain: &T,
+    node_address: Address,
+) -> anyhow::Result<HoprBalance>
+where
+    T: ChainReadAccountOperations + ChainValues + Sync,
+{
+    let bound = chain
+        .count_accounts(AccountSelector::default().with_chain_key(node_address))
+        .await?
+        > 0;
+    if bound {
+        Ok(HoprBalance::zero())
+    } else {
+        Ok(chain.key_binding_fee().await?)
+    }
+}
+
 /// Returns the minimum recommended wxHOPR and xDAI for this node to open
 /// `cfg.target_open_channels` channels from scratch.
 ///
 /// Queries ticket pricing from the safeless chain interactor so this can be
-/// called before the full node is started (e.g. during onboarding). Because
-/// the node starts from scratch, the one-time key-binding (announcement) fee
-/// is included on top of the channel stakes.
+/// called before the full node is started (e.g. during onboarding). The
+/// one-time key-binding (announcement) fee is included on top of the channel
+/// stakes only when the node's key is not yet bound on-chain.
 #[cfg(feature = "blokli")]
 pub async fn minimum_balance_recommendation(
     incentive_ops: &dyn crate::blokli::IncentiveOperations,
@@ -232,7 +257,7 @@ pub async fn minimum_balance_recommendation(
 ) -> anyhow::Result<BalanceRecommendation> {
     let stats = incentive_ops.ticket_stats().await?;
     let win_prob = stats.winning_probability.as_f64();
-    let key_binding_fee = incentive_ops.key_binding_fee().await?;
+    let key_binding_fee = incentive_ops.pending_key_binding_fee().await?;
     compute_balance_recommendation(
         stats.ticket_price,
         win_prob,

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -118,7 +118,8 @@ pub fn compute_funding_config(
 /// Minimum recommended wxHOPR and xDAI balance to open the target number of channels.
 #[derive(Clone, Copy, Debug)]
 pub struct BalanceRecommendation {
-    /// Minimum wxHOPR needed to stake the missing channels.
+    /// Minimum wxHOPR needed to stake the missing channels, plus the one-time
+    /// key-binding fee when the node has not announced itself on-chain yet.
     pub wxhopr: HoprBalance,
     /// Minimum xDAI for gas (fixed at [`hopr_lib::SUGGESTED_NATIVE_BALANCE`]).
     pub xdai: XDaiBalance,
@@ -157,22 +158,26 @@ pub struct Capacity {
 }
 
 /// Compute the recommended wxHOPR and xDAI balances for `missing_channels` new channels.
+///
+/// `key_binding_fee` is the one-time announcement fee added on top of the channel
+/// stakes; pass zero when the node's key is already bound on-chain. On networks
+/// with a dust ticket price (e.g. rotsee: 100 wei tickets, 0.01 wxHOPR fee) the
+/// fee dominates the recommendation, so omitting it underfunds the node.
 pub(crate) fn compute_balance_recommendation(
     ticket_price: HoprBalance,
     win_prob: f64,
     cfg: &IncentiveConfiguration,
     missing_channels: usize,
+    key_binding_fee: HoprBalance,
 ) -> anyhow::Result<BalanceRecommendation> {
-    if missing_channels == 0 {
-        return Ok(BalanceRecommendation {
-            wxhopr: HoprBalance::zero(),
-            xdai: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
-        });
-    }
-    let stake_per_channel = compute_funding_config(ticket_price, win_prob, cfg)?.initial_balance;
-    let wxhopr = stake_per_channel * (missing_channels as u64);
+    let stake = if missing_channels == 0 {
+        HoprBalance::zero()
+    } else {
+        compute_funding_config(ticket_price, win_prob, cfg)?.initial_balance
+            * (missing_channels as u64)
+    };
     Ok(BalanceRecommendation {
-        wxhopr,
+        wxhopr: stake + key_binding_fee,
         xdai: *hopr_lib::SUGGESTED_NATIVE_BALANCE,
     })
 }
@@ -217,7 +222,9 @@ pub(crate) fn compute_capacity(
 /// `cfg.target_open_channels` channels from scratch.
 ///
 /// Queries ticket pricing from the safeless chain interactor so this can be
-/// called before the full node is started (e.g. during onboarding).
+/// called before the full node is started (e.g. during onboarding). Because
+/// the node starts from scratch, the one-time key-binding (announcement) fee
+/// is included on top of the channel stakes.
 #[cfg(feature = "blokli")]
 pub async fn minimum_balance_recommendation(
     incentive_ops: &dyn crate::blokli::IncentiveOperations,
@@ -225,7 +232,14 @@ pub async fn minimum_balance_recommendation(
 ) -> anyhow::Result<BalanceRecommendation> {
     let stats = incentive_ops.ticket_stats().await?;
     let win_prob = stats.winning_probability.as_f64();
-    compute_balance_recommendation(stats.ticket_price, win_prob, cfg, cfg.target_open_channels)
+    let key_binding_fee = incentive_ops.key_binding_fee().await?;
+    compute_balance_recommendation(
+        stats.ticket_price,
+        win_prob,
+        cfg,
+        cfg.target_open_channels,
+        key_binding_fee,
+    )
 }
 
 /// Returns the default [`MultiStrategyConfig`] for an edge client reactor.
@@ -401,10 +415,45 @@ mod tests {
             1.0,
             &IncentiveConfiguration::default(),
             0,
+            HoprBalance::zero(),
         )
         .unwrap();
         assert_eq!(rec.wxhopr, HoprBalance::zero());
         assert_eq!(rec.xdai, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
+    }
+
+    #[test]
+    fn compute_balance_recommendation_includes_key_binding_fee() {
+        // rotsee-like: the fee dwarfs the channel stakes and must be added on top
+        let fee = HoprBalance::new_base(3);
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            &IncentiveConfiguration {
+                desired_message_count: 1,
+                ..Default::default()
+            },
+            8,
+            fee,
+        )
+        .unwrap();
+        assert_eq!(rec.wxhopr, HoprBalance::new_base(10) * 8u64 + fee);
+    }
+
+    #[test]
+    fn compute_balance_recommendation_zero_missing_still_includes_fee() {
+        // No channels to fund, key not yet bound: recommendation is exactly the
+        // fee — and a zero ticket price must not error on this path.
+        let fee = HoprBalance::new_base(1);
+        let rec = compute_balance_recommendation(
+            HoprBalance::zero(),
+            1.0,
+            &IncentiveConfiguration::default(),
+            0,
+            fee,
+        )
+        .unwrap();
+        assert_eq!(rec.wxhopr, fee);
     }
 
     #[test]
@@ -418,6 +467,7 @@ mod tests {
                 ..Default::default()
             },
             8,
+            HoprBalance::zero(),
         )
         .unwrap();
         assert_eq!(rec.wxhopr, HoprBalance::new_base(10) * 8u64);
@@ -431,7 +481,14 @@ mod tests {
             min_open_channels: 0,
             ..Default::default()
         };
-        let rec = compute_balance_recommendation(HoprBalance::new_base(10), 1.0, &cfg, 0).unwrap();
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            &cfg,
+            0,
+            HoprBalance::zero(),
+        )
+        .unwrap();
         assert_eq!(rec.wxhopr, HoprBalance::zero());
     }
 


### PR DESCRIPTION
 include one-time key-binding fee in minimum balance recommendation, so we could show the correct min wxHOPR value to fund new gVPN