### PR TITLE
feat: bump hoprnet for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,14 +105,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
+checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
+ "alloy-ens",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
@@ -306,6 +307,20 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-ens"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1616,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c4a03b3618185436fc74269e51c6945a55a3347eb05bde61a5fd3750d28401"
+checksum = "b6da9d0a178246498baf5e4b9f753affb25c14116ea8fbf75552841c6231a429"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1747,6 +1762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2505,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2739,6 +2763,7 @@ dependencies = [
  "anyhow",
  "async-signal",
  "async-trait",
+ "bytesize",
  "cfg-if",
  "clap",
  "console-subscriber",
@@ -3732,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.9.1"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1afa8766e3b7c9ac7f770e5330bb08f91af6db385a1b388239814fc03f7c171a"
+checksum = "0375fb0dc90a31484ae7620ce71681203f5ed1ee670cab51e02fb3b7a9d351dc"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3751,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3782,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3800,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3817,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3855,8 +3880,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "0.3.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3864,6 +3889,7 @@ dependencies = [
  "hopr-api",
  "hopr-utils",
  "indexmap 2.14.0",
+ "lazy_static",
  "parking_lot",
  "petgraph",
  "rand 0.10.2",
@@ -3875,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3888,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3917,8 +3943,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "1.2.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3949,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3963,16 +3989,18 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "0.20.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytesize",
  "dashmap",
  "futures",
  "futures-concurrency",
  "futures-time",
  "hopr-api",
+ "hopr-crypto-packet",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3990,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4012,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4053,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4070,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4091,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4116,8 +4144,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "0.23.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4149,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4160,9 +4188,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24293a5ce7289056c4e01b8d91beebc8663cdcca8ffbc24d847f3f22af4f274"
+checksum = "3aabecd53d5211c4a81f046d27bad0f7ad64659afcb5b88e0e410ecaa8928bf3"
 dependencies = [
  "aes 0.9.1",
  "anyhow",
@@ -4221,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4389,7 +4417,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6433,7 +6461,7 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6471,7 +6499,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6484,7 +6512,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7852,7 +7880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4177,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8#b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,20 +73,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -95,7 +95,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ prof = [
 
 [dependencies]
 anyhow = "1.0.103"
+bytesize = "2.4.2"
 smart-default = "0.7.1"
 async-signal = "0.2.14"
 async-trait = "0.1.89"
@@ -72,20 +73,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -94,7 +95,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b85cc31558f379c6dd5a8ecf4351905ab8a2f7e8", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -105,6 +105,12 @@ pub fn compute_funding_config(sizing: &IncentiveConfiguration) -> anyhow::Result
 /// capacity→balance conversion of `initial_capacity`
 /// (`ticket_price × packets × ASSUMED_HOPS / win_prob`).
 ///
+/// **Semantics:** `ticket_price` is the *expected* per-hop value
+/// (= `face_value × win_prob`), not the face value. The ticket face value
+/// (amount locked per ticket) = `ticket_price / win_prob`, which is why the
+/// stake divides by `win_prob`: the channel must hold at least one face value
+/// to mint a ticket at all.
+///
 /// Uses `desired_message_count` directly as the packet count (capacity is
 /// `N × SESSION_MTU`, and `SESSION_MTU < HoprPacket::PAYLOAD_SIZE`, so the
 /// strategy's own `ceil(bytes / PAYLOAD_SIZE)` resolves to ≤ N packets). This
@@ -209,6 +215,10 @@ pub(crate) fn compute_balance_recommendation(
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
     } else {
+        anyhow::ensure!(
+            cfg.desired_message_count > 0,
+            "desired_message_count is zero; cannot size a channel stake"
+        );
         initial_channel_stake(cfg.desired_message_count, ticket_price, win_prob)?
             * (missing_channels as u64)
     };

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use bytesize::ByteSize;
 use hopr_lib::api::types::primitive::prelude::{
     Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
 };
@@ -7,10 +8,12 @@ pub use hopr_strategy::channel_lifecycle::{
     ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig, SelectorProfile,
 };
 
+/// Paid downstream relay hops assumed when sizing a channel's stake. Edge nodes
+/// route over a single hop by default, so a channel's tickets pay one relay.
+const ASSUMED_HOPS: u32 = 1;
+
 #[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
 use hopr_lib::api::chain::{AccountSelector, ChainReadAccountOperations, ChainValues};
-#[cfg(feature = "runtime-tokio")]
-use hopr_lib::api::node::HasChainApi as _;
 
 /// Subset of strategies relevant to an edge node.
 pub enum EdgeStrategyKind {
@@ -32,13 +35,13 @@ pub struct MultiStrategyConfig {
 pub struct IncentiveConfiguration {
     /// Number of forwarded packets the initial channel stake is sized to cover.
     ///
-    /// Sets `initial_balance = max(N × ticket_price, ticket_price / win_prob)`:
-    /// the first term is the expected channel drain; the second is a minimum floor
-    /// ensuring at least one ticket face value is available even at low message counts.
+    /// Sets `initial_capacity = N × SESSION_MTU` bytes of channel data capacity;
+    /// the strategy resolves this to a wxHOPR stake at the live ticket price and
+    /// winning probability when it opens the channel.
     ///
-    /// The channel strategy tops up when balance falls below 25% of `initial_balance`,
-    /// so the channel can forward more than this many packets over its lifetime.
-    /// Default: 1,000,000.
+    /// The channel strategy tops up when capacity falls below 25% of
+    /// `initial_capacity`, so the channel can forward more than this many packets
+    /// over its lifetime. Default: 1,000,000.
     #[default = 1_000_000]
     pub desired_message_count: u64,
 
@@ -69,52 +72,54 @@ impl IncentiveConfiguration {
     }
 }
 
-/// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
+/// Compute the capacity-based [`FundingConfig`] for a desired message budget.
 ///
-/// **Semantics:** `ticket_price` is the *expected* per-hop value (= `face_value × win_prob`),
-/// not the face value. Per-hop expected channel drain is therefore `ticket_price`,
-/// regardless of `win_prob`. The ticket face value (amount locked per ticket)
-/// = `ticket_price / win_prob`.
+/// The strategy now sizes channels by *data capacity*: `initial_capacity` bytes
+/// are resolved to a wxHOPR stake at the live ticket economics when a channel is
+/// opened. We map `desired_message_count` packets to `N × SESSION_MTU` bytes,
+/// matching [`Capacity::byte_capacity`].
 ///
-/// Sizes `initial_balance` as the larger of:
-/// - expected drain over `sizing.desired_message_count` packets: `N × ticket_price`
-/// - one ticket's face value (the channel cannot mint a single ticket otherwise):
-///   `ticket_price / win_prob`
+/// Derived fields keep the strategy's invariants (`lower < initial`):
+/// - `topup_capacity`            = 75% of `initial_capacity`
+/// - `lower_capacity_threshold`  = 25% of `initial_capacity`
+/// - `min_safe_capacity_required` = `initial_capacity`
+pub fn compute_funding_config(sizing: &IncentiveConfiguration) -> anyhow::Result<FundingConfig> {
+    let initial_bytes = sizing
+        .desired_message_count
+        .saturating_mul(hopr_lib::SESSION_MTU as u64);
+    anyhow::ensure!(
+        initial_bytes > 0,
+        "computed initial_capacity is zero; desired_message_count is zero"
+    );
+    Ok(FundingConfig {
+        initial_capacity: ByteSize::b(initial_bytes),
+        topup_capacity: ByteSize::b(initial_bytes / 4 * 3),
+        lower_capacity_threshold: ByteSize::b(initial_bytes / 4),
+        min_safe_capacity_required: ByteSize::b(initial_bytes),
+        assumed_hops: ASSUMED_HOPS,
+        stop_when_unfunded: true,
+    })
+}
+
+/// wxHOPR a single new channel's initial stake locks, mirroring the strategy's
+/// capacity→balance conversion of `initial_capacity`
+/// (`ticket_price × packets × ASSUMED_HOPS / win_prob`).
 ///
-/// Derived fields keep the strategy's semantic invariants
-/// (`lower < initial`, `topup + lower ≈ initial`):
-/// - `topup_balance`            = 75% of `initial_balance`
-/// - `lower_balance_threshold`  = 25% of `initial_balance`
-/// - `min_safe_balance_required` = `initial_balance`
-pub fn compute_funding_config(
+/// Uses `desired_message_count` directly as the packet count (capacity is
+/// `N × SESSION_MTU`, and `SESSION_MTU < HoprPacket::PAYLOAD_SIZE`, so the
+/// strategy's own `ceil(bytes / PAYLOAD_SIZE)` resolves to ≤ N packets). This
+/// keeps the recommendation on the never-underfund side.
+fn initial_channel_stake(
+    desired_message_count: u64,
     ticket_price: HoprBalance,
     win_prob: f64,
-    sizing: &IncentiveConfiguration,
-) -> anyhow::Result<FundingConfig> {
+) -> anyhow::Result<HoprBalance> {
     anyhow::ensure!(
         win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
         "win_prob must be in (0, 1]; got {win_prob}"
     );
-    // face_value = price / win_prob: channel needs ≥1 face_value to issue any ticket.
-    let face_value = ticket_price.div_f64(win_prob)?;
-    // expected_drain = N × ticket_price (NOT × win_prob — ticket_price is already
-    // the expected per-hop value: each ticket has face = ticket_price/win_prob
-    // and pays out with probability win_prob, so expected per-ticket drain = ticket_price).
-    let expected_drain = ticket_price * sizing.desired_message_count;
-    let initial = expected_drain.max(face_value);
-    anyhow::ensure!(
-        initial > HoprBalance::new_base(0),
-        "computed initial_balance is zero; ticket_price is zero"
-    );
-    let topup = initial.mul_f64(0.75)?;
-    let lower = initial.mul_f64(0.25)?;
-    Ok(FundingConfig {
-        initial_balance: initial,
-        topup_balance: topup,
-        lower_balance_threshold: lower,
-        min_safe_balance_required: initial,
-        stop_when_unfunded: true,
-    })
+    let base = ticket_price * desired_message_count * ASSUMED_HOPS as u64;
+    Ok(base.div_f64(win_prob)?)
 }
 
 /// One-time costs still owed before this node can be fully up and running,
@@ -204,7 +209,7 @@ pub(crate) fn compute_balance_recommendation(
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
     } else {
-        compute_funding_config(ticket_price, win_prob, cfg)?.initial_balance
+        initial_channel_stake(cfg.desired_message_count, ticket_price, win_prob)?
             * (missing_channels as u64)
     };
     Ok(BalanceRecommendation {
@@ -320,21 +325,17 @@ pub async fn minimum_balance_recommendation(
 
 /// Returns the default [`MultiStrategyConfig`] for an edge client reactor.
 ///
-/// Fetches the minimum ticket price and winning probability from the chain and
-/// sizes the [`ChannelLifecycleStrategy`] funding to cover
-/// `sizing.desired_message_count` messages per channel.
-/// See [`compute_funding_config`] for the sizing formula.
+/// Sizes the channel-lifecycle funding to cover `sizing.desired_message_count`
+/// messages of data capacity per channel; the strategy resolves that capacity
+/// to a wxHOPR stake at the live ticket economics. See [`compute_funding_config`].
 #[cfg(feature = "runtime-tokio")]
 pub async fn default_strategy_cfg(
-    node: &crate::client::Edgli,
+    _node: &crate::client::Edgli,
     sizing: &IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {
     sizing.validate()?;
-    let chain = node.chain_api();
-    let ticket_price = chain.minimum_ticket_price().await?;
-    let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
     let cfg = ChannelLifecycleConfig {
-        funding: compute_funding_config(ticket_price, win_prob, sizing)?,
+        funding: compute_funding_config(sizing)?,
         population: PopulationConfig {
             min_open_channels: sizing.min_open_channels,
             target_open_channels: sizing.target_open_channels,
@@ -366,94 +367,44 @@ mod tests {
     }
 
     #[test]
-    fn compute_funding_config_win_prob_one() {
-        // With win_prob=1.0, every ticket pays out → initial = ticket_price × msg_count
-        let cfg = compute_funding_config(
-            HoprBalance::new_base(1),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 1,
-                ..Default::default()
-            },
-        )
+    fn compute_funding_config_capacity_from_message_count() {
+        // initial_capacity = desired_message_count × SESSION_MTU bytes
+        let cfg = compute_funding_config(&IncentiveConfiguration {
+            desired_message_count: 1,
+            ..Default::default()
+        })
         .unwrap();
-        assert_eq!(cfg.initial_balance, HoprBalance::new_base(1));
-        assert_eq!(cfg.min_safe_balance_required, HoprBalance::new_base(1));
-        assert!(cfg.lower_balance_threshold < cfg.initial_balance);
-        assert!(cfg.topup_balance > cfg.lower_balance_threshold);
-        assert!(cfg.topup_balance < cfg.initial_balance);
+        let mtu = hopr_lib::SESSION_MTU as u64;
+        assert_eq!(cfg.initial_capacity.as_u64(), mtu);
+        assert_eq!(cfg.min_safe_capacity_required.as_u64(), mtu);
+        assert!(cfg.lower_capacity_threshold < cfg.initial_capacity);
+        assert!(cfg.topup_capacity > cfg.lower_capacity_threshold);
+        assert!(cfg.topup_capacity < cfg.initial_capacity);
+        assert_eq!(cfg.assumed_hops, ASSUMED_HOPS);
         assert!(cfg.stop_when_unfunded);
     }
 
     #[test]
     fn compute_funding_config_proportional_fields() {
         // Verify lower < initial, min_safe == initial, topup ∈ (lower, initial)
-        let cfg = compute_funding_config(
-            HoprBalance::new_base(10),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 100,
-                ..Default::default()
-            },
-        )
+        let cfg = compute_funding_config(&IncentiveConfiguration {
+            desired_message_count: 100,
+            ..Default::default()
+        })
         .unwrap();
-        assert_eq!(cfg.min_safe_balance_required, cfg.initial_balance);
-        assert!(cfg.lower_balance_threshold < cfg.initial_balance);
-        assert!(cfg.topup_balance < cfg.initial_balance);
-        assert!(cfg.topup_balance > cfg.lower_balance_threshold);
+        assert_eq!(cfg.min_safe_capacity_required, cfg.initial_capacity);
+        assert!(cfg.lower_capacity_threshold < cfg.initial_capacity);
+        assert!(cfg.topup_capacity < cfg.initial_capacity);
+        assert!(cfg.topup_capacity > cfg.lower_capacity_threshold);
     }
 
     #[test]
-    fn compute_funding_config_rejects_zero_win_prob() {
+    fn compute_funding_config_rejects_zero_message_count() {
         assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                0.0,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn compute_funding_config_rejects_win_prob_above_one() {
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                1.1,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                f64::INFINITY,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                f64::NAN,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn compute_funding_config_rejects_zero_initial_balance() {
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(0),
-                1.0,
-                &IncentiveConfiguration {
-                    desired_message_count: 0,
-                    ..Default::default()
-                }
-            )
+            compute_funding_config(&IncentiveConfiguration {
+                desired_message_count: 0,
+                ..Default::default()
+            })
             .is_err()
         );
     }
@@ -461,14 +412,10 @@ mod tests {
     #[test]
     fn compute_funding_config_default_sizing_has_one_strategy_shape() {
         // Smoke-test: can build a MultiStrategyConfig from compute_funding_config output
-        let funding = compute_funding_config(
-            HoprBalance::new_base(1),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 1,
-                ..Default::default()
-            },
-        )
+        let funding = compute_funding_config(&IncentiveConfiguration {
+            desired_message_count: 1,
+            ..Default::default()
+        })
         .unwrap();
         let lifecycle_cfg = ChannelLifecycleConfig {
             funding,
@@ -555,7 +502,7 @@ mod tests {
 
     #[test]
     fn compute_balance_recommendation_scales_by_missing_channels() {
-        // win_prob=1.0, ticket_price=10, msg=1: stake = max(10, 10) = 10; 8 channels = 80
+        // win_prob=1.0, ticket_price=10, msg=1, hops=1: stake = 10; 8 channels = 80
         let rec = compute_balance_recommendation(
             HoprBalance::new_base(10),
             1.0,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1137,12 +1137,14 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
 
     // ── 5. Start the channel-lifecycle strategy reactor ──────────────────────
     // desired_message_count = 1000 × expected session packets (forward + SURB
-    // return). This absorbs background probe traffic and the probabilistic
-    // accumulation of winning tickets: at Rotsee values (price ≈ 1e-16 wxHOPR,
-    // win_prob ≈ 0.000125) the expected drain per packet is tiny, but the
-    // channel must hold at least `ticket_price` per winning ticket. Scaling by
-    // 1000× ensures the computed initial_balance comfortably exceeds the
-    // expected winning-ticket accumulation from both test and probe traffic.
+    // return). This sets initial_capacity = N × SESSION_MTU bytes, which the
+    // strategy resolves to a wxHOPR stake at open time. It absorbs background
+    // probe traffic and the probabilistic accumulation of winning tickets: at
+    // Rotsee values (price ≈ 1e-16 wxHOPR, win_prob ≈ 0.000125) the expected
+    // drain per packet is tiny, but the channel must hold at least `ticket_price`
+    // per winning ticket. Scaling by 1000× ensures the resolved stake comfortably
+    // exceeds the expected winning-ticket accumulation from both test and probe
+    // traffic.
     let session_packets = (PAYLOAD_SIZE / SESSION_MTU + 1) * 2; // fwd + SURB return
     let sizing = IncentiveConfiguration {
         desired_message_count: (session_packets as u64) * 1_000,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1160,7 +1160,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
 
     let EdgeStrategyKind::ChannelLifecycle(lc0) = &strat_cfg.strategies[0];
     tracing::info!(
-        initial_balance = ?lc0.funding.initial_balance,
+        initial_capacity = ?lc0.funding.initial_capacity,
         target_channels = sizing.target_open_channels,
         "strategy configured; starting reactor"
     );


### PR DESCRIPTION

  Breaking API change: capacity-based channel funding

  hopr-strategy (0.19 → 0.20) reworked FundingConfig from wxHOPR balances to ByteSize data-capacity. The strategy now resolves capacity → wxHOPR stake internally at the live ticket price / winning probability per pipeline tick, instead of taking pre-computed balances.

  Adapted src/strategy.rs:

  - compute_funding_config no longer takes ticket_price / win_prob. It maps desired_message_count packets to N × SESSION_MTU bytes and sets the new capacity fields (initial_capacity, topup_capacity = 75%, lower_capacity_threshold = 25%, min_safe_capacity_required = 100%, assumed_hops).
  - assumed_hops = 1 — edge nodes route over a single hop by default, so a channel's tickets pay one relay.
  - compute_balance_recommendation keeps its public signature but now derives the per-channel stake via the new initial_channel_stake helper, which mirrors the strategy's conversion (ticket_price × packets × hops / win_prob). It uses desired_message_count directly as the packet count; since SESSION_MTU <
  HoprPacket::PAYLOAD_SIZE, the strategy's own ceil(bytes / PAYLOAD_SIZE) resolves to ≤ N packets, so the recommendation stays on the never-underfund side.
  - Dropped the now-unused chain queries in default_strategy_cfg and the HasChainApi import.