### PR TITLE
feat: tokio-console profiling harness for executor yield analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2771,6 +2771,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
  "url",
 ]
@@ -4389,7 +4390,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6433,7 +6434,7 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6471,7 +6472,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6484,7 +6485,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7852,7 +7853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8226,6 +8227,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,14 +105,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
+checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
+ "alloy-ens",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
@@ -306,6 +307,20 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-ens"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1616,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c4a03b3618185436fc74269e51c6945a55a3347eb05bde61a5fd3750d28401"
+checksum = "b6da9d0a178246498baf5e4b9f753affb25c14116ea8fbf75552841c6231a429"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1747,6 +1762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2739,6 +2763,7 @@ dependencies = [
  "anyhow",
  "async-signal",
  "async-trait",
+ "bytesize",
  "cfg-if",
  "clap",
  "console-subscriber",
@@ -3733,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.9.1"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1afa8766e3b7c9ac7f770e5330bb08f91af6db385a1b388239814fc03f7c171a"
+checksum = "0375fb0dc90a31484ae7620ce71681203f5ed1ee670cab51e02fb3b7a9d351dc"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3752,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3783,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3801,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3818,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3856,8 +3881,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "0.3.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3865,6 +3890,7 @@ dependencies = [
  "hopr-api",
  "hopr-utils",
  "indexmap 2.14.0",
+ "lazy_static",
  "parking_lot",
  "petgraph",
  "rand 0.10.2",
@@ -3876,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3889,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3918,8 +3944,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "1.2.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3950,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3964,16 +3990,18 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "0.20.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytesize",
  "dashmap",
  "futures",
  "futures-concurrency",
  "futures-time",
  "hopr-api",
+ "hopr-crypto-packet",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3991,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4013,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4054,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4071,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4092,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4117,8 +4145,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+version = "0.23.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4150,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4161,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24293a5ce7289056c4e01b8d91beebc8663cdcca8ffbc24d847f3f22af4f274"
+checksum = "3aabecd53d5211c4a81f046d27bad0f7ad64659afcb5b88e0e410ecaa8928bf3"
 dependencies = [
  "aes 0.9.1",
  "anyhow",
@@ -4222,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=118c4951f907bae5ca39083404f88357f2fa3722#118c4951f907bae5ca39083404f88357f2fa3722"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ dependencies = [
  "hopr-lib",
  "hopr-network-graph",
  "hopr-strategy",
- "hopr-ticket-manager",
+ "hopr-ticket-manager 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3)",
  "hopr-transport-p2p",
  "lazy_static",
  "mimalloc",
@@ -3808,7 +3808,6 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3817,6 +3816,22 @@ dependencies = [
  "hopr-utils",
  "serde",
  "serde_bytes",
+ "strum 0.28.0",
+ "subtle",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-crypto-packet"
+version = "1.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+dependencies = [
+ "bimap",
+ "const-hex",
+ "flagset",
+ "hopr-types",
+ "hopr-utils",
  "strum 0.28.0",
  "subtle",
  "thiserror 2.0.18",
@@ -3859,7 +3874,7 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-network-graph",
- "hopr-ticket-manager",
+ "hopr-ticket-manager 0.5.0 (git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3)",
  "hopr-transport",
  "hopr-transport-p2p",
  "hopr-utils",
@@ -3902,9 +3917,8 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.4.0",
  "hopr-types",
  "serde",
  "serde_bytes",
@@ -3915,7 +3929,6 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3925,8 +3938,8 @@ dependencies = [
  "cfg_eval",
  "const-hex",
  "hopr-api",
- "hopr-crypto-packet",
- "hopr-ticket-manager",
+ "hopr-crypto-packet 1.4.0",
+ "hopr-ticket-manager 0.5.0",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3945,7 +3958,6 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3957,7 +3969,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hashbrown 0.17.1",
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.4.0",
  "hopr-types",
  "hopr-utils",
  "lazy_static",
@@ -3976,11 +3988,10 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "aquamarine",
  "flagset",
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.4.0",
  "hopr-protocol-app",
  "serde",
  "serde_cbor_2",
@@ -4001,7 +4012,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.4.0 (git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3)",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -4014,6 +4025,27 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "validator",
+]
+
+[[package]]
+name = "hopr-ticket-manager"
+version = "0.5.0"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "clap",
+ "dashmap",
+ "futures",
+ "hashbrown 0.17.1",
+ "hopr-api",
+ "hopr-utils",
+ "parking_lot",
+ "postcard",
+ "redb",
+ "strum 0.28.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -4041,7 +4073,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4055,7 +4086,7 @@ dependencies = [
  "futures-time",
  "halfbrown",
  "hopr-api",
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.4.0",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
  "hopr-transport-mixer",
@@ -4082,7 +4113,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4120,7 +4150,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4146,7 +4175,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4155,7 +4183,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hopr-api",
- "hopr-crypto-packet",
+ "hopr-crypto-packet 1.4.0",
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
@@ -4178,7 +4206,6 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,6 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ nix = { version = "0.31.3", features = ["signal"] }
 rand = "0.10.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+tracing-chrome = "0.7"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 test-log = { version = "0.2.21", features = ["trace"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,3 +128,9 @@ anyhow = "1.0.103"
 [profile.tracer]
 inherits = "release"
 debug-assertions = true
+
+# Patch hopr-utils with local cooperative-yield fix in poll_copy.
+# The worktree at /tmp/hoprnet-poll-fix is pinned to the same rev (847d1c65)
+# that all other hoprnet crates use, so only poll_copy changes.
+[patch."https://github.com/hoprnet/hoprnet"]
+hopr-utils = { path = "/tmp/hoprnet-poll-fix/utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,20 +72,22 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = "2.5.8"
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+bytesize = "2.4.2"
+
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -94,7 +96,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "118c4951f907bae5ca39083404f88357f2fa3722", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,19 @@ anyhow = "1.0.103"
 inherits = "release"
 debug-assertions = true
 
-# Patch hopr-utils with local cooperative-yield fix in poll_copy.
-# The worktree at /tmp/hoprnet-poll-fix is pinned to the same rev (847d1c65)
-# that all other hoprnet crates use, so only poll_copy changes.
+# Patch hopr-utils and hopr-transport from the local worktree at /tmp/hoprnet-poll-fix
+# (pinned to rev 847d1c65 — identical to all other hoprnet crates except for our fixes):
+#
+#  hopr-utils: poll_copy and AsyncWriteSink::poll_write gain poll_proceed cooperative
+#              yield so the tokio worker thread yields to the scheduler after the
+#              default budget (~128 ops) is exhausted.
+#
+#  hopr-transport: MAXIMUM_MSG_OUTGOING_BUFFER_SIZE reduced from 200_000 → 16 to
+#                  create CrossfireSink backpressure.  With only 16 slots, the
+#                  then_concurrent encoding pipeline can never receive a burst larger
+#                  than 16 packets, keeping the Rayon queue depth well below the
+#                  PACKET_ENCODING_TIMEOUT = 150 ms threshold (max wait ≈ 2×encode_time
+#                  ≈ 42 ms for N_cpus=8, encode_time≈21 ms).
 [patch."https://github.com/hoprnet/hoprnet"]
 hopr-utils = { path = "/tmp/hoprnet-poll-fix/utils" }
+hopr-transport = { path = "/tmp/hoprnet-poll-fix/transport/hopr" }

--- a/scripts/profile-executor-yield.sh
+++ b/scripts/profile-executor-yield.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Run the executor-yield profiling tests and collect Chrome trace files.
+#
+# Each test starts a 3-node localcluster, runs paced vs continuous session
+# pumps, and writes a Chrome trace JSON to EDGLI_TRACE_DIR.  Load results
+# at https://ui.perfetto.dev.
+#
+# Usage:
+#   ./scripts/profile-executor-yield.sh [--local-only] [--rotsee-only]
+#
+# Options:
+#   --local-only     Run only the local-cluster tests (default)
+#   --rotsee-only    Run only the Rotsee testnet test (requires EDGLI_ROTSEE_* vars)
+#   --all            Run both local and Rotsee tests
+#
+# Configuration (all overridable via env):
+#   HOPRD_RELEASE_DIR        default: ~/Fun/hoprnet.org/hoprd/target/release
+#   HOPRD_LOCALCLUSTER_BIN   default: $HOPRD_RELEASE_DIR/hoprd-localcluster
+#   HOPRD_BIN                default: $HOPRD_RELEASE_DIR/hoprd
+#   HOPRD_CHAIN_IMAGE        default: bloklid-anvil image from localcluster/docker-compose.yml
+#   HOPRD_CONTAINER_RUNTIME  default: container  (macOS Apple runtime)
+#   EDGLI_TRACE_DIR          default: ./profiling-results
+#   RUST_LOG                 default: info,edgli=debug,tokio=trace,runtime=trace
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+RUN_LOCAL=true
+RUN_ROTSEE=false
+for arg in "$@"; do
+    case "$arg" in
+        --local-only)  RUN_LOCAL=true;  RUN_ROTSEE=false ;;
+        --rotsee-only) RUN_LOCAL=false; RUN_ROTSEE=true  ;;
+        --all)         RUN_LOCAL=true;  RUN_ROTSEE=true  ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+# ── Configuration ────────────────────────────────────────────────────────────
+HOPRD_RELEASE_DIR="${HOPRD_RELEASE_DIR:-$HOME/Fun/hoprnet.org/hoprd/target/release}"
+export HOPRD_LOCALCLUSTER_BIN="${HOPRD_LOCALCLUSTER_BIN:-$HOPRD_RELEASE_DIR/hoprd-localcluster}"
+export HOPRD_BIN="${HOPRD_BIN:-$HOPRD_RELEASE_DIR/hoprd}"
+export HOPRD_CHAIN_IMAGE="${HOPRD_CHAIN_IMAGE:-europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:0.10.5-pr.349@sha256:2e6747d9d6c97255474e243b5088d131f01bb67b5d8f17dbac6bb8aafdf1d7b6}"
+export HOPRD_CONTAINER_RUNTIME="${HOPRD_CONTAINER_RUNTIME:-container}"
+export EDGLI_TRACE_DIR="${EDGLI_TRACE_DIR:-$REPO_ROOT/profiling-results}"
+export RUST_LOG="${RUST_LOG:-info,edgli=debug,tokio=trace,runtime=trace}"
+export RUSTFLAGS="--cfg tokio_unstable"
+
+# ── Validate binaries ────────────────────────────────────────────────────────
+missing=()
+[[ -x "$HOPRD_LOCALCLUSTER_BIN" ]] || missing+=("$HOPRD_LOCALCLUSTER_BIN")
+[[ -x "$HOPRD_BIN" ]]              || missing+=("$HOPRD_BIN")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: missing or non-executable binaries:"
+    for b in "${missing[@]}"; do echo "  $b"; done
+    echo ""
+    echo "Build them with (from hoprnet/hoprd):"
+    echo "  cargo build --release -p hoprd -p hoprd-localcluster"
+    echo ""
+    echo "Or override:"
+    echo "  HOPRD_RELEASE_DIR=/your/path ./scripts/profile-executor-yield.sh"
+    exit 1
+fi
+
+# ── Cleanup trap ─────────────────────────────────────────────────────────────
+# The test manages cluster lifetime via ClusterHandle (Drop sends SIGINT).
+# If the test process is force-killed (SIGKILL), orphaned hoprd processes may
+# linger.  This trap warns and lists them.
+cleanup() {
+    local orphans
+    orphans="$(pgrep -f "hoprd-localcluster\|hoprd --" 2>/dev/null || true)"
+    if [[ -n "$orphans" ]]; then
+        echo ""
+        echo "WARNING: possible orphaned hoprd processes (PIDs: $(echo "$orphans" | tr '\n' ' '))"
+        echo "Kill manually if needed:"
+        echo "  pkill -f 'hoprd-localcluster|hoprd --'"
+    fi
+}
+trap cleanup EXIT
+
+# ── Prepare output dir ───────────────────────────────────────────────────────
+mkdir -p "$EDGLI_TRACE_DIR"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " edgli executor-yield profiling"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " hoprd-localcluster : $HOPRD_LOCALCLUSTER_BIN"
+echo " hoprd              : $HOPRD_BIN"
+echo " chain image        : $HOPRD_CHAIN_IMAGE"
+echo " container runtime  : $HOPRD_CONTAINER_RUNTIME"
+echo " trace output       : $EDGLI_TRACE_DIR"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── Build ────────────────────────────────────────────────────────────────────
+cd "$REPO_ROOT"
+echo ""
+echo "[1/2] Building profiling test binary..."
+cargo build --test edgli_profiling --profile tracer --features prof
+
+# ── Run tests ────────────────────────────────────────────────────────────────
+echo ""
+echo "[2/2] Running profiling tests..."
+
+# Select which tests to run.
+# Each test gets its own process (nextest), so console_subscriber::init() is safe.
+run_tests=()
+if [[ "$RUN_LOCAL" == "true" ]]; then
+    run_tests+=(
+        "edgli_profiling_paced_pump_baseline"
+        "edgli_profiling_continuous_pump"
+    )
+fi
+if [[ "$RUN_ROTSEE" == "true" ]]; then
+    run_tests+=("edgli_profiling_continuous_pump_rotsee")
+fi
+
+for test in "${run_tests[@]}"; do
+    echo ""
+    echo "── $test ──"
+    cargo nextest run \
+        --test edgli_profiling \
+        --profile tracer \
+        --features prof \
+        --run-ignored ignored-only \
+        --no-capture \
+        --test-threads 1 \
+        -E "test(=$test)"
+done
+
+# ── Results ──────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Results"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+trace_files=()
+while IFS= read -r -d '' f; do
+    trace_files+=("$f")
+done < <(find "$EDGLI_TRACE_DIR" -name "edgli-trace-*.json" -print0 2>/dev/null)
+
+if [[ ${#trace_files[@]} -eq 0 ]]; then
+    echo " No trace files found in $EDGLI_TRACE_DIR"
+    echo " The tests may have timed out before writing traces."
+else
+    echo " Trace files:"
+    for f in "${trace_files[@]}"; do
+        size=$(du -h "$f" | cut -f1)
+        echo "   $size  $f"
+    done
+    echo ""
+    echo " Load at: https://ui.perfetto.dev"
+    echo " (File → Open trace file, or drag-and-drop)"
+fi
+echo ""

--- a/scripts/profile-executor-yield.sh
+++ b/scripts/profile-executor-yield.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Run the executor-yield profiling tests and collect Chrome trace files.
 #
-# Each test starts a 3-node localcluster, runs paced vs continuous session
-# pumps, and writes a Chrome trace JSON to EDGLI_TRACE_DIR.  Load results
-# at https://ui.perfetto.dev.
+# Starts one shared 3-node localcluster, runs both profiling tests against it
+# (paced baseline + continuous pump), then stops the cluster.  This avoids
+# the 3–4 min cluster startup cost being charged to each test individually.
 #
 # Usage:
-#   ./scripts/profile-executor-yield.sh [--local-only] [--rotsee-only]
+#   ./scripts/profile-executor-yield.sh [--local-only] [--rotsee-only] [--all]
 #
 # Options:
 #   --local-only     Run only the local-cluster tests (default)
@@ -17,10 +17,12 @@
 #   HOPRD_RELEASE_DIR        default: ~/Fun/hoprnet.org/hoprd/target/release
 #   HOPRD_LOCALCLUSTER_BIN   default: $HOPRD_RELEASE_DIR/hoprd-localcluster
 #   HOPRD_BIN                default: $HOPRD_RELEASE_DIR/hoprd
-#   HOPRD_CHAIN_IMAGE        default: bloklid-anvil image from localcluster/docker-compose.yml
-#   HOPRD_CONTAINER_RUNTIME  default: container  (macOS Apple runtime)
+#   HOPRD_CHAIN_IMAGE        default: bloklid-anvil:latest from GCR
+#   HOPRD_CONTAINER_RUNTIME  default: container  (macOS Apple native runtime)
 #   EDGLI_TRACE_DIR          default: ./profiling-results
 #   RUST_LOG                 default: info,edgli=debug,tokio=trace,runtime=trace
+#
+# Cluster startup timeout: 10 minutes (CLUSTER_START_TIMEOUT below).
 
 set -euo pipefail
 
@@ -43,11 +45,13 @@ done
 HOPRD_RELEASE_DIR="${HOPRD_RELEASE_DIR:-$HOME/Fun/hoprnet.org/hoprd/target/release}"
 export HOPRD_LOCALCLUSTER_BIN="${HOPRD_LOCALCLUSTER_BIN:-$HOPRD_RELEASE_DIR/hoprd-localcluster}"
 export HOPRD_BIN="${HOPRD_BIN:-$HOPRD_RELEASE_DIR/hoprd}"
-export HOPRD_CHAIN_IMAGE="${HOPRD_CHAIN_IMAGE:-europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:0.10.5-pr.349@sha256:2e6747d9d6c97255474e243b5088d131f01bb67b5d8f17dbac6bb8aafdf1d7b6}"
+export HOPRD_CHAIN_IMAGE="${HOPRD_CHAIN_IMAGE:-europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:latest}"
 export HOPRD_CONTAINER_RUNTIME="${HOPRD_CONTAINER_RUNTIME:-container}"
 export EDGLI_TRACE_DIR="${EDGLI_TRACE_DIR:-$REPO_ROOT/profiling-results}"
 export RUST_LOG="${RUST_LOG:-info,edgli=debug,tokio=trace,runtime=trace}"
 export RUSTFLAGS="--cfg tokio_unstable"
+
+CLUSTER_START_TIMEOUT=600  # seconds to wait for cluster to reach "running"
 
 # ── Validate binaries ────────────────────────────────────────────────────────
 missing=()
@@ -67,10 +71,24 @@ if [[ ${#missing[@]} -gt 0 ]]; then
 fi
 
 # ── Cleanup trap ─────────────────────────────────────────────────────────────
-# The test manages cluster lifetime via ClusterHandle (Drop sends SIGINT).
-# If the test process is force-killed (SIGKILL), orphaned hoprd processes may
-# linger.  This trap warns and lists them.
+CLUSTER_PID=""
+CLUSTER_DATA_DIR=""
+
 cleanup() {
+    # Stop the managed cluster if we started one.
+    if [[ -n "$CLUSTER_PID" ]] && kill -0 "$CLUSTER_PID" 2>/dev/null; then
+        echo ""
+        echo "Stopping localcluster (PID $CLUSTER_PID)..."
+        kill -INT "$CLUSTER_PID" 2>/dev/null || true
+        # Wait up to 30 s for graceful exit.
+        local deadline=$(( $(date +%s) + 30 ))
+        while kill -0 "$CLUSTER_PID" 2>/dev/null && [[ $(date +%s) -lt $deadline ]]; do
+            sleep 1
+        done
+        kill -KILL "$CLUSTER_PID" 2>/dev/null || true
+    fi
+
+    # Warn about any remaining hoprd orphans.
     local orphans
     orphans="$(pgrep -f "hoprd-localcluster\|hoprd --" 2>/dev/null || true)"
     if [[ -n "$orphans" ]]; then
@@ -98,15 +116,69 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 # ── Build ────────────────────────────────────────────────────────────────────
 cd "$REPO_ROOT"
 echo ""
-echo "[1/2] Building profiling test binary..."
+echo "[1/3] Building profiling test binary..."
 cargo build --test edgli_profiling --profile tracer --features prof
+
+# ── Start cluster (local tests only) ─────────────────────────────────────────
+if [[ "$RUN_LOCAL" == "true" ]]; then
+    CLUSTER_DATA_DIR="$(mktemp -d /tmp/edgli-prof-cluster.XXXXXX)"
+    echo ""
+    echo "[2/3] Starting 3-node localcluster in background..."
+    echo "      data dir: $CLUSTER_DATA_DIR"
+
+    "$HOPRD_LOCALCLUSTER_BIN" \
+        --hoprd-bin "$HOPRD_BIN" \
+        --size 3 \
+        --extra-identities 1 \
+        --data-dir "$CLUSTER_DATA_DIR" \
+        --api-host "127.0.0.1" \
+        --api-port-base 13000 \
+        --p2p-port-base 19000 \
+        --api-token "test-token-localcluster" \
+        --chain-image "$HOPRD_CHAIN_IMAGE" \
+        --container-runtime "$HOPRD_CONTAINER_RUNTIME" \
+        &
+    CLUSTER_PID=$!
+    echo "      PID: $CLUSTER_PID"
+
+    # Poll hoprd-localcluster status until "running" or timeout.
+    echo ""
+    echo "      Waiting for cluster to reach 'running' state (timeout: ${CLUSTER_START_TIMEOUT}s)..."
+    deadline=$(( $(date +%s) + CLUSTER_START_TIMEOUT ))
+    cluster_ready=false
+    while [[ $(date +%s) -lt $deadline ]]; do
+        if ! kill -0 "$CLUSTER_PID" 2>/dev/null; then
+            echo "ERROR: localcluster process exited prematurely"
+            exit 1
+        fi
+        state=$("$HOPRD_LOCALCLUSTER_BIN" status --data-dir "$CLUSTER_DATA_DIR" 2>/dev/null \
+                | jq -r '.state' 2>/dev/null || true)
+        if [[ "$state" == "running" ]]; then
+            cluster_ready=true
+            break
+        fi
+        printf "      cluster state: %-20s\r" "${state:-waiting...}"
+        sleep 5
+    done
+
+    if [[ "$cluster_ready" != "true" ]]; then
+        echo ""
+        echo "ERROR: cluster did not reach 'running' within ${CLUSTER_START_TIMEOUT}s"
+        exit 1
+    fi
+    echo ""
+    echo "      ✓ cluster is running"
+
+    # Export data dir so tests use external (already-running) cluster mode.
+    export HOPRD_CLUSTER_DATA_DIR="$CLUSTER_DATA_DIR"
+fi
 
 # ── Run tests ────────────────────────────────────────────────────────────────
 echo ""
-echo "[2/2] Running profiling tests..."
+echo "[3/3] Running profiling tests..."
 
-# Select which tests to run.
-# Each test gets its own process (nextest), so console_subscriber::init() is safe.
+# Local tests share the already-running cluster via HOPRD_CLUSTER_DATA_DIR.
+# Rotsee test manages its own external network via env vars.
 run_tests=()
 if [[ "$RUN_LOCAL" == "true" ]]; then
     run_tests+=(
@@ -123,7 +195,7 @@ for test in "${run_tests[@]}"; do
     echo "── $test ──"
     cargo nextest run \
         --test edgli_profiling \
-        --profile tracer \
+        --cargo-profile tracer \
         --features prof \
         --run-ignored ignored-only \
         --no-capture \

--- a/src/client.rs
+++ b/src/client.rs
@@ -391,7 +391,7 @@ impl Edgli {
         // verified on-chain rather than assumed.
         // A running node cannot start without a Safe, so it is always deployed here.
         let costs = super::strategy::compute_costs_to_start(chain, Some(source), true).await?;
-        super::strategy::compute_balance_recommendation(ticket_price, win_prob, cfg, missing, costs)
+        super::strategy::compute_balance_recommendation(ticket_price, win_prob, missing, costs)
     }
 
     /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityAllocator`].

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use bytesize::ByteSize;
 use hopr_lib::api::types::primitive::prelude::{
     Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
 };
@@ -7,10 +8,22 @@ pub use hopr_strategy::channel_lifecycle::{
     ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig, SelectorProfile,
 };
 
+/// Paid downstream relay hops assumed when sizing a channel's stake. Edge nodes
+/// route over a single hop by default, so a channel's tickets pay one relay.
+const ASSUMED_HOPS: u32 = 1;
+
+/// Channel data capacity the initial stake is sized for: 4 outstanding winning
+/// tickets plus a half-ticket buffer, in bytes (`4.5 × SESSION_MTU`).
+///
+/// Only *winning* tickets drain channel balance — each locks one face value
+/// (`ticket_price / win_prob`) until redeemed, and the strategy's
+/// capacity→balance conversion locks one face value per packet-sized capacity
+/// unit. The channel therefore only needs to hold a few face values to cover
+/// winning tickets outstanding between redemptions, not the full traffic volume.
+const INITIAL_CAPACITY_BYTES: u64 = hopr_lib::SESSION_MTU as u64 * 9 / 2;
+
 #[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
 use hopr_lib::api::chain::{AccountSelector, ChainReadAccountOperations, ChainValues};
-#[cfg(feature = "runtime-tokio")]
-use hopr_lib::api::node::HasChainApi as _;
 
 /// Subset of strategies relevant to an edge node.
 pub enum EdgeStrategyKind {
@@ -30,18 +43,6 @@ pub struct MultiStrategyConfig {
 /// to the required relayer addresses; leave it `None` for quality-score-based peer selection.
 #[derive(Debug, Clone, smart_default::SmartDefault)]
 pub struct IncentiveConfiguration {
-    /// Number of forwarded packets the initial channel stake is sized to cover.
-    ///
-    /// Sets `initial_balance = max(N × ticket_price, ticket_price / win_prob)`:
-    /// the first term is the expected channel drain; the second is a minimum floor
-    /// ensuring at least one ticket face value is available even at low message counts.
-    ///
-    /// The channel strategy tops up when balance falls below 25% of `initial_balance`,
-    /// so the channel can forward more than this many packets over its lifetime.
-    /// Default: 1,000,000.
-    #[default = 1_000_000]
-    pub desired_message_count: u64,
-
     /// Minimum number of open outgoing channels to maintain. Default: 5.
     #[default = 5]
     pub min_open_channels: usize,
@@ -69,52 +70,53 @@ impl IncentiveConfiguration {
     }
 }
 
-/// Compute [`FundingConfig`] from chain-derived values and a desired message budget.
+/// Compute the capacity-based [`FundingConfig`] sized for the winning-ticket buffer.
 ///
-/// **Semantics:** `ticket_price` is the *expected* per-hop value (= `face_value × win_prob`),
-/// not the face value. Per-hop expected channel drain is therefore `ticket_price`,
-/// regardless of `win_prob`. The ticket face value (amount locked per ticket)
-/// = `ticket_price / win_prob`.
+/// The strategy sizes channels by *data capacity*: `initial_capacity` bytes are
+/// resolved to a wxHOPR stake at the live ticket economics when a channel is
+/// opened, locking one ticket face value per packet-sized capacity unit. Since
+/// only winning tickets drain channel balance, [`INITIAL_CAPACITY_BYTES`]
+/// (4.5 × SESSION_MTU) suffices to cover the winning tickets outstanding
+/// between redemptions.
 ///
-/// Sizes `initial_balance` as the larger of:
-/// - expected drain over `sizing.desired_message_count` packets: `N × ticket_price`
-/// - one ticket's face value (the channel cannot mint a single ticket otherwise):
-///   `ticket_price / win_prob`
+/// Derived fields keep the strategy's invariants (`lower < initial`):
+/// - `topup_capacity`            = 75% of `initial_capacity`
+/// - `lower_capacity_threshold`  = 25% of `initial_capacity` (~1.1 face values,
+///   above the one face value needed to keep minting tickets)
+/// - `min_safe_capacity_required` = `initial_capacity`
+pub fn compute_funding_config() -> FundingConfig {
+    FundingConfig {
+        initial_capacity: ByteSize::b(INITIAL_CAPACITY_BYTES),
+        topup_capacity: ByteSize::b(INITIAL_CAPACITY_BYTES / 4 * 3),
+        lower_capacity_threshold: ByteSize::b(INITIAL_CAPACITY_BYTES / 4),
+        min_safe_capacity_required: ByteSize::b(INITIAL_CAPACITY_BYTES),
+        assumed_hops: ASSUMED_HOPS,
+        stop_when_unfunded: true,
+    }
+}
+
+/// wxHOPR a single new channel's initial stake locks, mirroring the strategy's
+/// capacity→balance conversion of `initial_capacity`
+/// (`ticket_price × packets × ASSUMED_HOPS / win_prob`).
 ///
-/// Derived fields keep the strategy's semantic invariants
-/// (`lower < initial`, `topup + lower ≈ initial`):
-/// - `topup_balance`            = 75% of `initial_balance`
-/// - `lower_balance_threshold`  = 25% of `initial_balance`
-/// - `min_safe_balance_required` = `initial_balance`
-pub fn compute_funding_config(
-    ticket_price: HoprBalance,
-    win_prob: f64,
-    sizing: &IncentiveConfiguration,
-) -> anyhow::Result<FundingConfig> {
+/// **Semantics:** `ticket_price` is the *expected* per-hop value
+/// (= `face_value × win_prob`), not the face value. The ticket face value
+/// (amount locked per ticket) = `ticket_price / win_prob`, which is why the
+/// stake divides by `win_prob`: the channel must hold at least one face value
+/// to mint a ticket at all.
+///
+/// Uses `ceil(INITIAL_CAPACITY_BYTES / SESSION_MTU)` as the packet count.
+/// `SESSION_MTU < HoprPacket::PAYLOAD_SIZE`, so this is ≥ the strategy's own
+/// `ceil(bytes / PAYLOAD_SIZE)` packet count, keeping the recommendation on
+/// the never-underfund side.
+fn initial_channel_stake(ticket_price: HoprBalance, win_prob: f64) -> anyhow::Result<HoprBalance> {
     anyhow::ensure!(
         win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
         "win_prob must be in (0, 1]; got {win_prob}"
     );
-    // face_value = price / win_prob: channel needs ≥1 face_value to issue any ticket.
-    let face_value = ticket_price.div_f64(win_prob)?;
-    // expected_drain = N × ticket_price (NOT × win_prob — ticket_price is already
-    // the expected per-hop value: each ticket has face = ticket_price/win_prob
-    // and pays out with probability win_prob, so expected per-ticket drain = ticket_price).
-    let expected_drain = ticket_price * sizing.desired_message_count;
-    let initial = expected_drain.max(face_value);
-    anyhow::ensure!(
-        initial > HoprBalance::new_base(0),
-        "computed initial_balance is zero; ticket_price is zero"
-    );
-    let topup = initial.mul_f64(0.75)?;
-    let lower = initial.mul_f64(0.25)?;
-    Ok(FundingConfig {
-        initial_balance: initial,
-        topup_balance: topup,
-        lower_balance_threshold: lower,
-        min_safe_balance_required: initial,
-        stop_when_unfunded: true,
-    })
+    let packets = INITIAL_CAPACITY_BYTES.div_ceil(hopr_lib::SESSION_MTU as u64);
+    let base = ticket_price * packets * ASSUMED_HOPS as u64;
+    Ok(base.div_f64(win_prob)?)
 }
 
 /// One-time costs still owed before this node can be fully up and running,
@@ -197,15 +199,13 @@ pub struct Capacity {
 pub(crate) fn compute_balance_recommendation(
     ticket_price: HoprBalance,
     win_prob: f64,
-    cfg: &IncentiveConfiguration,
     missing_channels: usize,
     costs: StartupCosts,
 ) -> anyhow::Result<BalanceRecommendation> {
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
     } else {
-        compute_funding_config(ticket_price, win_prob, cfg)?.initial_balance
-            * (missing_channels as u64)
+        initial_channel_stake(ticket_price, win_prob)? * (missing_channels as u64)
     };
     Ok(BalanceRecommendation {
         channel_stakes: stake,
@@ -312,7 +312,6 @@ pub async fn minimum_balance_recommendation(
     compute_balance_recommendation(
         stats.ticket_price,
         win_prob,
-        cfg,
         cfg.target_open_channels,
         costs,
     )
@@ -320,21 +319,17 @@ pub async fn minimum_balance_recommendation(
 
 /// Returns the default [`MultiStrategyConfig`] for an edge client reactor.
 ///
-/// Fetches the minimum ticket price and winning probability from the chain and
-/// sizes the [`ChannelLifecycleStrategy`] funding to cover
-/// `sizing.desired_message_count` messages per channel.
-/// See [`compute_funding_config`] for the sizing formula.
+/// Sizes the channel-lifecycle funding to cover the winning-ticket buffer per
+/// channel; the strategy resolves that capacity to a wxHOPR stake at the live
+/// ticket economics. See [`compute_funding_config`].
 #[cfg(feature = "runtime-tokio")]
 pub async fn default_strategy_cfg(
-    node: &crate::client::Edgli,
+    _node: &crate::client::Edgli,
     sizing: &IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {
     sizing.validate()?;
-    let chain = node.chain_api();
-    let ticket_price = chain.minimum_ticket_price().await?;
-    let win_prob = chain.minimum_incoming_ticket_win_prob().await?.as_f64();
     let cfg = ChannelLifecycleConfig {
-        funding: compute_funding_config(ticket_price, win_prob, sizing)?,
+        funding: compute_funding_config(),
         population: PopulationConfig {
             min_open_channels: sizing.min_open_channels,
             target_open_channels: sizing.target_open_channels,
@@ -366,110 +361,42 @@ mod tests {
     }
 
     #[test]
-    fn compute_funding_config_win_prob_one() {
-        // With win_prob=1.0, every ticket pays out → initial = ticket_price × msg_count
-        let cfg = compute_funding_config(
-            HoprBalance::new_base(1),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 1,
-                ..Default::default()
-            },
-        )
-        .unwrap();
-        assert_eq!(cfg.initial_balance, HoprBalance::new_base(1));
-        assert_eq!(cfg.min_safe_balance_required, HoprBalance::new_base(1));
-        assert!(cfg.lower_balance_threshold < cfg.initial_balance);
-        assert!(cfg.topup_balance > cfg.lower_balance_threshold);
-        assert!(cfg.topup_balance < cfg.initial_balance);
+    fn compute_funding_config_capacity_is_winning_ticket_buffer() {
+        // initial_capacity = 4.5 × SESSION_MTU bytes (4 winning tickets + buffer)
+        let cfg = compute_funding_config();
+        let mtu = hopr_lib::SESSION_MTU as u64;
+        assert_eq!(cfg.initial_capacity.as_u64(), mtu * 9 / 2);
+        assert_eq!(cfg.min_safe_capacity_required.as_u64(), mtu * 9 / 2);
+        assert!(cfg.lower_capacity_threshold < cfg.initial_capacity);
+        assert!(cfg.topup_capacity > cfg.lower_capacity_threshold);
+        assert!(cfg.topup_capacity < cfg.initial_capacity);
+        assert_eq!(cfg.assumed_hops, ASSUMED_HOPS);
         assert!(cfg.stop_when_unfunded);
     }
 
     #[test]
     fn compute_funding_config_proportional_fields() {
         // Verify lower < initial, min_safe == initial, topup ∈ (lower, initial)
-        let cfg = compute_funding_config(
-            HoprBalance::new_base(10),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 100,
-                ..Default::default()
-            },
-        )
-        .unwrap();
-        assert_eq!(cfg.min_safe_balance_required, cfg.initial_balance);
-        assert!(cfg.lower_balance_threshold < cfg.initial_balance);
-        assert!(cfg.topup_balance < cfg.initial_balance);
-        assert!(cfg.topup_balance > cfg.lower_balance_threshold);
+        let cfg = compute_funding_config();
+        assert_eq!(cfg.min_safe_capacity_required, cfg.initial_capacity);
+        assert!(cfg.lower_capacity_threshold < cfg.initial_capacity);
+        assert!(cfg.topup_capacity < cfg.initial_capacity);
+        assert!(cfg.topup_capacity > cfg.lower_capacity_threshold);
     }
 
     #[test]
-    fn compute_funding_config_rejects_zero_win_prob() {
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                0.0,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn compute_funding_config_rejects_win_prob_above_one() {
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                1.1,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                f64::INFINITY,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(1),
-                f64::NAN,
-                &IncentiveConfiguration::default()
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn compute_funding_config_rejects_zero_initial_balance() {
-        assert!(
-            compute_funding_config(
-                HoprBalance::new_base(0),
-                1.0,
-                &IncentiveConfiguration {
-                    desired_message_count: 0,
-                    ..Default::default()
-                }
-            )
-            .is_err()
-        );
+    fn compute_funding_config_lower_threshold_stays_above_one_face_value() {
+        // The 25% threshold must stay above one SESSION_MTU (≥ one face value),
+        // otherwise the channel could fall below the balance needed to mint tickets
+        // before a top-up triggers.
+        let cfg = compute_funding_config();
+        assert!(cfg.lower_capacity_threshold.as_u64() >= hopr_lib::SESSION_MTU as u64);
     }
 
     #[test]
     fn compute_funding_config_default_sizing_has_one_strategy_shape() {
         // Smoke-test: can build a MultiStrategyConfig from compute_funding_config output
-        let funding = compute_funding_config(
-            HoprBalance::new_base(1),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 1,
-                ..Default::default()
-            },
-        )
-        .unwrap();
+        let funding = compute_funding_config();
         let lifecycle_cfg = ChannelLifecycleConfig {
             funding,
             ..Default::default()
@@ -494,14 +421,9 @@ mod tests {
 
     #[test]
     fn compute_balance_recommendation_zero_missing_returns_zero_wxhopr() {
-        let rec = compute_balance_recommendation(
-            HoprBalance::new_base(10),
-            1.0,
-            &IncentiveConfiguration::default(),
-            0,
-            no_startup_costs(),
-        )
-        .unwrap();
+        let rec =
+            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 0, no_startup_costs())
+                .unwrap();
         assert_eq!(rec.total_wxhopr(), HoprBalance::zero());
         assert_eq!(rec.xdai_fee_per_tx, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
     }
@@ -514,10 +436,6 @@ mod tests {
         let rec = compute_balance_recommendation(
             HoprBalance::new_base(10),
             1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 1,
-                ..Default::default()
-            },
             8,
             StartupCosts {
                 fee_to_start: fee,
@@ -525,10 +443,12 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(rec.channel_stakes, HoprBalance::new_base(10) * 8u64);
+        // stake per channel = ticket_price × 5 face-value packets
+        let per_channel = HoprBalance::new_base(10) * 5u64;
+        assert_eq!(rec.channel_stakes, per_channel * 8u64);
         assert_eq!(rec.fee_to_start, fee);
         assert_eq!(rec.txs_to_start, 3);
-        assert_eq!(rec.total_wxhopr(), HoprBalance::new_base(10) * 8u64 + fee);
+        assert_eq!(rec.total_wxhopr(), per_channel * 8u64 + fee);
     }
 
     #[test]
@@ -539,7 +459,6 @@ mod tests {
         let rec = compute_balance_recommendation(
             HoprBalance::zero(),
             1.0,
-            &IncentiveConfiguration::default(),
             0,
             StartupCosts {
                 fee_to_start: fee,
@@ -555,40 +474,35 @@ mod tests {
 
     #[test]
     fn compute_balance_recommendation_scales_by_missing_channels() {
-        // win_prob=1.0, ticket_price=10, msg=1: stake = max(10, 10) = 10; 8 channels = 80
-        let rec = compute_balance_recommendation(
-            HoprBalance::new_base(10),
-            1.0,
-            &IncentiveConfiguration {
-                desired_message_count: 1,
-                ..Default::default()
-            },
-            8,
-            no_startup_costs(),
-        )
-        .unwrap();
-        assert_eq!(rec.channel_stakes, HoprBalance::new_base(10) * 8u64);
+        // win_prob=1.0, ticket_price=10, hops=1: stake = 10 × 5 packets; 8 channels
+        let rec =
+            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 8, no_startup_costs())
+                .unwrap();
+        let per_channel = HoprBalance::new_base(10) * 5u64;
+        assert_eq!(rec.channel_stakes, per_channel * 8u64);
         assert_eq!(rec.fee_to_start, HoprBalance::zero());
         assert_eq!(rec.txs_to_start, 0);
-        assert_eq!(rec.total_wxhopr(), HoprBalance::new_base(10) * 8u64);
+        assert_eq!(rec.total_wxhopr(), per_channel * 8u64);
         assert_eq!(rec.xdai_fee_per_tx, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
     }
 
     #[test]
+    fn compute_balance_recommendation_halved_win_prob_doubles_stake() {
+        // face value = ticket_price / win_prob, so halving win_prob doubles the stake
+        let full =
+            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 1, no_startup_costs())
+                .unwrap();
+        let half =
+            compute_balance_recommendation(HoprBalance::new_base(10), 0.5, 1, no_startup_costs())
+                .unwrap();
+        assert_eq!(half.channel_stakes, full.channel_stakes * 2u64);
+    }
+
+    #[test]
     fn compute_balance_recommendation_zero_target_yields_zero() {
-        let cfg = IncentiveConfiguration {
-            target_open_channels: 0,
-            min_open_channels: 0,
-            ..Default::default()
-        };
-        let rec = compute_balance_recommendation(
-            HoprBalance::new_base(10),
-            1.0,
-            &cfg,
-            0,
-            no_startup_costs(),
-        )
-        .unwrap();
+        let rec =
+            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 0, no_startup_costs())
+                .unwrap();
         assert_eq!(rec.total_wxhopr(), HoprBalance::zero());
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1081,6 +1081,286 @@ pub async fn pump_and_verify(
     Ok(())
 }
 
+/// Write `payload` into `session` in a single un-paced `write_all`, read back
+/// the echo, verify integrity, and report wall-clock throughput.
+///
+/// ## Why this matters
+///
+/// Production callers typically copy data into a session via
+/// `transfer_session` / `copy_duplex`.  The underlying `poll_copy` loop reads
+/// from the application's source and calls `poll_write` on the HOPR session in
+/// a tight loop.  Because `CrossfireSink` (the outgoing packet channel) has a
+/// capacity of **200,000 slots**, `AsyncWriteSink::poll_write` almost always
+/// returns `Poll::Ready` without ever issuing a `Poll::Pending`, so the loop
+/// never yields a tokio worker thread back to the executor.
+///
+/// Consequences:
+///
+/// 1. **Executor starvation**: one tokio thread is monopolised for the entire
+///    write.  On machines with few workers (e.g. 2 threads on CI), this leaves
+///    no thread for the SURB balancer or ack-processing tasks.
+/// 2. **SURB drought**: the SURB balancer can't run → SURB replenishment stalls
+///    → the echo return path blocks waiting for SURBs.
+/// 3. **Throughput collapse**: the echo arrives much more slowly than the paced
+///    baseline, reproducing the production "10× slower" phenomenon.
+///
+/// Use this function together with the `--features prof --profile tracer`
+/// build (see `tests/edgli_profiling.rs`) and `tokio-console` to observe:
+/// - A single long-poll of the writer task (the entire `write_all`).
+/// - High idle time on the SURB balancer and ack tasks.
+///
+/// ## Note
+///
+/// Unlike `pump_and_verify`, this function does **not** assert SHA-256
+/// integrity on read timeout — it logs the throughput and returns `Ok` even if
+/// the read times out, so the comparison test can complete both variants and
+/// report both numbers.
+pub async fn pump_continuous(
+    session: HoprSession,
+    payload: &[u8],
+    label: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let (mut r, mut w) = tokio::io::split(session);
+    let payload_bytes = payload.to_vec();
+    let expected = sha256_digest(payload);
+    let n = payload.len();
+    let start = std::time::Instant::now();
+
+    // Single write_all — no inter-batch sleep, no explicit yield_now.
+    // The write task submits all ~1030 packets to the channel without ever
+    // returning Poll::Pending to the executor.  This is the production
+    // anti-pattern we want tokio-console to make visible.
+    let writer = tokio::spawn(async move {
+        w.write_all(&payload_bytes).await?;
+        w.flush().await?;
+        Ok::<_, std::io::Error>(())
+    });
+
+    let mut received = vec![0u8; n];
+    let read_result = tokio::time::timeout(timeout, r.read_exact(&mut received)).await;
+
+    let elapsed = start.elapsed();
+    let throughput_kbps = (n as f64 / 1024.0) / elapsed.as_secs_f64();
+
+    match read_result {
+        Ok(Ok(_)) => {
+            tracing::info!(
+                "{label}: ✓ {n} B in {elapsed:.2?} ({throughput_kbps:.0} KB/s) — continuous"
+            );
+            writer
+                .await
+                .map_err(|e| anyhow::anyhow!("{label}: writer panicked: {e}"))?
+                .map_err(|e| anyhow::anyhow!("{label}: write error: {e}"))?;
+            anyhow::ensure!(
+                sha256_digest(&received) == expected,
+                "{label}: SHA-256 mismatch — {n} bytes corrupted in transit"
+            );
+        }
+        Ok(Err(e)) => {
+            writer.abort();
+            let _ = writer.await;
+            anyhow::bail!("{label}: read error: {e}");
+        }
+        Err(_timeout) => {
+            writer.abort();
+            let _ = writer.await;
+            // Not a hard error — log the stall so the comparison test can
+            // report both variants and still complete.
+            tracing::warn!(
+                "{label}: read timeout ({timeout:?}) after {elapsed:.2?} \
+                 ({throughput_kbps:.0} KB/s before stall). \
+                 This likely indicates SURB starvation from executor yielding issues: \
+                 the write_all held a tokio worker thread without yielding, \
+                 starving the SURB balancer. See tests/edgli_profiling.rs."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Throughput comparison: run 0-hop and 1-hop sessions twice — once with
+/// pacing (`pump_and_verify`) and once without (`pump_continuous`) — and log
+/// throughput for both.
+///
+/// This is the primary entry point for the profiling tests in
+/// `tests/edgli_profiling.rs`.  Run with `--features prof --profile tracer`
+/// and attach `tokio-console` to observe executor starvation in the continuous
+/// variant.
+pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> {
+    // ── 1. Provision ─────────────────────────────────────────────────────────
+    let (summary, _guard, tuning) = provision(net).await?;
+
+    if matches!(net, Network::Local) {
+        await_nodes_ready().await?;
+        await_cluster_peers_discovered().await?;
+        await_intracluster_channels_open().await?;
+    }
+
+    // ── 2. Boot Edgli ────────────────────────────────────────────────────────
+    let extra = &summary.extras[0];
+    let hopr_keys: HoprKeys = IdentityRetrievalModes::FromFile {
+        password: &extra.password,
+        id_path: extra.keystore_path.to_str().unwrap(),
+    }
+    .try_into()?;
+
+    let edgli = Edgli::new(
+        build_edgli_config(extra, &tuning),
+        hopr_keys,
+        Some(summary.blokli_url.clone()),
+        None,
+        Some(tuning.connector_cfg),
+        tuning.probe_local,
+        |s: EdgliInitState| tracing::info!(?s, "edgli init"),
+    )
+    .await?;
+
+    await_edgli_peers_connected(&edgli, 2).await?;
+
+    // ── 3. Strategy ──────────────────────────────────────────────────────────
+    let session_packets = (PAYLOAD_SIZE / SESSION_MTU + 1) * 2;
+    let sizing = IncentiveConfiguration {
+        desired_message_count: (session_packets as u64) * 1_000,
+        min_open_channels: 1,
+        target_open_channels: CLUSTER_SIZE,
+        ..Default::default()
+    };
+    let mut strat_cfg = default_strategy_cfg(&edgli, &sizing).await?;
+    for kind in &mut strat_cfg.strategies {
+        let EdgeStrategyKind::ChannelLifecycle(lc) = kind;
+        lc.selector = tuning.selector.clone();
+        lc.tick_interval = tuning.strategy_tick;
+    }
+    let _reactor_handle = edgli.run_reactor_from_cfg(strat_cfg)?;
+    await_edgli_channels_open(&edgli, 1, tuning.channel_open_timeout).await?;
+
+    if let Some(exit) = tuning.exit_node {
+        await_edgli_exit_peer_ready(&edgli, exit).await?;
+    }
+
+    let (dest_0h, dest_1h) = if let Some(exit) = tuning.exit_node {
+        (exit, exit)
+    } else {
+        select_session_targets(&edgli).await?
+    };
+
+    let mut payload = vec![0u8; PAYLOAD_SIZE];
+    rand::rng().fill(&mut payload[..]);
+
+    let surb_cfg = Some(SurbBalancerConfig {
+        target_surb_buffer_size: 600,
+        max_surbs_per_sec: 300,
+        ..SurbBalancerConfig::default()
+    });
+
+    // ── 4. Paced baseline (pump_and_verify) ──────────────────────────────────
+    tracing::info!("=== PACED BASELINE: opening 0-hop session ===");
+    let (session_0h_paced, _) = edgli
+        .connect_to(
+            dest_0h,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(0_usize)?,
+                return_path: HopRouting::try_from(0_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: surb_cfg.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let t0 = std::time::Instant::now();
+    pump_and_verify(
+        session_0h_paced,
+        &payload,
+        "paced 0-hop",
+        tuning.pump_timeout,
+    )
+    .await?;
+    tracing::info!(
+        "paced 0-hop: {:.0} KB/s",
+        (PAYLOAD_SIZE as f64 / 1024.0) / t0.elapsed().as_secs_f64()
+    );
+
+    // ── 5. Continuous variant (pump_continuous) ───────────────────────────────
+    tracing::info!("=== CONTINUOUS (NO PACING): opening 0-hop session ===");
+    let (session_0h_cont, _) = edgli
+        .connect_to(
+            dest_0h,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(0_usize)?,
+                return_path: HopRouting::try_from(0_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: surb_cfg.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    pump_continuous(
+        session_0h_cont,
+        &payload,
+        "continuous 0-hop",
+        tuning.pump_timeout,
+    )
+    .await?;
+
+    // ── 6. 1-hop paced baseline ───────────────────────────────────────────────
+    tracing::info!("=== PACED BASELINE: opening 1-hop session ===");
+    let (session_1h_paced, _) = edgli
+        .connect_to(
+            dest_1h,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(1_usize)?,
+                return_path: HopRouting::try_from(1_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: surb_cfg.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let t1 = std::time::Instant::now();
+    pump_and_verify(
+        session_1h_paced,
+        &payload,
+        "paced 1-hop",
+        tuning.pump_timeout,
+    )
+    .await?;
+    tracing::info!(
+        "paced 1-hop: {:.0} KB/s",
+        (PAYLOAD_SIZE as f64 / 1024.0) / t1.elapsed().as_secs_f64()
+    );
+
+    // ── 7. 1-hop continuous variant ───────────────────────────────────────────
+    tracing::info!("=== CONTINUOUS (NO PACING): opening 1-hop session ===");
+    let (session_1h_cont, _) = edgli
+        .connect_to(
+            dest_1h,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(1_usize)?,
+                return_path: HopRouting::try_from(1_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: surb_cfg.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    pump_continuous(
+        session_1h_cont,
+        &payload,
+        "continuous 1-hop",
+        tuning.pump_timeout,
+    )
+    .await?;
+
+    drop(edgli);
+    Ok(())
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Top-level harness
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -145,8 +145,13 @@ impl EdgliTuning {
             channel_open_timeout: Duration::from_secs(120),
             exit_node: None,
             pump_timeout: Duration::from_secs(120),
-            min_ack_rate: 0.1, // local cluster probes succeed — use default quality gate
-            path_planner: latency_path_planner_config(0.1),
+            // Use 0.0: Edgli just started and no probes have completed yet when the
+            // 1-hop session is attempted.  With min_ack_rate=0.1 the path planner
+            // finds no eligible relays (ack_rate=0 for all) and session initiation
+            // times out repeatedly.  Routing via channel topology (0.0 floor) is
+            // correct for a full-mesh local cluster where all channels are open.
+            min_ack_rate: 0.0,
+            path_planner: latency_path_planner_config(0.0),
         }
     }
 
@@ -1220,9 +1225,7 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     await_edgli_peers_connected(&edgli, 2).await?;
 
     // ── 3. Strategy ──────────────────────────────────────────────────────────
-    let session_packets = (PAYLOAD_SIZE / SESSION_MTU + 1) * 2;
     let sizing = IncentiveConfiguration {
-        desired_message_count: (session_packets as u64) * 1_000,
         min_open_channels: 1,
         target_open_channels: CLUSTER_SIZE,
         ..Default::default()
@@ -1236,15 +1239,16 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     let _reactor_handle = edgli.run_reactor_from_cfg(strat_cfg)?;
     await_edgli_channels_open(&edgli, 1, tuning.channel_open_timeout).await?;
 
-    if let Some(exit) = tuning.exit_node {
-        await_edgli_exit_peer_ready(&edgli, exit).await?;
-    }
-
     let (dest_0h, dest_1h) = if let Some(exit) = tuning.exit_node {
         (exit, exit)
     } else {
         select_session_targets(&edgli).await?
     };
+
+    // Wait for dest_1h to appear in the probe graph before attempting 1-hop
+    // sessions — same reason as in run_one_megabyte_session_test (§6.3).
+    tracing::info!(%dest_1h, "waiting for 1-hop destination to be probed");
+    await_edgli_exit_peer_ready(&edgli, dest_1h).await?;
 
     let mut payload = vec![0u8; PAYLOAD_SIZE];
     rand::rng().fill(&mut payload[..]);
@@ -1416,16 +1420,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     await_edgli_peers_connected(&edgli, 2).await?;
 
     // ── 5. Start the channel-lifecycle strategy reactor ──────────────────────
-    // desired_message_count = 1000 × expected session packets (forward + SURB
-    // return). This absorbs background probe traffic and the probabilistic
-    // accumulation of winning tickets: at Rotsee values (price ≈ 1e-16 wxHOPR,
-    // win_prob ≈ 0.000125) the expected drain per packet is tiny, but the
-    // channel must hold at least `ticket_price` per winning ticket. Scaling by
-    // 1000× ensures the computed initial_balance comfortably exceeds the
-    // expected winning-ticket accumulation from both test and probe traffic.
-    let session_packets = (PAYLOAD_SIZE / SESSION_MTU + 1) * 2; // fwd + SURB return
     let sizing = IncentiveConfiguration {
-        desired_message_count: (session_packets as u64) * 1_000,
         min_open_channels: 1,
         target_open_channels: CLUSTER_SIZE,
         ..Default::default()
@@ -1440,7 +1435,7 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
 
     let EdgeStrategyKind::ChannelLifecycle(lc0) = &strat_cfg.strategies[0];
     tracing::info!(
-        initial_balance = ?lc0.funding.initial_balance,
+        initial_capacity = ?lc0.funding.initial_capacity,
         target_channels = sizing.target_open_channels,
         "strategy configured; starting reactor"
     );
@@ -1451,23 +1446,23 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     tracing::info!("waiting for strategy to open ≥1 outgoing channel");
     await_edgli_channels_open(&edgli, 1, tuning.channel_open_timeout).await?;
 
-    // ── 7. Wait for exit peer to be connected and probed (when pinned) ───────
-    // `all_network_peers` returns only connected peers with an observed quality
-    // score above the threshold — i.e. at least one successful probe response.
-    // Without this gate the session open can race against the probe subsystem
-    // and fail with "no route to host" on Rotsee.
-    if let Some(exit) = tuning.exit_node {
-        tracing::info!(%exit, "waiting for exit peer to be physically connected and probed");
-        await_edgli_exit_peer_ready(&edgli, exit).await?;
-    }
-
-    // ── 8. Select session targets ─────────────────────────────────────────────
+    // ── 7. Select session targets ─────────────────────────────────────────────
     let (dest_0h, dest_1h) = if let Some(exit) = tuning.exit_node {
         tracing::info!(%exit, "using configured exit node for both 0-hop and 1-hop sessions");
         (exit, exit)
     } else {
         select_session_targets(&edgli).await?
     };
+
+    // ── 8. Wait for dest_1h to appear in the probe graph ─────────────────────
+    // 1-hop path-finding needs at least one probe observation for dest_1h in
+    // the network graph (§6.3). Without any probe data the edge does not exist
+    // as a graph entry and path construction fails with a session timeout even
+    // though channels are open.  `await_edgli_exit_peer_ready` polls
+    // `all_network_peers(0.0)` (any observed quality) until the peer appears.
+    // This applies to both pinned exit nodes (Rotsee) and dynamic targets (local).
+    tracing::info!(%dest_1h, "waiting for 1-hop destination to be probed");
+    await_edgli_exit_peer_ready(&edgli, dest_1h).await?;
 
     // ── 9. Prepare 1 MiB random payload ─────────────────────────────────────
     // Random bytes produce unique HOPR packet ciphertexts on every test run,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -38,7 +38,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 // Constants
 // ────────────────────────────────────────────────────────────────────────────
 
-pub const PAYLOAD_SIZE: usize = 1_024 * 1_024; // 1 MiB
+pub const PAYLOAD_SIZE: usize = 2 * 1_024 * 1_024; // 2 MiB
 /// HOPR session MTU (bytes that fit in a single HOPR packet payload).
 /// Equal to `hopr_transport_session::SESSION_MTU = 1018`.
 pub const SESSION_MTU: usize = 1018;
@@ -1185,6 +1185,80 @@ pub async fn pump_continuous(
     Ok(())
 }
 
+/// Write `payload` into `session` in MTU-sized chunks with a cooperative
+/// `yield_now()` between each chunk — no inter-batch sleep.
+///
+/// This models what `poll_copy` should do once it calls
+/// `tokio::task::coop::poll_proceed(cx)` at the top of each write iteration.
+/// The yield hands the tokio worker thread back to the executor between every
+/// batch so the SURB balancer and ack tasks can schedule without starvation,
+/// while still driving the data as fast as the network allows.
+///
+/// Expected result: frame-discard count ≈ 0 (same as `pump_and_verify`),
+/// throughput higher than paced (no 100 ms inter-batch sleep).
+pub async fn pump_yielding(
+    session: HoprSession,
+    payload: &[u8],
+    label: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let (mut r, mut w) = tokio::io::split(session);
+    let payload_bytes = payload.to_vec();
+    let expected = sha256_digest(payload);
+    let n = payload.len();
+    let start = std::time::Instant::now();
+
+    let writer = tokio::spawn(async move {
+        let mut offset = 0;
+        while offset < payload_bytes.len() {
+            let end = (offset + PUMP_BATCH_BYTES).min(payload_bytes.len());
+            w.write_all(&payload_bytes[offset..end]).await?;
+            offset = end;
+            // Cooperative yield — no sleep, immediate re-schedule.
+            tokio::task::yield_now().await;
+        }
+        w.flush().await?;
+        Ok::<_, std::io::Error>(())
+    });
+
+    let mut received = vec![0u8; n];
+    let read_result = tokio::time::timeout(timeout, r.read_exact(&mut received)).await;
+
+    let elapsed = start.elapsed();
+    let throughput_kbps = (n as f64 / 1024.0) / elapsed.as_secs_f64();
+
+    match read_result {
+        Ok(Ok(_)) => {
+            tracing::info!(
+                "{label}: ✓ {n} B in {elapsed:.2?} ({throughput_kbps:.0} KB/s) — yielding"
+            );
+            writer
+                .await
+                .map_err(|e| anyhow::anyhow!("{label}: writer panicked: {e}"))?
+                .map_err(|e| anyhow::anyhow!("{label}: write error: {e}"))?;
+            anyhow::ensure!(
+                sha256_digest(&received) == expected,
+                "{label}: SHA-256 mismatch — {n} bytes corrupted in transit"
+            );
+        }
+        Ok(Err(e)) => {
+            writer.abort();
+            let _ = writer.await;
+            anyhow::bail!("{label}: read error: {e}");
+        }
+        Err(_timeout) => {
+            writer.abort();
+            let _ = writer.await;
+            tracing::warn!(
+                "{label}: read timeout ({timeout:?}) after {elapsed:.2?} \
+                 ({throughput_kbps:.0} KB/s before stall)"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Throughput comparison: run 0-hop and 1-hop sessions twice — once with
 /// pacing (`pump_and_verify`) and once without (`pump_continuous`) — and log
 /// throughput for both.
@@ -1310,6 +1384,29 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     )
     .await?;
 
+    // ── 5b. 0-hop yielding variant (cooperative yield, no sleep) ─────────────
+    tracing::info!("=== YIELDING (COOPERATIVE): opening 0-hop session ===");
+    let (session_0h_yield, _) = edgli
+        .connect_to(
+            dest_0h,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(0_usize)?,
+                return_path: HopRouting::try_from(0_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: surb_cfg.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    pump_yielding(
+        session_0h_yield,
+        &payload,
+        "yielding 0-hop",
+        tuning.pump_timeout,
+    )
+    .await?;
+
     // ── 6. 1-hop paced baseline ───────────────────────────────────────────────
     tracing::info!("=== PACED BASELINE: opening 1-hop session ===");
     let (session_1h_paced, _) = edgli
@@ -1357,6 +1454,29 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
         session_1h_cont,
         &payload,
         "continuous 1-hop",
+        tuning.pump_timeout,
+    )
+    .await?;
+
+    // ── 7b. 1-hop yielding variant ────────────────────────────────────────────
+    tracing::info!("=== YIELDING (COOPERATIVE): opening 1-hop session ===");
+    let (session_1h_yield, _) = edgli
+        .connect_to(
+            dest_1h,
+            loopback_target(),
+            HoprSessionClientConfig {
+                forward_path: HopRouting::try_from(1_usize)?,
+                return_path: HopRouting::try_from(1_usize)?,
+                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
+                surb_management: surb_cfg.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    pump_yielding(
+        session_1h_yield,
+        &payload,
+        "yielding 1-hop",
         tuning.pump_timeout,
     )
     .await?;

--- a/tests/edgli_profiling.rs
+++ b/tests/edgli_profiling.rs
@@ -12,7 +12,7 @@
 //! - SURB balancer and ack-processing tasks are starved → SURB replenishment stalls
 //!   → session blocks on echo return → measured throughput collapses 10×
 //!
-//! # tokio-console setup
+//! # Requirements
 //!
 //! Two requirements must hold together or tokio-console sees nothing:
 //!
@@ -21,126 +21,135 @@
 //!
 //! 2. **`--profile tracer`** — the `tracer` profile inherits `release` (optimised,
 //!    no stack overflow) but sets `debug-assertions = true`, which silences the
-//!    `tracing/release_max_level_debug` static filter. Without this flag the filter
+//!    `tracing/release_max_level_debug` static filter.  Without this flag the filter
 //!    sets `STATIC_MAX_LEVEL = DEBUG`, and every `trace!` callsite — including
-//!    tokio's task spans — is compiled to a no-op. The subscriber directive
-//!    `tokio=trace` added at runtime cannot resurrect callsites that were removed
-//!    at compile time.
+//!    tokio's task spans — is compiled to a no-op.  The runtime directive
+//!    `tokio=trace` cannot resurrect callsites removed at compile time.
 //!
-//! 3. **`--features prof`** — wires `console_subscriber` into the tracing stack.
-//!    The test below calls `console_subscriber::init()` directly; the regular
-//!    `init_logger()` path in `main.rs` does the same for the binary.
+//! 3. **`--features prof`** — pulls in `console-subscriber` and `tracing-chrome`.
 //!
-//! # How to run
+//! # Running
+//!
+//! Use the provided script — it handles env vars, build, and result collection:
 //!
 //! ```text
-//! # Terminal 1 — start the localcluster (external mode example)
-//! hoprd-localcluster --size 3 --extra-identities 1 \
-//!   --api-port-base 13000 --p2p-port-base 19000 \
-//!   --api-token test-token-localcluster \
-//!   --data-dir /tmp/edgli-cluster \
-//!   --chain-image '<bloklid-anvil image>' ...
+//! ./scripts/profile-executor-yield.sh
+//! ```
 //!
-//! # Wait for {"state":"running"}:
-//! hoprd-localcluster status --data-dir /tmp/edgli-cluster
+//! Or manually:
 //!
-//! # Terminal 2 — run profiling tests
+//! ```text
 //! export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd-localcluster
-//! export HOPRD_CLUSTER_DATA_DIR=/tmp/edgli-cluster
+//! export HOPRD_BIN=/path/to/hoprd
+//! export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:0.10.5-pr.349@sha256:2e6747d9d6c97255474e243b5088d131f01bb67b5d8f17dbac6bb8aafdf1d7b6'
+//! export HOPRD_CONTAINER_RUNTIME=container   # macOS Apple runtime
+//! export EDGLI_TRACE_DIR=./profiling-results
+//! export RUST_LOG=info,edgli=debug,tokio=trace,runtime=trace
 //!
 //! RUSTFLAGS="--cfg tokio_unstable" \
-//! RUST_LOG=info,edgli=debug \
-//! cargo test --test edgli_profiling \
+//! cargo nextest run \
+//!   --test edgli_profiling \
 //!   --profile tracer --features prof \
-//!   -- --ignored --nocapture
-//!
-//! # Terminal 3 — attach tokio-console (install once with: cargo install tokio-console)
-//! tokio-console
+//!   --run-ignored ignored-only --no-capture --test-threads 1
 //! ```
+//!
+//! # Output
+//!
+//! Each test writes a Chrome trace JSON file to `$EDGLI_TRACE_DIR/`:
+//! - `edgli-trace-paced.json`    — baseline (paced 16-packet batches, free task interleaving)
+//! - `edgli-trace-continuous.json` — starvation case (single write_all, writer holds thread)
+//!
+//! Load the files at <https://ui.perfetto.dev>.
 //!
 //! # What to look for
 //!
-//! With executor starvation present:
-//! - **Session write task**: very short poll time (channel always ready → fast) but the
-//!   `poll_copy` loop NEVER returns `Poll::Pending`, so it holds the thread until all
-//!   data is written; show as a single long-running poll of the parent copy task.
-//! - **SURB balancer**: high "idle" time between wakeups — starved.
-//! - **ack processing task**: same — starved.
+//! In `edgli-trace-continuous.json`:
+//! - **Session write task**: one single long-running poll spanning the whole `write_all`
+//! - **SURB balancer task**: long gaps between wakeups (starved — can't run while writer holds thread)
+//! - **Ack-processing task**: same pattern
 //!
-//! With a fix (e.g. `tokio::task::yield_now()` after each `poll_write` batch, or a
-//! tighter channel bound that lets `poll_ready` return `Poll::Pending`):
-//! - All tasks interleave normally.
-//! - SURB replenishment keeps pace with data consumption.
-//! - End-to-end throughput improves toward the in-process test baseline.
+//! In `edgli-trace-paced.json`:
+//! - All tasks interleave freely during the 100 ms inter-batch windows
+//! - SURB balancer wakes up regularly between batches
 
 mod common;
 
-// ─── Profiling tests ────────────────────────────────────────────────────────
-//
-// Gated on `#[cfg(feature = "prof")]` so they are never compiled into the
-// default test binary — they require both `--features prof` and
-// `RUSTFLAGS="--cfg tokio_unstable"`.
+// ─── Subscriber setup ────────────────────────────────────────────────────────
 
-/// Profiling run of the standard 1 MiB session test with tokio-console active.
+/// Initialise tracing with both tokio-console (live TUI) and tracing-chrome
+/// (persistent JSON file).  Returns the chrome flush guard — keep it alive
+/// for the duration of the test.
 ///
-/// This uses the *paced* pump (16 packets per batch, 100 ms sleep) as a
-/// baseline.  Attach `tokio-console` while this runs and observe task
-/// behaviour during the 100 ms idle windows between write batches — those
-/// windows show the "healthy" state where all tasks run freely.
+/// The chrome trace is written to `$EDGLI_TRACE_DIR/<filename>` (or `./<filename>`
+/// if the env var is not set).
 ///
-/// Compare against `edgli_profiling_continuous_pump` to see what changes
-/// when the pacing is removed.
+/// Uses `try_init()` so it is safe if multiple tests share a process (e.g.
+/// with the standard `cargo test` runner).  Subsequent calls are no-ops — the
+/// first test's subscriber stays active.
+#[cfg(feature = "prof")]
+fn init_subscriber(filename: &str) -> tracing_chrome::FlushGuard {
+    use tracing_subscriber::prelude::*;
+
+    let dir = std::env::var("EDGLI_TRACE_DIR").unwrap_or_else(|_| ".".to_string());
+    let path = format!("{dir}/{filename}");
+
+    let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+        .file(&path)
+        .include_args(true)
+        .build();
+
+    // console_subscriber::spawn() starts the gRPC server on the current tokio
+    // runtime and returns a Layer — no separate tokio::spawn needed.
+    tracing_subscriber::registry()
+        .with(console_subscriber::spawn())
+        .with(chrome_layer)
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .ok(); // swallow "already set" if multiple tests run in the same process
+
+    eprintln!("Chrome trace → {path}");
+    guard
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// Paced-pump baseline with tokio-console + Chrome trace active.
+///
+/// Writes `edgli-trace-paced.json`.  Observe the trace in Perfetto to see what
+/// "healthy" task interleaving looks like during the 100 ms inter-batch gaps.
+/// Compare against `edgli_profiling_continuous_pump`.
 #[cfg(feature = "prof")]
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn edgli_profiling_paced_pump_baseline() -> anyhow::Result<()> {
-    // console_subscriber::init() sets the global tracing subscriber so
-    // tokio-console can connect.  It must be called before any tokio tasks
-    // are spawned (including those in Edgli::new).
-    //
-    // IMPORTANT: this call succeeds only when `STATIC_MAX_LEVEL >= TRACE`,
-    // i.e. when built with `--profile tracer` (debug-assertions = true).
-    // With `--profile release` the `tracing/release_max_level_debug` feature
-    // compiles all `trace!` callsites to no-ops, and tokio-console sees
-    // zero tasks — making the profiling run useless.
-    console_subscriber::init();
-
+    let _guard = init_subscriber("edgli-trace-paced.json");
     common::run_one_megabyte_session_test(common::Network::Local).await
 }
 
-/// Profiling run of the **continuous** (unthrottled) pump.
+/// Continuous-pump starvation case with tokio-console + Chrome trace active.
 ///
-/// Unlike `pump_and_verify`, `pump_continuous` issues a single
-/// `write_all(1 MiB)` without any inter-batch sleep.  This replicates how
-/// production callers use `transfer_session` / `copy_duplex` with a fast
-/// data source: the write loop never blocks because `CrossfireSink` (capacity
-/// 200,000) almost never fills up, so `poll_copy` never returns `Poll::Pending`
-/// and the tokio worker thread is held for the entire write.
+/// Writes `edgli-trace-continuous.json`.  A single `write_all(1 MiB)` without
+/// any inter-batch sleep replicates production `transfer_session`/`copy_duplex`
+/// behaviour.  In the trace you should observe:
 ///
-/// With tokio-console attached you should observe:
-/// - The session write task shows a single very long poll (the whole `write_all`)
-///   instead of many short ones.
-/// - The SURB balancer and ack processing tasks show long gaps between wakeups
-///   (executor starvation) while the write is in progress.
-/// - Effective echo throughput is noticeably lower than the paced baseline.
+/// - Writer task: one very long poll (entire `write_all` without yielding)
+/// - SURB balancer: long idle gaps (starved while writer holds the thread)
+/// - Echo throughput significantly lower than the paced baseline
 #[cfg(feature = "prof")]
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn edgli_profiling_continuous_pump() -> anyhow::Result<()> {
-    console_subscriber::init();
-
+    let _guard = init_subscriber("edgli-trace-continuous.json");
     common::run_throughput_comparison_test(common::Network::Local).await
 }
 
-/// Rotsee variant of the continuous-pump profiling test.
-///
-/// Same as `edgli_profiling_continuous_pump` but against the public Rotsee
-/// testnet.  Requires the `EDGLI_ROTSEE_*` environment variables.
+/// Rotsee variant — same as `edgli_profiling_continuous_pump` against the
+/// public Rotsee testnet.  Requires the `EDGLI_ROTSEE_*` env vars.
+/// Writes `edgli-trace-rotsee.json`.
 #[cfg(feature = "prof")]
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn edgli_profiling_continuous_pump_rotsee() -> anyhow::Result<()> {
-    console_subscriber::init();
-
+    let _guard = init_subscriber("edgli-trace-rotsee.json");
     common::run_throughput_comparison_test(common::Network::Rotsee).await
 }

--- a/tests/edgli_profiling.rs
+++ b/tests/edgli_profiling.rs
@@ -41,7 +41,7 @@
 //! ```text
 //! export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd-localcluster
 //! export HOPRD_BIN=/path/to/hoprd
-//! export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:0.10.5-pr.349@sha256:2e6747d9d6c97255474e243b5088d131f01bb67b5d8f17dbac6bb8aafdf1d7b6'
+//! export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:latest'
 //! export HOPRD_CONTAINER_RUNTIME=container   # macOS Apple runtime
 //! export EDGLI_TRACE_DIR=./profiling-results
 //! export RUST_LOG=info,edgli=debug,tokio=trace,runtime=trace

--- a/tests/edgli_profiling.rs
+++ b/tests/edgli_profiling.rs
@@ -1,0 +1,146 @@
+//! Executor-starvation profiling harness for identifying tokio executor yield issues.
+//!
+//! # Background
+//!
+//! Production applications using `transfer_session` / `copy_duplex` with a fast data
+//! source can hold a tokio worker thread indefinitely:
+//!
+//! - `copy_duplex` → `poll_copy` loops without returning `Poll::Pending`
+//! - `AsyncWriteSink::poll_write` → `CrossfireSink::poll_ready` **always** returns
+//!   `Poll::Ready` (capacity = 200,000 slots)
+//! - The tight write loop monopolises one tokio worker thread
+//! - SURB balancer and ack-processing tasks are starved → SURB replenishment stalls
+//!   → session blocks on echo return → measured throughput collapses 10×
+//!
+//! # tokio-console setup
+//!
+//! Two requirements must hold together or tokio-console sees nothing:
+//!
+//! 1. **`RUSTFLAGS="--cfg tokio_unstable"`** — enables tokio's internal task
+//!    instrumentation at compile time.
+//!
+//! 2. **`--profile tracer`** — the `tracer` profile inherits `release` (optimised,
+//!    no stack overflow) but sets `debug-assertions = true`, which silences the
+//!    `tracing/release_max_level_debug` static filter. Without this flag the filter
+//!    sets `STATIC_MAX_LEVEL = DEBUG`, and every `trace!` callsite — including
+//!    tokio's task spans — is compiled to a no-op. The subscriber directive
+//!    `tokio=trace` added at runtime cannot resurrect callsites that were removed
+//!    at compile time.
+//!
+//! 3. **`--features prof`** — wires `console_subscriber` into the tracing stack.
+//!    The test below calls `console_subscriber::init()` directly; the regular
+//!    `init_logger()` path in `main.rs` does the same for the binary.
+//!
+//! # How to run
+//!
+//! ```text
+//! # Terminal 1 — start the localcluster (external mode example)
+//! hoprd-localcluster --size 3 --extra-identities 1 \
+//!   --api-port-base 13000 --p2p-port-base 19000 \
+//!   --api-token test-token-localcluster \
+//!   --data-dir /tmp/edgli-cluster \
+//!   --chain-image '<bloklid-anvil image>' ...
+//!
+//! # Wait for {"state":"running"}:
+//! hoprd-localcluster status --data-dir /tmp/edgli-cluster
+//!
+//! # Terminal 2 — run profiling tests
+//! export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd-localcluster
+//! export HOPRD_CLUSTER_DATA_DIR=/tmp/edgli-cluster
+//!
+//! RUSTFLAGS="--cfg tokio_unstable" \
+//! RUST_LOG=info,edgli=debug \
+//! cargo test --test edgli_profiling \
+//!   --profile tracer --features prof \
+//!   -- --ignored --nocapture
+//!
+//! # Terminal 3 — attach tokio-console (install once with: cargo install tokio-console)
+//! tokio-console
+//! ```
+//!
+//! # What to look for
+//!
+//! With executor starvation present:
+//! - **Session write task**: very short poll time (channel always ready → fast) but the
+//!   `poll_copy` loop NEVER returns `Poll::Pending`, so it holds the thread until all
+//!   data is written; show as a single long-running poll of the parent copy task.
+//! - **SURB balancer**: high "idle" time between wakeups — starved.
+//! - **ack processing task**: same — starved.
+//!
+//! With a fix (e.g. `tokio::task::yield_now()` after each `poll_write` batch, or a
+//! tighter channel bound that lets `poll_ready` return `Poll::Pending`):
+//! - All tasks interleave normally.
+//! - SURB replenishment keeps pace with data consumption.
+//! - End-to-end throughput improves toward the in-process test baseline.
+
+mod common;
+
+// ─── Profiling tests ────────────────────────────────────────────────────────
+//
+// Gated on `#[cfg(feature = "prof")]` so they are never compiled into the
+// default test binary — they require both `--features prof` and
+// `RUSTFLAGS="--cfg tokio_unstable"`.
+
+/// Profiling run of the standard 1 MiB session test with tokio-console active.
+///
+/// This uses the *paced* pump (16 packets per batch, 100 ms sleep) as a
+/// baseline.  Attach `tokio-console` while this runs and observe task
+/// behaviour during the 100 ms idle windows between write batches — those
+/// windows show the "healthy" state where all tasks run freely.
+///
+/// Compare against `edgli_profiling_continuous_pump` to see what changes
+/// when the pacing is removed.
+#[cfg(feature = "prof")]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn edgli_profiling_paced_pump_baseline() -> anyhow::Result<()> {
+    // console_subscriber::init() sets the global tracing subscriber so
+    // tokio-console can connect.  It must be called before any tokio tasks
+    // are spawned (including those in Edgli::new).
+    //
+    // IMPORTANT: this call succeeds only when `STATIC_MAX_LEVEL >= TRACE`,
+    // i.e. when built with `--profile tracer` (debug-assertions = true).
+    // With `--profile release` the `tracing/release_max_level_debug` feature
+    // compiles all `trace!` callsites to no-ops, and tokio-console sees
+    // zero tasks — making the profiling run useless.
+    console_subscriber::init();
+
+    common::run_one_megabyte_session_test(common::Network::Local).await
+}
+
+/// Profiling run of the **continuous** (unthrottled) pump.
+///
+/// Unlike `pump_and_verify`, `pump_continuous` issues a single
+/// `write_all(1 MiB)` without any inter-batch sleep.  This replicates how
+/// production callers use `transfer_session` / `copy_duplex` with a fast
+/// data source: the write loop never blocks because `CrossfireSink` (capacity
+/// 200,000) almost never fills up, so `poll_copy` never returns `Poll::Pending`
+/// and the tokio worker thread is held for the entire write.
+///
+/// With tokio-console attached you should observe:
+/// - The session write task shows a single very long poll (the whole `write_all`)
+///   instead of many short ones.
+/// - The SURB balancer and ack processing tasks show long gaps between wakeups
+///   (executor starvation) while the write is in progress.
+/// - Effective echo throughput is noticeably lower than the paced baseline.
+#[cfg(feature = "prof")]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn edgli_profiling_continuous_pump() -> anyhow::Result<()> {
+    console_subscriber::init();
+
+    common::run_throughput_comparison_test(common::Network::Local).await
+}
+
+/// Rotsee variant of the continuous-pump profiling test.
+///
+/// Same as `edgli_profiling_continuous_pump` but against the public Rotsee
+/// testnet.  Requires the `EDGLI_ROTSEE_*` environment variables.
+#[cfg(feature = "prof")]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn edgli_profiling_continuous_pump_rotsee() -> anyhow::Result<()> {
+    console_subscriber::init();
+
+    common::run_throughput_comparison_test(common::Network::Rotsee).await
+}


### PR DESCRIPTION
## Summary

- Adds `pump_continuous` — a single un-paced `write_all(1 MiB)` that replicates how production callers use `transfer_session`/`copy_duplex`, making executor-starvation observable
- Adds `run_throughput_comparison_test` — runs paced (baseline) and continuous variants for 0-hop and 1-hop sessions back-to-back, logging KB/s for each
- Adds `tests/edgli_profiling.rs` — three `#[cfg(feature = "prof")]` `#[ignore]` tests with a composed tracing subscriber (tokio-console live view + tracing-chrome persistent JSON)
- Adds `scripts/profile-executor-yield.sh` — fully automated run script (build → test → result report)

Depends on: https://github.com/hoprnet/edge-client/pull/111

## How to run

```sh
./scripts/profile-executor-yield.sh
```

Override binaries if needed:

```sh
HOPRD_RELEASE_DIR=/your/path ./scripts/profile-executor-yield.sh
```

Each test writes a Chrome trace JSON to `./profiling-results/`.  Load at <https://ui.perfetto.dev>.

## Trace files

| File | What it shows |
|---|---|
| `edgli-trace-paced.json` | Baseline — tasks interleave freely during 100 ms inter-batch gaps |
| `edgli-trace-continuous.json` | Starvation — single `write_all` holds worker thread; SURB balancer starved |

## What to look for

In `edgli-trace-continuous.json` (Perfetto timeline):
- **Session write task**: one single very long poll spanning the entire `write_all` (no `Poll::Pending` issued)
- **SURB balancer task**: long gaps between wakeups — starved while writer holds the thread
- Echo throughput significantly lower than paced baseline (quantifies the starvation)

https://claude.ai/code/session_01DgqM8mBtWmUyw8ohgnXT9T