### PR TITLE
feat(deps): migrate hopr-strategy to standalone repo v0.22.0 with stochastic sizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3880,8 +3880,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.3-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+version = "4.0.2-rc.9"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4059,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.34.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6532addd54c6f73e4dd5aa320864b7a3f4266d4a#6532addd54c6f73e4dd5aa320864b7a3f4266d4a"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4462,7 +4462,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6556,7 +6556,7 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6594,7 +6594,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6607,7 +6607,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -243,7 +243,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -269,7 +269,7 @@ dependencies = [
  "borsh",
  "k256 0.13.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -401,7 +401,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ dependencies = [
  "rand 0.8.6",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -501,7 +501,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -610,7 +610,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ dependencies = [
  "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dependencies = [
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.6",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -743,7 +743,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -779,7 +779,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -1155,7 +1155,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -1300,13 +1300,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1665,7 +1665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -1971,7 +1971,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2808,7 +2808,7 @@ dependencies = [
  "strum 0.28.0",
  "tempfile",
  "test-log",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3176,9 +3176,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3201,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3224,15 +3224,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3241,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -3260,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3282,15 +3282,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-time"
@@ -3315,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3397,6 +3397,30 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "glob"
@@ -3613,7 +3637,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3639,7 +3663,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3660,7 +3684,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -3682,7 +3706,7 @@ dependencies = [
  "rand 0.9.4",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -3708,7 +3732,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -3766,7 +3790,7 @@ dependencies = [
  "multiaddr",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3783,7 +3807,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -3805,7 +3829,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3814,9 +3838,9 @@ dependencies = [
  "serde_json",
  "smart-default",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
- "validator",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -3828,12 +3852,12 @@ dependencies = [
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3848,10 +3872,10 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "smart-default",
  "tracing",
- "validator",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -3877,7 +3901,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3887,11 +3911,11 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
- "validator",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -3903,14 +3927,14 @@ dependencies = [
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
  "petgraph",
  "rand 0.10.2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3924,7 +3948,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3942,7 +3966,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3952,9 +3976,9 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
- "validator",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -3974,7 +3998,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -3983,7 +4007,7 @@ dependencies = [
  "serde_bytes",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4000,13 +4024,14 @@ dependencies = [
  "serde",
  "serde_cbor_2",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "hopr-strategy"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hopr-strategy?rev=b5fe92b5f17d218702beddfc7e4806a636154dc9#b5fe92b5f17d218702beddfc7e4806a636154dc9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b7849a82fe53e861a4938d1fab94123a16ba55917ff187de358610c07d599a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4016,7 +4041,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.3.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4026,9 +4051,9 @@ dependencies = [
  "serde_with",
  "smart-default",
  "statrs",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
- "validator",
+ "validator 0.21.0",
 ]
 
 [[package]]
@@ -4043,13 +4068,13 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "parking_lot",
  "postcard",
  "redb",
  "strum 0.28.0",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -4078,7 +4103,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4086,15 +4111,15 @@ dependencies = [
  "multiaddr",
  "proc-macro-regex",
  "rand 0.10.2",
- "rand_distr 0.6.0",
+ "rand_distr",
  "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio-util",
  "tracing",
- "validator",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -4110,7 +4135,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -4125,13 +4150,13 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
  "pin-project",
  "quinn-udp 0.6.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -4149,16 +4174,16 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
  "serde",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
- "validator",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -4177,7 +4202,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.4.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4188,7 +4213,7 @@ dependencies = [
  "serde_repr",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4201,8 +4226,8 @@ dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
- "thiserror 2.0.18",
- "validator",
+ "thiserror 2.0.19",
+ "validator 0.20.0",
 ]
 
 [[package]]
@@ -4258,24 +4283,11 @@ dependencies = [
  "smart-default",
  "strum 0.28.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "typenum",
  "uuid",
  "zeroize",
-]
-
-[[package]]
-name = "hopr-utilities"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5f44193a6854b1c8dd5339e692eb1e3a7eb4992c534ea2c82b249a0d17211d"
-dependencies = [
- "auto_impl",
- "futures",
- "indexmap 2.14.0",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4304,7 +4316,7 @@ dependencies = [
  "serde_bytes",
  "socket2 0.6.4",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4450,7 +4462,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4833,7 +4845,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -5042,7 +5054,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5076,7 +5088,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.6",
  "rand_core 0.6.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "web-time",
 ]
@@ -5111,7 +5123,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.6",
  "rw-stream-sink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -5150,7 +5162,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -5168,7 +5180,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zeroize",
 ]
@@ -5225,7 +5237,7 @@ dependencies = [
  "rand 0.8.6",
  "snow",
  "static_assertions",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5248,7 +5260,7 @@ dependencies = [
  "ring",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -5347,7 +5359,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x509-parser",
  "yasna",
 ]
@@ -5376,7 +5388,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -5628,17 +5640,20 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
  "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.2",
  "matrixmultiply",
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.6",
- "rand_distr 0.4.3",
+ "rand 0.10.2",
  "simba",
  "typenum",
 ]
@@ -5681,7 +5696,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5894,7 +5909,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -5924,7 +5939,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -5967,7 +5982,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6541,8 +6556,8 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
- "thiserror 2.0.18",
+ "socket2 0.5.10",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -6564,7 +6579,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6579,7 +6594,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6592,7 +6607,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "windows-sys 0.61.2",
 ]
 
@@ -6701,16 +6716,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
 
 [[package]]
 name = "rand_distr"
@@ -7224,9 +7229,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -7422,9 +7427,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7452,22 +7457,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7669,14 +7674,13 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
 dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "paste",
  "wide",
 ]
 
@@ -7831,14 +7835,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+checksum = "c78553aa710187998fc7c7945c18889c59ef199ff7d2146ab90998b431b29eea"
 dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.10.2",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7930,6 +7935,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8069,11 +8085,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -8089,13 +8105,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8612,6 +8628,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "validator"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
+dependencies = [
+ "idna",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
 name = "validator_derive"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8836,9 +8867,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -9290,7 +9321,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "aquamarine"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1757,12 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -2758,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.3.1"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3736,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c76f9c17f903a3a0487c7eb0766914baf94380cd7a9112043310e4bc4dc9547"
+checksum = "2f8c7f28951b250cc61b68d8d06aa2d73fb05f96d19380325fc235924768f579"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3776,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3790,7 +3805,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3807,13 +3822,13 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3825,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3833,7 +3848,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "smart-default",
  "tracing",
  "validator",
@@ -3841,13 +3856,14 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "4.0.3-rc.8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "anyhow",
  "async-broadcast",
  "async-trait",
  "backon",
+ "bytesize",
  "cfg_eval",
  "const_format",
  "futures",
@@ -3861,7 +3877,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3881,13 +3897,13 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -3901,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3914,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3926,7 +3942,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3944,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3958,7 +3974,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -3975,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3989,8 +4005,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.22.0"
+source = "git+https://github.com/hoprnet/hopr-strategy?rev=b5fe92b5f17d218702beddfc7e4806a636154dc9#b5fe92b5f17d218702beddfc7e4806a636154dc9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4000,8 +4016,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-crypto-packet",
- "hopr-utils",
+ "hopr-utilities 0.3.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4010,6 +4025,7 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
+ "statrs",
  "thiserror 2.0.18",
  "tracing",
  "validator",
@@ -4017,8 +4033,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.5.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4027,7 +4043,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "parking_lot",
  "postcard",
  "redb",
@@ -4039,8 +4055,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.34.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4052,6 +4068,7 @@ dependencies = [
  "dashmap",
  "futures",
  "futures-time",
+ "futures-timer",
  "halfbrown",
  "hopr-api",
  "hopr-crypto-packet",
@@ -4061,13 +4078,15 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "humantime-serde",
  "lazy_static",
  "libp2p",
  "moka",
  "multiaddr",
  "proc-macro-regex",
+ "rand 0.10.2",
+ "rand_distr 0.6.0",
  "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
@@ -4081,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4098,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4106,7 +4125,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4119,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4130,7 +4149,7 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
@@ -4144,8 +4163,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.23.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4158,7 +4177,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utils",
+ "hopr-utilities 0.4.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4177,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0ba0b57bab014cdc421a7b65c824af17c0d3e74f#0ba0b57bab014cdc421a7b65c824af17c0d3e74f"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4247,9 +4266,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-utils"
+name = "hopr-utilities"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5f44193a6854b1c8dd5339e692eb1e3a7eb4992c534ea2c82b249a0d17211d"
+dependencies = [
+ "auto_impl",
+ "futures",
+ "indexmap 2.14.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-utilities"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f60cbe7d588c9ee1bb454db33e6de7e969638a096ac6bdf1406fd7a43e476aa"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -5462,6 +5495,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,6 +5627,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.6",
+ "rand_distr 0.4.3",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5697,6 +5757,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,6 +5777,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -6623,6 +6703,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6639,6 +6739,12 @@ checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7117,6 +7223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "salsa20"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7553,6 +7668,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7700,6 +7828,18 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.6",
+]
 
 [[package]]
 name = "strobe-rs"
@@ -8692,6 +8832,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,20 +92,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a" }
 hopr-strategy = { version = "0.22.0", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -114,7 +114,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "6532addd54c6f73e4dd5aa320864b7a3f4266d4a", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0
   "runtime-tokio",
 ] }
 hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
-hopr-strategy = { git = "https://github.com/hoprnet/hopr-strategy", rev = "b5fe92b5f17d218702beddfc7e4806a636154dc9", features = [
+hopr-strategy = { version = "0.22.0", features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -92,20 +92,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
+hopr-strategy = { git = "https://github.com/hoprnet/hopr-strategy", rev = "b5fe92b5f17d218702beddfc7e4806a636154dc9", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -114,7 +114,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0ba0b57bab014cdc421a7b65c824af17c0d3e74f", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -5,7 +5,8 @@ use hopr_lib::api::types::primitive::prelude::{
     Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
 };
 pub use hopr_strategy::channel_lifecycle::{
-    ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig, SelectorProfile,
+    CapacitySizingMode, ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
+    SelectorProfile,
 };
 
 /// Paid downstream relay hops assumed when sizing a channel's stake. Edge nodes
@@ -92,6 +93,9 @@ pub fn compute_funding_config() -> FundingConfig {
         min_safe_capacity_required: ByteSize::b(INITIAL_CAPACITY_BYTES),
         assumed_hops: ASSUMED_HOPS,
         stop_when_unfunded: true,
+        sizing_mode: CapacitySizingMode::Probabilistic {
+            success_probability: 0.999,
+        },
     }
 }
 
@@ -391,6 +395,20 @@ mod tests {
         // before a top-up triggers.
         let cfg = compute_funding_config();
         assert!(cfg.lower_capacity_threshold.as_u64() >= hopr_lib::SESSION_MTU as u64);
+    }
+
+    #[test]
+    fn compute_funding_config_uses_probabilistic_sizing() {
+        let cfg = compute_funding_config();
+        assert!(
+            matches!(
+                cfg.sizing_mode,
+                CapacitySizingMode::Probabilistic { success_probability }
+                if (success_probability - 0.999).abs() < f64::EPSILON
+            ),
+            "expected Probabilistic(0.999), got {:?}",
+            cfg.sizing_mode
+        );
     }
 
     #[test]

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -99,9 +99,8 @@ pub fn compute_funding_config() -> FundingConfig {
     }
 }
 
-/// wxHOPR a single new channel's initial stake locks, mirroring the strategy's
-/// capacity→balance conversion of `initial_capacity`
-/// (`ticket_price × packets × ASSUMED_HOPS / win_prob`).
+/// wxHOPR a single new channel's initial stake locks, using conservative
+/// face-value sizing regardless of [`CapacitySizingMode`].
 ///
 /// **Semantics:** `ticket_price` is the *expected* per-hop value
 /// (= `face_value × win_prob`), not the face value. The ticket face value
@@ -113,6 +112,12 @@ pub fn compute_funding_config() -> FundingConfig {
 /// `SESSION_MTU < HoprPacket::PAYLOAD_SIZE`, so this is ≥ the strategy's own
 /// `ceil(bytes / PAYLOAD_SIZE)` packet count, keeping the recommendation on
 /// the never-underfund side.
+///
+/// **Conservative by design:** the capacity threshold values in [`FundingConfig`]
+/// are sizing-mode agnostic (bytes). [`CapacitySizingMode`] controls how the
+/// strategy converts those thresholds to wxHOPR at runtime; recommendations
+/// intentionally use face-value sizing as a safe upper bound so that users are
+/// never told to fund less than the strategy will actually lock.
 fn initial_channel_stake(ticket_price: HoprBalance, win_prob: f64) -> anyhow::Result<HoprBalance> {
     anyhow::ensure!(
         win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,


### PR DESCRIPTION
## Summary

- Drops `hopr-strategy` from the hoprnet monorepo and replaces it with the published crate `hopr-strategy = "0.22.0"` from crates.io
- Bumps all other monorepo crates to PR #8285 head (`0ba0b57b`) — the commit that adds `impl PacketTransport for Hopr` required by the new strategy's `build<N>` bound
- Wires up `CapacitySizingMode::Probabilistic { success_probability: 0.999 }` in `compute_funding_config()`, enabling stochastic channel-stake sizing (buffers μ + k·σ of the Binomial drain distribution, reducing locked capital vs. old face-value sizing)
- Exports `CapacitySizingMode` from `src/strategy.rs` for callers that need runtime tunability
- Adds a regression test asserting the `Probabilistic(0.999)` variant is explicitly set

**Depends on:** hoprnet/hoprnet#8285 (adds `impl PacketTransport for Hopr`)

## Verification

All 65 unit tests pass:
```
Summary [1.274s] 65 tests run: 65 passed, 0 skipped
```
`hopr-api` resolves to a single v1.16.0 across the whole dependency graph.