### PR TITLE
test(session-e2e): paced 20 MiB pump + time-of-last-byte throughput measurement

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,6 +26,13 @@ LDFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 # does NOT merge `[build]` and target-specific rustflags — the matching target
 # table wins outright — so the flag is repeated in the aarch64 table below as
 # well as `[build]`. `--check-cfg` keeps `-D warnings` clean.
+#
+# NOTE: The `RUSTFLAGS` environment variable *replaces* these tables wholesale —
+# it does not append. Exporting `RUSTFLAGS="--cfg tokio_unstable"` for a
+# profiling build would therefore silently drop `-Ctarget-feature=+aes,+neon`
+# and `--cfg=aes_armv8` on aarch64-apple-darwin. Because this file already
+# supplies `--cfg tokio_unstable` unconditionally, profiling builds must NOT set
+# `RUSTFLAGS` at all (the profiling docs in README.md rely on this).
 [build]
 rustflags = ["--cfg", "tokio_unstable", "--check-cfg", "cfg(tokio_unstable)"]
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,9 +21,24 @@ CFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 CPPFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 LDFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 
+# Build with `--cfg tokio_unstable` so the hoprnet crates (hopr-utilities and
+# the transport/session stack) get Tokio's improved cooperative yielding. Cargo
+# does NOT merge `[build]` and target-specific rustflags — the matching target
+# table wins outright — so the flag is repeated in the aarch64 table below as
+# well as `[build]`. `--check-cfg` keeps `-D warnings` clean.
+[build]
+rustflags = ["--cfg", "tokio_unstable", "--check-cfg", "cfg(tokio_unstable)"]
+
 # Enable hardware AES intrinsics on aarch64 — selects aes::armv8 backend at
 # compile time instead of the runtime-dispatched aes::soft::fixslice path.
 # Benchmarks show ~10× key-schedule improvement on Apple Silicon.
 # See: hoprnet/edge-client#82
 [target.aarch64-apple-darwin]
-rustflags = ["--cfg=aes_armv8", "-Ctarget-feature=+aes,+neon"]
+rustflags = [
+  "--cfg=aes_armv8",
+  "-Ctarget-feature=+aes,+neon",
+  "--cfg",
+  "tokio_unstable",
+  "--check-cfg",
+  "cfg(tokio_unstable)",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3865,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.9"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.35.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.24.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3830,7 +3830,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3847,13 +3847,13 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3865,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3873,7 +3873,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "smart-default",
  "tracing",
  "validator",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.9"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3902,7 +3902,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3922,13 +3922,13 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3967,7 +3967,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3984,8 +3984,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+version = "1.3.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3999,7 +3999,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4069,7 +4069,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "parking_lot",
  "postcard",
  "redb",
@@ -4081,8 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.34.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+version = "0.35.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4104,7 +4104,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4150,7 +4150,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4174,7 +4174,7 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
@@ -4188,8 +4188,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+version = "0.24.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4202,7 +4202,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.5.0",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c3137ffba76fd2feda004f8ffc20e8a6c3690381#c3137ffba76fd2feda004f8ffc20e8a6c3690381"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4305,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474fc7b7c21f62689d148928cd178fca6d169cf4a9162a6d2c5f9a6a35d75d6"
+checksum = "c3fb9c92de05424fd684bc1a0ac2f7df91ec2b6958f2733b2ff1c830a4390a34"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1934,14 +1934,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2812,6 +2812,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-chrome",
+ "tracing-flame",
  "tracing-subscriber",
  "url",
 ]
@@ -3816,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3824,13 +3825,12 @@ dependencies = [
  "async-trait",
  "atomic_enum",
  "blokli-client",
- "const-hex",
  "dashmap",
  "futures",
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3841,19 +3841,19 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tracing",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3865,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3873,16 +3873,16 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "smart-default",
  "tracing",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.9"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3902,7 +3902,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3916,19 +3916,19 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3967,7 +3967,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -3979,13 +3979,13 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.19",
  "tracing",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3999,7 +3999,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4042,7 +4042,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.4.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4054,13 +4054,13 @@ dependencies = [
  "statrs",
  "thiserror 2.0.19",
  "tracing",
- "validator 0.21.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4069,7 +4069,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "parking_lot",
  "postcard",
  "redb",
@@ -4081,8 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.34.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+version = "0.34.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4104,7 +4104,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4113,20 +4113,19 @@ dependencies = [
  "proc-macro-regex",
  "rand 0.10.2",
  "rand_distr",
- "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
  "strum 0.28.0",
  "thiserror 2.0.19",
  "tokio-util",
  "tracing",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4143,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4151,7 +4150,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4164,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4175,7 +4174,7 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
@@ -4184,13 +4183,13 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.19",
  "tracing",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4203,7 +4202,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities",
+ "hopr-utilities 0.5.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4222,13 +4221,13 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=837f8d933c1ba78cda1ffe42bd37d13e7a9f0929#837f8d933c1ba78cda1ffe42bd37d13e7a9f0929"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8b59fb4f66337d783414e1b188f509dbb3c32098#8b59fb4f66337d783414e1b188f509dbb3c32098"
 dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
  "thiserror 2.0.19",
- "validator 0.20.0",
+ "validator",
 ]
 
 [[package]]
@@ -4297,13 +4296,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95680cead4b551cdeb76b016e99197f17b3528e790d1b37a7978b8e38e5f36b7"
 dependencies = [
+ "auto_impl",
+ "futures",
+ "indexmap 2.14.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-utilities"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a474fc7b7c21f62689d148928cd178fca6d169cf4a9162a6d2c5f9a6a35d75d6"
+dependencies = [
+ "anyhow",
  "arrayvec",
  "auto_impl",
+ "blokli-client",
+ "const-hex",
  "crossfire",
  "flume",
  "futures",
  "futures-time",
  "hickory-resolver 0.26.1",
+ "hopr-api",
  "hopr-types",
  "indexmap 2.14.0",
  "lazy_static",
@@ -4315,6 +4331,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
+ "serde_json",
  "socket2 0.6.4",
  "strum 0.28.0",
  "thiserror 2.0.19",
@@ -7055,16 +7072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
-name = "rust-stream-ext-concurrent"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b7b0b486f2712aa8fa4a7b21303d79c60ceca3b11a3e9d82eb7c650bc9c4ff"
-dependencies = [
- "futures",
- "pin-project",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7478,9 +7485,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -7491,13 +7498,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8191,9 +8198,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -8242,14 +8249,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -8432,6 +8440,17 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8621,22 +8640,6 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "validator"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,20 +92,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
 hopr-strategy = { version = "0.22.0", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -114,11 +114,14 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "837f8d933c1ba78cda1ffe42bd37d13e7a9f0929", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098", features = [
   "runtime-tokio",
   "testing",
 ] }
 tokio = { version = "1.52.3", features = ["full", "process", "tracing"] }
+# Optional flamegraph layer for the session e2e harness (env-gated: FLAME_OUTPUT).
+# `tracing-chrome` (Chrome/Perfetto layer) is already declared below.
+tracing-flame = "0.2.0"
 reqwest = { version = "0.13.4", default-features = false, features = [
   "rustls",
   "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,20 +92,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937" }
 hopr-strategy = { version = "0.22.0", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -114,7 +114,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,20 +92,20 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381", features = [
   "runtime-tokio",
 ] }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
 hopr-strategy = { version = "0.22.0", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381" }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -114,7 +114,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8b59fb4f66337d783414e1b188f509dbb3c32098", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c3137ffba76fd2feda004f8ffc20e8a6c3690381", features = [
   "runtime-tokio",
   "testing",
 ] }

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ export HOPRD_BIN=/path/to/hoprd/target/release/hoprd
 # tag known to match your hoprd binaries with e.g.
 # `docker buildx imagetools inspect <image>:latest`, then substitute it below.
 export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil@sha256:<pinned-digest>'
+# macOS Apple `container` runtime; on Linux/others use `docker` or `podman`.
 export HOPRD_CONTAINER_RUNTIME=container
 export EDGLI_TRACE_DIR=./profiling-results
 export RUST_LOG=info,edgli=debug,tokio=trace,runtime=trace

--- a/README.md
+++ b/README.md
@@ -117,14 +117,36 @@ Coverage (lcov at `coverage.lcov`):
 nix run .#coverage-unit
 ```
 
-### End-to-end session tests (`#[ignore]`, not run in CI)
+### Tests excluded from CI (`#[ignore]` / feature-gated)
 
-`tests/edgli_session_e2e.rs` spins up a real 3-node HOPR cluster via
-`hoprd-localcluster`, boots Edgli against it, and pumps a payload through 0-hop
-and 1-hop sessions (measuring throughput and packet loss, verifying SHA-256
-integrity). It is gated behind `#[ignore]` — it needs external binaries and a
-container runtime, so it is **not** part of `cargo nextest run` /
-`nix flake check`.
+Some integration tests are **not** part of `cargo nextest run --lib` or
+`nix flake check`: they need external binaries, a container runtime, a funded
+testnet identity, or a non-default build profile. They are marked `#[ignore]`
+(and some are additionally gated behind a Cargo feature), so a normal test run
+skips them and CI never invokes them. Run them explicitly with `--ignored`.
+
+To list what exists without running anything:
+
+```bash
+# every ignored test, with its module path
+cargo test --no-default-features --features runtime-tokio,blokli \
+  --tests -- --ignored --list
+```
+
+| Test file                       | Test(s)                                     | What it needs                                 |
+| ------------------------------- | ------------------------------------------- | --------------------------------------------- |
+| `tests/edgli_session_e2e.rs`    | `edgli_sends_payload_through_local_cluster` | `hoprd*` binaries + container runtime         |
+| `tests/edgli_session_rotsee.rs` | `edgli_sends_payload_through_rotsee`        | funded Rotsee identity (`EDGLI_ROTSEE_*` env) |
+| `tests/edgli_profiling.rs`      | 3 executor-yield profiling tests            | `--features prof` + `--cfg tokio_unstable`    |
+
+The authoritative setup for each lives in the module docs at the top of the
+corresponding test file; the summaries below are the fast path.
+
+#### 1. Local-cluster session throughput (`edgli_session_e2e.rs`)
+
+Spins up a real 3-node HOPR cluster via `hoprd-localcluster`, boots Edgli
+against it, and pumps a 20 MiB payload through 0-hop and 1-hop sessions
+(measuring throughput and packet loss, verifying SHA-256 integrity).
 
 Prerequisites:
 
@@ -162,6 +184,63 @@ The run reports, per hop count:
 See the module docs at the top of `tests/edgli_session_e2e.rs` for the full
 env-var table and the "external mode" (attach to an already-running cluster)
 variant.
+
+#### 2. Rotsee public-testnet session (`edgli_session_rotsee.rs`)
+
+Same pump/verify flow as the local-cluster test, but against the **Rotsee**
+public testnet instead of a managed cluster. Needs a HOPR identity that is
+already funded and registered with a Safe + HOPR module on Gnosis Chain — there
+is no cluster to boot, so all configuration comes from `EDGLI_ROTSEE_*` env
+vars:
+
+```bash
+export EDGLI_ROTSEE_BLOKLI_URL=https://blokli.rotsee.gnosisvpn.io
+export EDGLI_ROTSEE_IDENTITY_FILE=/path/to/identity.json
+export EDGLI_ROTSEE_IDENTITY_PASSWORD=my-password
+export EDGLI_ROTSEE_SAFE_ADDRESS=0x...
+export EDGLI_ROTSEE_MODULE_ADDRESS=0x...
+
+# --release is required for the same stack-depth reason as above.
+RUST_LOG=info,edgli=debug \
+  cargo test --test edgli_session_rotsee --release -- --ignored --nocapture
+```
+
+#### 3. Executor-yield profiling (`edgli_profiling.rs`)
+
+Runs the session pump under a `tokio-console` + `tracing-chrome` subscriber to
+capture executor-starvation traces (a fast writer monopolising a worker thread
+and starving the SURB balancer). These tests are **doubly gated**: `#[ignore]`
+_and_ `#[cfg(feature = "prof")]`, and they only see tokio's task spans when
+built with `--cfg tokio_unstable` under the `tracer` profile (which re-enables
+the TRACE callsites `hopr-lib`'s `release_max_level_debug` would otherwise
+compile out). They reuse the same local-cluster / Rotsee prerequisites as the
+tests above.
+
+The simplest way to run them is the wrapper script, which wires up the env vars,
+build flags, and result collection:
+
+```bash
+./scripts/profile-executor-yield.sh
+```
+
+Or manually (writes Chrome traces to `$EDGLI_TRACE_DIR`, load them at
+<https://ui.perfetto.dev>):
+
+```bash
+export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd/target/release/hoprd-localcluster
+export HOPRD_BIN=/path/to/hoprd/target/release/hoprd
+export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:latest'
+export HOPRD_CONTAINER_RUNTIME=container
+export EDGLI_TRACE_DIR=./profiling-results
+export RUST_LOG=info,edgli=debug,tokio=trace,runtime=trace
+
+RUSTFLAGS="--cfg tokio_unstable" cargo nextest run \
+  --test edgli_profiling --profile tracer --features prof \
+  --run-ignored ignored-only --no-capture --test-threads 1
+```
+
+See the module docs at the top of `tests/edgli_profiling.rs` for what each trace
+should show and why all three build flags are required together.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,14 @@ skips them and CI never invokes them. Run them explicitly with `--ignored`.
 To list what exists without running anything:
 
 ```bash
-# every ignored test, with its module path
+# every ignored test EXCEPT the feature-gated profiling ones, with its module path
 cargo test --no-default-features --features runtime-tokio,blokli \
   --tests -- --ignored --list
+
+# the profiling tests are gated behind the `prof` feature, so list them separately
+# (`.cargo/config.toml` supplies `--cfg tokio_unstable`; do not export RUSTFLAGS)
+cargo test --no-default-features --features runtime-tokio,blokli,prof \
+  --test edgli_profiling -- --ignored --list
 ```
 
 | Test file                       | Test(s)                                     | What it needs                                 |
@@ -177,8 +182,8 @@ RUST_LOG=info,edgli=debug \
 The run reports, per hop count:
 
 ```text
-0-hop: send … kB/s | recv … kB/s | loss …% (bytes)
-1-hop: send … kB/s | recv … kB/s | loss …% (bytes)
+0-hop: send … KiB/s | recv … KiB/s | loss …% (bytes)
+1-hop: send … KiB/s | recv … KiB/s | loss …% (bytes)
 ```
 
 See the module docs at the top of `tests/edgli_session_e2e.rs` for the full
@@ -196,7 +201,10 @@ vars:
 ```bash
 export EDGLI_ROTSEE_BLOKLI_URL=https://blokli.rotsee.gnosisvpn.io
 export EDGLI_ROTSEE_IDENTITY_FILE=/path/to/identity.json
-export EDGLI_ROTSEE_IDENTITY_PASSWORD=my-password
+# Read the identity password interactively so it never lands in shell history.
+read -rsp 'Rotsee identity password: ' EDGLI_ROTSEE_IDENTITY_PASSWORD
+printf '\n'
+export EDGLI_ROTSEE_IDENTITY_PASSWORD
 export EDGLI_ROTSEE_SAFE_ADDRESS=0x...
 export EDGLI_ROTSEE_MODULE_ADDRESS=0x...
 
@@ -229,12 +237,20 @@ Or manually (writes Chrome traces to `$EDGLI_TRACE_DIR`, load them at
 ```bash
 export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd/target/release/hoprd-localcluster
 export HOPRD_BIN=/path/to/hoprd/target/release/hoprd
-export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:latest'
+# For reproducible profiling numbers, pin the chain image to an immutable digest
+# (`bloklid-anvil@sha256:<digest>`) rather than `:latest` — a remote `:latest`
+# update can shift throughput without any code change. Resolve the digest of a
+# tag known to match your hoprd binaries with e.g.
+# `docker buildx imagetools inspect <image>:latest`, then substitute it below.
+export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil@sha256:<pinned-digest>'
 export HOPRD_CONTAINER_RUNTIME=container
 export EDGLI_TRACE_DIR=./profiling-results
 export RUST_LOG=info,edgli=debug,tokio=trace,runtime=trace
 
-RUSTFLAGS="--cfg tokio_unstable" cargo nextest run \
+# Do NOT export RUSTFLAGS: `.cargo/config.toml` already supplies
+# `--cfg tokio_unstable`, and RUSTFLAGS would *replace* (not append) the target
+# rustflags, silently dropping the aarch64 AES intrinsics (`+aes,+neon`).
+cargo nextest run \
   --test edgli_profiling --profile tracer --features prof \
   --run-ignored ignored-only --no-capture --test-threads 1
 ```
@@ -285,7 +301,8 @@ Key inputs handed to `Edgli::new`:
   Pass `--probe-local-addresses` (or `HOPR_EDGE_PROBE_LOCAL_ADDRESSES=true`, or
   the `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
   same-host test cluster).
-- **Profiling.** Build with
-  `RUSTFLAGS="--cfg tokio_unstable" cargo build --features prof` and attach
-  `tokio-console`.
+- **Profiling.** Build with `cargo build --features prof` and attach
+  `tokio-console`. (`.cargo/config.toml` already supplies `--cfg tokio_unstable`;
+  do **not** export `RUSTFLAGS`, as it replaces the target rustflags and would
+  drop the aarch64 AES intrinsics.)
 - **Reporting issues.** <https://github.com/hoprnet/edge-client/issues>

--- a/README.md
+++ b/README.md
@@ -117,6 +117,52 @@ Coverage (lcov at `coverage.lcov`):
 nix run .#coverage-unit
 ```
 
+### End-to-end session tests (`#[ignore]`, not run in CI)
+
+`tests/edgli_session_e2e.rs` spins up a real 3-node HOPR cluster via
+`hoprd-localcluster`, boots Edgli against it, and pumps a payload through 0-hop
+and 1-hop sessions (measuring throughput and packet loss, verifying SHA-256
+integrity). It is gated behind `#[ignore]` — it needs external binaries and a
+container runtime, so it is **not** part of `cargo nextest run` /
+`nix flake check`.
+
+Prerequisites:
+
+- `hoprd` and `hoprd-localcluster` binaries, built from the
+  [`hoprnet/hoprd`](https://github.com/hoprnet/hoprd) repo:
+  ```bash
+  cargo build --release -p hoprd -p hoprd-localcluster
+  ```
+- A container runtime for the chain image. On macOS use Apple's native
+  `container` (`container system start`); elsewhere Docker/Podman.
+- The `bloklid-anvil` chain image pulled (see below).
+
+Run (managed mode — the test starts and tears down its own cluster):
+
+```bash
+export HOPRD_LOCALCLUSTER_BIN=/path/to/hoprd/target/release/hoprd-localcluster
+export HOPRD_BIN=/path/to/hoprd/target/release/hoprd
+# Use the `latest` tag — the tag pinned in hoprd's docker-compose can lag the contract
+# schema the hoprd binaries expect (fails with `missing field 'xhopr_token'`).
+export HOPRD_CHAIN_IMAGE='europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid-anvil:latest'
+export HOPRD_CONTAINER_RUNTIME=container   # macOS Apple runtime; default is docker
+
+# `--release` is required: HOPR's async future chains overflow the default debug stack.
+RUST_LOG=info,edgli=debug \
+  cargo test --test edgli_session_e2e --release -- --ignored --nocapture
+```
+
+The run reports, per hop count:
+
+```text
+0-hop: send … kB/s | recv … kB/s | loss …% (bytes)
+1-hop: send … kB/s | recv … kB/s | loss …% (bytes)
+```
+
+See the module docs at the top of `tests/edgli_session_e2e.rs` for the full
+env-var table and the "external mode" (attach to an already-running cluster)
+variant.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Key inputs handed to `Edgli::new`:
   the `probe_local_addresses` argument to `Edgli::new`) to probe them (e.g. a
   same-host test cluster).
 - **Profiling.** Build with `cargo build --features prof` and attach
-  `tokio-console`. (`.cargo/config.toml` already supplies `--cfg tokio_unstable`;
-  do **not** export `RUSTFLAGS`, as it replaces the target rustflags and would
-  drop the aarch64 AES intrinsics.)
+  `tokio-console`. (`.cargo/config.toml` already supplies
+  `--cfg tokio_unstable`; do **not** export `RUSTFLAGS`, as it replaces the
+  target rustflags and would drop the aarch64 AES intrinsics.)
 - **Reporting issues.** <https://github.com/hoprnet/edge-client/issues>

--- a/scripts/profile-executor-yield.sh
+++ b/scripts/profile-executor-yield.sh
@@ -62,7 +62,9 @@ export HOPRD_CHAIN_IMAGE="${HOPRD_CHAIN_IMAGE:-europe-west3-docker.pkg.dev/hopra
 export HOPRD_CONTAINER_RUNTIME="${HOPRD_CONTAINER_RUNTIME:-container}"
 export EDGLI_TRACE_DIR="${EDGLI_TRACE_DIR:-$REPO_ROOT/profiling-results}"
 export RUST_LOG="${RUST_LOG:-info,edgli=debug,tokio=trace,runtime=trace}"
-export RUSTFLAGS="--cfg tokio_unstable"
+# Do NOT export RUSTFLAGS here: `.cargo/config.toml` already supplies
+# `--cfg tokio_unstable`, and RUSTFLAGS *replaces* (not appends) the target
+# rustflags, which would silently drop the aarch64 AES intrinsics (+aes,+neon).
 
 CLUSTER_START_TIMEOUT=600 # seconds to wait for cluster to reach "running"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub use endpoint::*;
 #[cfg(feature = "blokli")]
 pub use hopr_chain_connector::{BlockchainConnectorConfig, DEFAULT_REQUEST_TIMEOUT};
 pub use hopr_lib::exports::transport::path::PathPlannerConfig;
+// Re-exported so consumers can set per-session flow control (the `flow_control`
+// field of `HoprSessionClientConfig`) without reaching into `hopr_lib` internals.
+pub use hopr_lib::exports::transport::FlowControlConfig;
 // Re-exported so consumers constructing a `BlokliEndpoint` do not need their own
 // `url` dependency, which would have to match this crate's version to unify.
 #[cfg(feature = "blokli")]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1263,7 +1263,7 @@ pub async fn pump_and_verify(
 
     let writer_offset = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let writer_offset_clone = writer_offset.clone();
-    let writer = tokio::spawn(async move {
+    let mut writer = tokio::spawn(async move {
         let write_start = tokio::time::Instant::now();
         let mut offset = 0usize;
         while offset < payload_bytes.len() {
@@ -1379,11 +1379,22 @@ pub async fn pump_and_verify(
     let writer_budget = deadline
         .saturating_duration_since(tokio::time::Instant::now())
         .max(Duration::from_secs(5));
-    let write_elapsed = match tokio::time::timeout(writer_budget, writer).await {
+    let write_elapsed = match tokio::time::timeout(writer_budget, &mut writer).await {
         Ok(Ok(Ok(dur))) => dur,
         Ok(Ok(Err(e))) => return Err(anyhow::anyhow!("{label}: write error: {e}")),
         Ok(Err(e)) => return Err(anyhow::anyhow!("{label}: writer panicked: {e}")),
-        Err(_) => return Err(anyhow::anyhow!("{label}: writer timeout")),
+        Err(_) => {
+            // Dropping a `JoinHandle` detaches the task rather than cancelling it. Abort the
+            // writer explicitly (matching the read-error path above) so it stops competing for
+            // the executor and return path during the next measurement, and report progress so
+            // the stall is diagnosable.
+            let sent = writer_offset.load(std::sync::atomic::Ordering::Relaxed);
+            writer.abort();
+            let _ = writer.await;
+            return Err(anyhow::anyhow!(
+                "{label}: writer timeout (sent {sent}/{n} B, received {bytes_received}/{n} B)"
+            ));
+        }
     };
 
     // Metrics
@@ -1901,12 +1912,26 @@ pub fn init_tracing() -> (
     };
 
     // `try_init` (not `init`) so this coexists with a subscriber already installed by the
-    // `#[test_log::test]` attribute: if one is set, we keep it rather than panicking.
-    let _ = tracing_subscriber::registry()
+    // `#[test_log::test]` attribute: if one is set, we keep it rather than panicking. But when a
+    // subscriber is already installed our Chrome/flame layers are silently dropped — the profiling
+    // files would be created yet never written. Surface that and return no guards, so the caller
+    // cannot mistake a dead layer for a live one (an empty FLAME_OUTPUT read as real profiling data).
+    let profiling_layers = chrome_guard.is_some() || flame_guard.is_some();
+    if tracing_subscriber::registry()
         .with(fmt_layer)
         .with(chrome_layer)
         .with(flame_layer)
-        .try_init();
+        .try_init()
+        .is_err()
+    {
+        if profiling_layers {
+            eprintln!(
+                "init_tracing: a subscriber is already installed; Chrome/flame profiling layers \
+                 were NOT activated — ignoring CHROME_TRACE/FLAME_OUTPUT for this run"
+            );
+        }
+        return (None, None);
+    }
 
     (chrome_guard, flame_guard)
 }
@@ -2054,11 +2079,16 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     if matches!(net, Network::Local) {
         // Multi-hop needs the WHOLE cluster in the graph — not just the exit — so path-finding and
         // its SURB return paths route over observed relays. Poll until every cluster node appears.
-        tracing::info!("waiting for the full network graph to populate (all cluster nodes observed)");
+        tracing::info!(
+            "waiting for the full network graph to populate (all cluster nodes observed)"
+        );
         await_graph_populated(&edgli, cluster_size(), GRAPH_POPULATE_TIMEOUT).await?;
     }
     let settle = probe_settle_duration();
-    tracing::info!(?settle, "letting the graph settle and probing rounds mature before routing");
+    tracing::info!(
+        ?settle,
+        "letting the graph settle and probing rounds mature before routing"
+    );
     tokio::time::sleep(settle).await;
 
     // ── 9. Prepare the random payload ─────────────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::{
 };
 
 use edgli::{
-    BlokliEndpoint, Edgli, EdgliInitState, PathPlannerConfig,
+    BlokliEndpoint, Edgli, EdgliInitState, FlowControlConfig, PathPlannerConfig,
     hopr_lib::{
         HopRouting, HoprKeys, HoprSessionClientConfig, IdentityRetrievalModes,
         api::{
@@ -26,7 +26,7 @@ use edgli::{
         },
         config::{HoprLibConfig, HostConfig, HostType, SafeModule},
         exports::transport::SessionCapability,
-        exports::transport::{FlowControlConfig, HoprSession, SessionTarget, SurbBalancerConfig},
+        exports::transport::{HoprSession, SessionTarget, SurbBalancerConfig},
     },
     latency_path_planner_config,
     strategy::{EdgeStrategyKind, IncentiveConfiguration, SelectorProfile, default_strategy_cfg},

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2061,7 +2061,7 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     if matches!(net, Network::Local) {
         let peers = edgli.connected_peer_addresses().await?;
         anyhow::ensure!(
-            peers.len() >= max_hops + 1,
+            peers.len() > max_hops,
             "need ≥{} connected peers for {}-hop path-finding, have {} (raise CLUSTER_SIZE)",
             max_hops + 1,
             max_hops,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1038,6 +1038,18 @@ pub fn loopback_target() -> SessionTarget {
     SessionTarget::ExitNode(0)
 }
 
+/// Segmentation-only loopback session config with symmetric `hops`-hop forward/return
+/// paths and SURBs maxed out (so the pump isn't SURB-starved).
+fn loopback_session_config(hops: usize) -> anyhow::Result<HoprSessionClientConfig> {
+    Ok(HoprSessionClientConfig {
+        forward_path: HopRouting::try_from(hops)?,
+        return_path: HopRouting::try_from(hops)?,
+        capabilities: SessionCapability::Segmentation.into(),
+        always_max_out_surbs: true,
+        ..Default::default()
+    })
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Edgli config builder
 // ────────────────────────────────────────────────────────────────────────────
@@ -1081,6 +1093,11 @@ pub fn sha256_digest(data: &[u8]) -> Vec<u8> {
     h.finalize().to_vec()
 }
 
+/// Throughput of `bytes` transferred over `elapsed`, expressed in kB/s (1 kB = 1024 B).
+fn throughput_kbs(bytes: usize, elapsed: Duration) -> f64 {
+    bytes as f64 / elapsed.as_secs_f64() / 1024.0
+}
+
 /// Sends `payload` as fast as backpressure allows over `session`, reads the echo back,
 /// then reports and asserts send/receive throughput and packet-loss metrics.
 ///
@@ -1094,7 +1111,6 @@ pub async fn pump_and_verify(
 ) -> anyhow::Result<()> {
     let (mut r, mut w) = tokio::io::split(session);
     let payload_bytes = payload.to_vec();
-    let expected = sha256_digest(payload);
     let n = payload.len();
     let overall_start = std::time::Instant::now();
 
@@ -1172,7 +1188,7 @@ pub async fn pump_and_verify(
                 if cursor >= next_progress || cursor >= n {
                     let pct = cursor * 100 / n;
                     let elapsed = overall_start.elapsed();
-                    let kbs = cursor as f64 / elapsed.as_secs_f64() / 1024.0;
+                    let kbs = throughput_kbs(cursor, elapsed);
                     let wo = writer_offset.load(std::sync::atomic::Ordering::Relaxed);
                     tracing::info!(
                         "{label}: recv progress {cursor}/{n} B ({pct}%) in {elapsed:.2?} ({kbs:.1} kB/s) [writer_sent={wo}]"
@@ -1221,8 +1237,8 @@ pub async fn pump_and_verify(
     };
 
     // Metrics
-    let send_kbs = n as f64 / write_elapsed.as_secs_f64() / 1024.0;
-    let recv_kbs = bytes_received as f64 / recv_elapsed.as_secs_f64() / 1024.0;
+    let send_kbs = throughput_kbs(n, write_elapsed);
+    let recv_kbs = throughput_kbs(bytes_received, recv_elapsed);
     let loss_pct = (n - bytes_received) as f64 / n as f64 * 100.0;
     tracing::info!(
         "{label}: send {send_kbs:.1} kB/s ({:.2?}) | recv {recv_kbs:.1} kB/s ({:.2?}) | loss {loss_pct:.2}% ({bytes_received}/{n} B)",
@@ -1235,8 +1251,10 @@ pub async fn pump_and_verify(
     // would let a corrupted-but-lossy run (within PUMP_MAX_LOSS_PCT) pass the loss assertion
     // below without any integrity check.
     if bytes_received == n {
+        // Only hash the payload here — on a lossy run we take the prefix-compare branch
+        // below and never need the full-payload digest.
         anyhow::ensure!(
-            sha256_digest(&received) == expected,
+            sha256_digest(&received) == sha256_digest(payload),
             "{label}: SHA-256 mismatch — {n} bytes corrupted in transit"
         );
         tracing::info!("{label}: SHA-256 OK");
@@ -1880,17 +1898,7 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     // ── 10. 0-hop session — direct path, no relay ────────────────────────────
     tracing::info!("opening 0-hop session (loopback)");
     let (session_0h, _) = edgli
-        .connect_to(
-            dest_0h,
-            loopback_target(),
-            HoprSessionClientConfig {
-                forward_path: HopRouting::try_from(0_usize)?,
-                return_path: HopRouting::try_from(0_usize)?,
-                capabilities: SessionCapability::Segmentation.into(),
-                always_max_out_surbs: true,
-                ..Default::default()
-            },
-        )
+        .connect_to(dest_0h, loopback_target(), loopback_session_config(0)?)
         .await?;
     // Allow SURBs to accumulate before pumping data.
     // Default balancer target=7000; EXIT's pool reaches ~7000 SURBs after 5 s.
@@ -1900,17 +1908,7 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     // ── 11. 1-hop session — full relay path ──────────────────────────────────
     tracing::info!("opening 1-hop session (loopback)");
     let (session_1h, _) = edgli
-        .connect_to(
-            dest_1h,
-            loopback_target(),
-            HoprSessionClientConfig {
-                forward_path: HopRouting::try_from(1_usize)?,
-                return_path: HopRouting::try_from(1_usize)?,
-                capabilities: SessionCapability::Segmentation.into(),
-                always_max_out_surbs: true,
-                ..Default::default()
-            },
-        )
+        .connect_to(dest_1h, loopback_target(), loopback_session_config(1)?)
         .await?;
     // Same SURB pre-fill delay as the 0-hop session above.
     tokio::time::sleep(Duration::from_secs(5)).await;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ use edgli::{
         },
         config::{HoprLibConfig, HostConfig, HostType, SafeModule},
         exports::transport::SessionCapability,
-        exports::transport::{HoprSession, SessionTarget, SurbBalancerConfig},
+        exports::transport::{FlowControlConfig, HoprSession, SessionTarget, SurbBalancerConfig},
     },
     latency_path_planner_config,
     strategy::{EdgeStrategyKind, IncentiveConfiguration, SelectorProfile, default_strategy_cfg},
@@ -69,11 +69,25 @@ pub const PUMP_MAX_LOSS_PCT: f64 = 5.0;
 /// Must exceed the session frame timeout (3 s) so a legitimately delayed tail frame still
 /// counts; kept short so the test does not block on the unflushable end-of-stream tail.
 pub const PUMP_RECV_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
-pub const CLUSTER_SIZE: usize = 3;
+/// Cluster node count (hoprd nodes, **excluding** the edge client). Sized per run by
+/// `EDGLI_E2E_CLUSTER_SIZE` so each hop count gets a minimal cluster: an N-hop forward path
+/// `E → r₁…r_N → X` spans `N+2` distinct nodes (no node may repeat, RFC-0014 §6.3), i.e. the
+/// edge client + `N` relays + the exit — so it needs `N+1` cluster nodes (`max(N+1, 2)`; ≥2 so
+/// target selection always has two distinct peers). Counting the edge client, that is 3 total for
+/// 0/1-hop, 4 for 2-hop, 5 for 3-hop. Defaults to 3 when unset (covers the default 0/1-hop run).
+pub fn cluster_size() -> usize {
+    std::env::var("EDGLI_E2E_CLUSTER_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n >= 2)
+        .unwrap_or(3)
+}
 const API_PORT_BASE: u16 = 13000;
 const P2P_PORT_BASE: u16 = 19000;
 /// Edgli's P2P port — one slot beyond the cluster nodes.
-const EDGE_P2P_PORT: u16 = P2P_PORT_BASE + CLUSTER_SIZE as u16;
+fn edge_p2p_port() -> u16 {
+    P2P_PORT_BASE + cluster_size() as u16
+}
 const API_HOST: &str = "127.0.0.1";
 const API_TOKEN: &str = "test-token-localcluster";
 
@@ -84,6 +98,9 @@ const PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 const INTRACLUSTER_CHANNEL_TIMEOUT: Duration = Duration::from_secs(120);
 const EDGLI_PEER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 const EXIT_PEER_PROBE_TIMEOUT: Duration = Duration::from_secs(120);
+/// How long to wait for the edge client's network graph to observe the whole cluster (all nodes
+/// probed, channels indexed via SSE) before routing multi-hop sessions.
+const GRAPH_POPULATE_TIMEOUT: Duration = Duration::from_secs(240);
 
 // ────────────────────────────────────────────────────────────────────────────
 // Network selector
@@ -538,7 +555,7 @@ async fn provision_local() -> anyhow::Result<ClusterHandle> {
         "--hoprd-bin",
         &hoprd_bin,
         "--size",
-        &CLUSTER_SIZE.to_string(),
+        &cluster_size().to_string(),
         "--extra-identities",
         "1",
         "--data-dir",
@@ -754,7 +771,7 @@ where
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         let results = futures::future::join_all(
-            (0..CLUSTER_SIZE).map(|i| check_node(i, API_PORT_BASE + i as u16)),
+            (0..cluster_size()).map(|i| check_node(i, API_PORT_BASE + i as u16)),
         )
         .await;
         if results.into_iter().all(|ok| ok) {
@@ -772,7 +789,7 @@ pub async fn await_nodes_ready() -> anyhow::Result<()> {
     poll_cluster_until(
         READYZ_TIMEOUT,
         Duration::from_secs(3),
-        &format!("all {} cluster nodes passed /readyz", CLUSTER_SIZE),
+        &format!("all {} cluster nodes passed /readyz", cluster_size()),
         &format!("timeout ({READYZ_TIMEOUT:?}) waiting for cluster /readyz"),
         |_i, port| {
             let client = client.clone();
@@ -792,7 +809,7 @@ pub async fn await_nodes_ready() -> anyhow::Result<()> {
 /// Poll /api/v4/network/announced on each node until every node sees CLUSTER_SIZE-1 peers.
 pub async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
     let client = node_http_client();
-    let expected = CLUSTER_SIZE - 1;
+    let expected = cluster_size() - 1;
     poll_cluster_until(
         PEER_DISCOVERY_TIMEOUT,
         Duration::from_secs(3),
@@ -826,7 +843,7 @@ pub async fn await_cluster_peers_discovered() -> anyhow::Result<()> {
 /// Poll /api/v4/channels on each node until every node has CLUSTER_SIZE-1 Open outgoing channels.
 pub async fn await_intracluster_channels_open() -> anyhow::Result<()> {
     let client = node_http_client();
-    let expected = CLUSTER_SIZE - 1;
+    let expected = cluster_size() - 1;
     poll_cluster_until(
         INTRACLUSTER_CHANNEL_TIMEOUT,
         Duration::from_secs(5),
@@ -992,6 +1009,40 @@ async fn await_edgli_exit_peer_ready(edgli: &Edgli, target: Address) -> anyhow::
     .await
 }
 
+/// Wait until the edge client's network graph is populated enough for multi-hop routing.
+///
+/// Multi-hop path construction is only as good as the graph it runs on: path-finding enumerates
+/// simple paths over the observed channel graph and validates each non-final edge against on-chain
+/// channels (RFC-0014 §6.3). A freshly-booted edge client indexes the cluster's channels via SSE
+/// and probes its neighbours over successive rounds — until every cluster node is *in* the graph,
+/// deeper paths (and their SURB return paths) can route through not-yet-observed relays and stall
+/// at the tail. This polls `all_network_peers(0.0)` until every cluster node has been observed.
+async fn await_graph_populated(
+    edgli: &Edgli,
+    min_peers: usize,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    poll_edgli_until(
+        timeout,
+        Duration::from_secs(5),
+        || format!("timeout ({timeout:?}) waiting for network graph to observe {min_peers} cluster peers"),
+        || async {
+            let peers = edgli
+                .transport()
+                .all_network_peers(0.0)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if peers.len() >= min_peers {
+                tracing::info!(observed = peers.len(), min_peers, "network graph populated");
+                return Ok(true);
+            }
+            tracing::debug!(observed = peers.len(), min_peers, "network graph still populating");
+            Ok(false)
+        },
+    )
+    .await
+}
+
 /// Select session destinations that work for both 0-hop and 1-hop.
 ///
 /// 0-hop target: the first open outgoing channel whose destination is also a
@@ -1038,16 +1089,107 @@ pub fn loopback_target() -> SessionTarget {
     SessionTarget::ExitNode(0)
 }
 
-/// Segmentation-only loopback session config with symmetric `hops`-hop forward/return
-/// paths and SURBs maxed out (so the pump isn't SURB-starved).
+/// Truthy env flag: `1` or `true` (case-insensitive), else false.
+fn env_flag(var: &str) -> bool {
+    std::env::var(var)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Hop counts to exercise this run, selected by `EDGLI_E2E_HOPS` (comma-separated, e.g. `"2"` or
+/// `"0,1,2,3"`). Defaults to `[0, 1]` (the original behaviour). Run one hop count per invocation
+/// (e.g. `EDGLI_E2E_HOPS=3`) to get a **fresh cluster per hop** — each binary run provisions and
+/// tears down its own cluster.
+pub fn hop_counts() -> Vec<usize> {
+    match std::env::var("EDGLI_E2E_HOPS") {
+        Ok(v) if !v.trim().is_empty() => v
+            .split(',')
+            .filter_map(|s| s.trim().parse::<usize>().ok())
+            .collect(),
+        _ => vec![0, 1],
+    }
+}
+
+/// Seconds to let the cluster settle after readiness so nodes complete several probing rounds
+/// before path-finding runs (`EDGLI_E2E_PROBE_SETTLE_SECS`, default 20 s). At hoprd's local probe
+/// cadence this comfortably covers ≥3 rounds, warming edge scores for reliable multi-hop paths
+/// (RFC-0010 §6.2, RFC-0014 §6.3).
+fn probe_settle_duration() -> Duration {
+    let secs = std::env::var("EDGLI_E2E_PROBE_SETTLE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(60);
+    Duration::from_secs(secs)
+}
+
+/// The flow-control config the harness applies to the loopback session, **selected by env for test
+/// parameterization** across the matrix below. This is *not* a production mechanism — production sets
+/// [`HoprSessionClientConfig::flow_control`] directly; the test just picks which config to build.
+///
+/// * `HOPR_SESSION_FLOW_CONTROL` unset → `None`: flow control off (the original hand-paced harness).
+/// * set → `Some(FlowControlConfig::default())`: the clean profile (production path / ship gate).
+/// * set + `HOPR_SESSION_FLOW_CONTROL_ROBUST` → `Some(FlowControlConfig::robust())`: the opt-in
+///   tail-tolerance bundle (persist probe + larger retransmission budget).
+pub fn flow_control_config() -> Option<FlowControlConfig> {
+    if !env_flag("HOPR_SESSION_FLOW_CONTROL") {
+        return None;
+    }
+    Some(if env_flag("HOPR_SESSION_FLOW_CONTROL_ROBUST") {
+        FlowControlConfig::robust()
+    } else {
+        FlowControlConfig::default()
+    })
+}
+
+/// Whether flow control is enabled for this run (the session then runs **reliable** so the honest
+/// ack clock exists, and the pump sends **unpaced** — the window replaces manual pacing).
+pub fn flow_control_enabled() -> bool {
+    flow_control_config().is_some()
+}
+
+/// Human-readable label of the active flow-control profile, for self-documenting run logs:
+/// `paced` (off) / `fc:clean` (default profile) / `fc:robust` (tail-tolerance bundle).
+pub fn flow_control_profile() -> &'static str {
+    match flow_control_config() {
+        None => "paced",
+        Some(cfg) if cfg == FlowControlConfig::robust() => "fc:robust",
+        Some(_) => "fc:clean",
+    }
+}
+
+/// Loopback session config with symmetric `hops`-hop forward/return paths and SURBs maxed out (so
+/// the pump isn't SURB-starved). Reliable (`RetransmissionAck`) when flow control is enabled so the
+/// window has an honest delivery clock; Segmentation-only otherwise.
+///
+/// `HOPR_SESSION_MAX_SURBS_PER_SEC`, when set, overrides the SURB balancer's `max_surbs_per_sec`
+/// (raising the return-path drain ceiling) so the flow-control window's scaling can be swept without
+/// code changes between points.
 fn loopback_session_config(hops: usize) -> anyhow::Result<HoprSessionClientConfig> {
-    Ok(HoprSessionClientConfig {
+    let capabilities = if flow_control_enabled() {
+        SessionCapability::Segmentation | SessionCapability::RetransmissionAck
+    } else {
+        SessionCapability::Segmentation.into()
+    };
+    let mut cfg = HoprSessionClientConfig {
         forward_path: HopRouting::try_from(hops)?,
         return_path: HopRouting::try_from(hops)?,
-        capabilities: SessionCapability::Segmentation.into(),
+        capabilities,
         always_max_out_surbs: true,
+        // Client's dial: apply the selected flow-control profile as a real config field (no env is
+        // read node-side). `None` = paced; `Some(clean)` / `Some(robust)` per the profile.
+        flow_control: flow_control_config(),
         ..Default::default()
-    })
+    };
+    if let Some(max_surbs_per_sec) = std::env::var("HOPR_SESSION_MAX_SURBS_PER_SEC")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        cfg.surb_management = Some(SurbBalancerConfig {
+            max_surbs_per_sec,
+            ..cfg.surb_management.unwrap_or_default()
+        });
+    }
+    Ok(cfg)
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1059,7 +1201,7 @@ pub fn build_edgli_config(extra: &ExtraInfo, tuning: &EdgliTuning) -> HoprLibCon
     HoprLibConfig {
         host: HostConfig {
             address: HostType::IPv4("0.0.0.0".to_string()),
-            port: EDGE_P2P_PORT,
+            port: edge_p2p_port(),
         },
         publish: true,
         protocol: HoprProtocolConfig {
@@ -1113,6 +1255,11 @@ pub async fn pump_and_verify(
     let payload_bytes = payload.to_vec();
     let n = payload.len();
     let overall_start = std::time::Instant::now();
+    tracing::info!(
+        "{label}: starting pump [profile={}, {} B]",
+        flow_control_profile(),
+        n
+    );
 
     let writer_offset = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let writer_offset_clone = writer_offset.clone();
@@ -1129,7 +1276,10 @@ pub async fn pump_and_verify(
             // have no end-to-end flow control, and a full-speed burst overruns the return path
             // (Exit ack-amplification + mixer saturation) — see the investigation writeup. We
             // still send the entire payload, just metered to ~PUMP_SEND_RATE_PPS packets/sec.
-            if offset < payload_bytes.len() {
+            //
+            // When client-side flow control is enabled the adaptive send window replaces this
+            // manual pacing, so we send unpaced and let the window self-size against the drain rate.
+            if offset < payload_bytes.len() && !flow_control_enabled() {
                 tokio::time::sleep(Duration::from_millis(PUMP_BATCH_DELAY_MS)).await;
             }
         }
@@ -1494,7 +1644,7 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     // ── 3. Strategy ──────────────────────────────────────────────────────────
     let sizing = IncentiveConfiguration {
         min_open_channels: 1,
-        target_open_channels: CLUSTER_SIZE,
+        target_open_channels: cluster_size(),
         ..Default::default()
     };
     let mut strat_cfg = default_strategy_cfg(&edgli, &sizing).await?;
@@ -1842,7 +1992,7 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     }
     let sizing = IncentiveConfiguration {
         min_open_channels: 1,
-        target_open_channels: CLUSTER_SIZE + genesis_channel_count,
+        target_open_channels: cluster_size() + genesis_channel_count,
         ..Default::default()
     };
     let mut strat_cfg = default_strategy_cfg(&edgli, &sizing).await?;
@@ -1869,50 +2019,66 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     tracing::info!("waiting for strategy to open ≥1 outgoing channel");
     await_edgli_channels_open(&edgli, 1, tuning.channel_open_timeout).await?;
 
-    // ── 7. Select session targets ─────────────────────────────────────────────
-    let (dest_0h, dest_1h) = if let Some(exit) = tuning.exit_node {
-        tracing::info!(%exit, "using configured exit node for both 0-hop and 1-hop sessions");
-        (exit, exit)
+    // ── 7. Select the loopback exit and validate topology depth ───────────────
+    // The exit is the session destination (final forward hop / first return hop); path-finding
+    // fills the intermediate relays from the channel graph. Any peer works as the exit.
+    let hops = hop_counts();
+    let max_hops = hops.iter().copied().max().unwrap_or(0);
+    let exit = if let Some(exit) = tuning.exit_node {
+        tracing::info!(%exit, "using configured exit node for the loopback session(s)");
+        exit
     } else {
-        select_session_targets(&edgli).await?
+        select_session_targets(&edgli).await?.0
     };
 
-    // ── 8. Wait for dest_1h to appear in the probe graph ─────────────────────
-    // 1-hop path-finding needs at least one probe observation for dest_1h in
-    // the network graph (§6.3). Without any probe data the edge does not exist
-    // as a graph entry and path construction fails with a session timeout even
-    // though channels are open.  `await_edgli_exit_peer_ready` polls
-    // `all_network_peers(0.0)` (any observed quality) until the peer appears.
-    // This applies to both pinned exit nodes (Rotsee) and dynamic targets (local).
-    tracing::info!(%dest_1h, "waiting for 1-hop destination to be probed");
-    await_edgli_exit_peer_ready(&edgli, dest_1h).await?;
+    // An N-hop forward path is `N+1` edges over `N` distinct relays plus the exit, with no repeated
+    // node (RFC-0014 §6.3) — so we need at least `max_hops + 1` distinct peers besides ourselves.
+    if matches!(net, Network::Local) {
+        let peers = edgli.connected_peer_addresses().await?;
+        anyhow::ensure!(
+            peers.len() >= max_hops + 1,
+            "need ≥{} connected peers for {}-hop path-finding, have {} (raise CLUSTER_SIZE)",
+            max_hops + 1,
+            max_hops,
+            peers.len()
+        );
+    }
 
-    // ── 9. Prepare 1 MiB random payload ─────────────────────────────────────
-    // Random bytes produce unique HOPR packet ciphertexts on every test run,
-    // preventing false replay-detection hits in cluster nodes' in-memory
-    // packet-tag caches (which persist across Edgli reconnections to the same
-    // hoprd instance).
+    // ── 8. Warm the network: exit probed + several probing rounds ─────────────
+    // Path-finding scores edges from probe results (RFC-0010 §6.2). Without any probe observation
+    // the destination edge is not yet a graph entry and path construction times out; and for
+    // multi-hop we want the intermediate edges scored too. Wait for the exit to be probed, then let
+    // the cluster complete a few more rounds so multi-hop paths are stable (RFC-0014 §6.3).
+    tracing::info!(%exit, "waiting for loopback exit to be probed");
+    await_edgli_exit_peer_ready(&edgli, exit).await?;
+    if matches!(net, Network::Local) {
+        // Multi-hop needs the WHOLE cluster in the graph — not just the exit — so path-finding and
+        // its SURB return paths route over observed relays. Poll until every cluster node appears.
+        tracing::info!("waiting for the full network graph to populate (all cluster nodes observed)");
+        await_graph_populated(&edgli, cluster_size(), GRAPH_POPULATE_TIMEOUT).await?;
+    }
+    let settle = probe_settle_duration();
+    tracing::info!(?settle, "letting the graph settle and probing rounds mature before routing");
+    tokio::time::sleep(settle).await;
+
+    // ── 9. Prepare the random payload ─────────────────────────────────────────
+    // Random bytes produce unique HOPR packet ciphertexts on every test run, preventing false
+    // replay-detection hits in cluster nodes' in-memory packet-tag caches.
     let mut payload = vec![0u8; PAYLOAD_SIZE];
     rand::rng().fill(&mut payload[..]);
 
-    // ── 10. 0-hop session — direct path, no relay ────────────────────────────
-    tracing::info!("opening 0-hop session (loopback)");
-    let (session_0h, _) = edgli
-        .connect_to(dest_0h, loopback_target(), loopback_session_config(0)?)
-        .await?;
-    // Allow SURBs to accumulate before pumping data.
-    // Default balancer target=7000; EXIT's pool reaches ~7000 SURBs after 5 s.
-    tokio::time::sleep(Duration::from_secs(5)).await;
-    pump_and_verify(session_0h, &payload, "0-hop", tuning.pump_timeout).await?;
-
-    // ── 11. 1-hop session — full relay path ──────────────────────────────────
-    tracing::info!("opening 1-hop session (loopback)");
-    let (session_1h, _) = edgli
-        .connect_to(dest_1h, loopback_target(), loopback_session_config(1)?)
-        .await?;
-    // Same SURB pre-fill delay as the 0-hop session above.
-    tokio::time::sleep(Duration::from_secs(5)).await;
-    pump_and_verify(session_1h, &payload, "1-hop", tuning.pump_timeout).await?;
+    // ── 10. Run each requested hop count over the (warm) cluster ──────────────
+    for &h in &hops {
+        tracing::info!(hops = h, "opening {h}-hop loopback session");
+        let (session, _) = edgli
+            .connect_to(exit, loopback_target(), loopback_session_config(h)?)
+            .await?;
+        // Let SURBs accumulate before pumping. The default balancer targets ~7000 SURBs; longer
+        // return paths replenish the pool more slowly, so scale the pre-fill with the hop count.
+        let prefill = Duration::from_secs(5 * (h as u64 + 1));
+        tokio::time::sleep(prefill).await;
+        pump_and_verify(session, &payload, &format!("{h}-hop"), tuning.pump_timeout).await?;
+    }
 
     // ── 12. Final state assertion ─────────────────────────────────────────────
     let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,12 +2,15 @@
 //!
 //! Used by both `edgli_session_e2e` (local cluster) and `edgli_session_rotsee`
 //! (Rotsee testnet).  Each test file declares `mod common;` and calls
-//! [`run_one_megabyte_session_test`] with its [`Network`] variant.
+//! [`run_session_throughput_test`] with its [`Network`] variant.
 
 #![allow(dead_code)]
 
 use anyhow::Context as _;
 use std::{path::PathBuf, time::Duration};
+use tracing_subscriber::{
+    EnvFilter, Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _,
+};
 
 use edgli::{
     BlokliEndpoint, Edgli, EdgliInitState, PathPlannerConfig,
@@ -38,15 +41,34 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 // Constants
 // ────────────────────────────────────────────────────────────────────────────
 
-pub const PAYLOAD_SIZE: usize = 1_024 * 1_024; // 1 MiB
+pub const PAYLOAD_SIZE: usize = 20 * 1_024 * 1_024; // 20 MiB
 /// Bytes that fit in a single HOPR packet payload. Re-exported rather than
 /// hardcoded so it cannot drift from the pinned transport.
 pub use edgli::hopr_lib::SESSION_MTU;
-/// Packets per write-batch in `pump_and_verify`.  Keeps the Rayon encoding
-/// queue well below the `PACKET_ENCODING_TIMEOUT = 150 ms` threshold even
-/// when the host machine is under load running a 3-node cluster.
+/// Packets per write-batch in `pump_and_verify`.  16 packets at SESSION_MTU
+/// bytes each ≈ 16 kB per flush, giving natural backpressure granularity.
 pub const PUMP_BATCH_PACKETS: usize = 16;
 pub const PUMP_BATCH_BYTES: usize = PUMP_BATCH_PACKETS * SESSION_MTU;
+/// Paced send rate (HOPR packets/sec). We send the *entire* payload but pace it so the
+/// writer does not burst it all into the 16384-segment session socket buffer at once (which
+/// masks transport backpressure and triggers the return-path feedback stall). 1000 pkt/sec
+/// (~1.0 MB/s) stays comfortably under EXIT's echo ceiling (target 7000 / 5 s = 1400 pkt/sec),
+/// so SURB supply keeps pace and the pool never depletes.
+pub const PUMP_SEND_RATE_PPS: u64 = 1000;
+/// Inter-batch delay derived from the send-rate cap: `PUMP_BATCH_PACKETS` packets per tick.
+/// Rounded **up** (`div_ceil`) so the effective send rate never exceeds `PUMP_SEND_RATE_PPS`
+/// after retuning — truncating division would silently push the rate above the cap.
+pub const PUMP_BATCH_DELAY_MS: u64 =
+    (PUMP_BATCH_PACKETS as u64 * 1000).div_ceil(PUMP_SEND_RATE_PPS);
+/// Minimum acceptable receive throughput. At 1000 pkt/sec paced send the echo returns at the
+/// same rate; this floor sits well below that so it only catches a genuine stall.
+pub const PUMP_MIN_RECV_RATE_KBS: f64 = 100.0;
+/// Maximum acceptable packet loss percentage.
+pub const PUMP_MAX_LOSS_PCT: f64 = 5.0;
+/// How long the reader waits with no new bytes before concluding delivery has drained.
+/// Must exceed the session frame timeout (3 s) so a legitimately delayed tail frame still
+/// counts; kept short so the test does not block on the unflushable end-of-stream tail.
+pub const PUMP_RECV_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 pub const CLUSTER_SIZE: usize = 3;
 const API_PORT_BASE: u16 = 13000;
 const P2P_PORT_BASE: u16 = 19000;
@@ -143,7 +165,9 @@ impl EdgliTuning {
             selector: SelectorProfile::LowLatency,
             channel_open_timeout: Duration::from_secs(120),
             exit_node: None,
-            pump_timeout: Duration::from_secs(120),
+            // 300 s outer budget accommodates the 20 MiB paced payload (~24 s pump plus
+            // cluster/channel latency and the end-of-stream tail).
+            pump_timeout: Duration::from_secs(300),
             // Use 0.0: Edgli just started and no probes have completed yet when the
             // 1-hop session is attempted.  With min_ack_rate=0.1 the path planner
             // finds no eligible relays (ack_rate=0 for all) and session initiation
@@ -478,8 +502,36 @@ async fn provision_local() -> anyhow::Result<ClusterHandle> {
         .map_err(|_| anyhow::anyhow!("HOPRD_CHAIN_IMAGE is not set"))?;
     let container_runtime = std::env::var("HOPRD_CONTAINER_RUNTIME").ok();
 
-    let tempdir = tempfile::TempDir::with_prefix("edgli-it-")?;
-    let data_dir = tempdir.path().to_path_buf();
+    // When EDGLI_DATA_DIR is set, use a persistent data dir (not auto-removed) so the hoprd
+    // node logs under <data_dir>/logs/hoprd_{id}.log survive the test for post-mortem analysis.
+    // Otherwise use a tempdir that is cleaned up on drop.
+    let (data_dir, tempdir) = match std::env::var("EDGLI_DATA_DIR") {
+        Ok(dir) if !dir.trim().is_empty() => {
+            let path = PathBuf::from(dir.trim());
+            std::fs::create_dir_all(&path).context("failed to create EDGLI_DATA_DIR")?;
+            // A non-empty dir carries stale cluster state (node DBs, keys, channels) from a
+            // previous run, which perturbs the very throughput/loss measurement this harness
+            // makes. Warn loudly so the operator clears it before a measurement run.
+            let non_empty = std::fs::read_dir(&path)
+                .map(|mut d| d.next().is_some())
+                .unwrap_or(false);
+            if non_empty {
+                tracing::warn!(
+                    data_dir = %path.display(),
+                    "EDGLI_DATA_DIR is not empty — stale cluster state from a previous run may perturb \
+                     measurements; clear it for a clean measurement run"
+                );
+            }
+            tracing::warn!(data_dir = %path.display(), "using persistent EDGLI_DATA_DIR — not cleaned up");
+            (path, None)
+        }
+        _ => {
+            let td = tempfile::TempDir::with_prefix("edgli-it-")?;
+            let path = td.path().to_path_buf();
+            (path, Some(td))
+        }
+    };
+    tracing::info!(data_dir = %data_dir.display(), "cluster data dir (hoprd node logs under <data_dir>/logs/)");
 
     let mut cmd = tokio::process::Command::new(&lc_bin);
     cmd.args([
@@ -556,7 +608,7 @@ async fn provision_local() -> anyhow::Result<ClusterHandle> {
     Ok(ClusterHandle {
         child: Some(child),
         summary,
-        _tempdir: Some(tempdir),
+        _tempdir: tempdir,
     })
 }
 
@@ -872,14 +924,16 @@ pub async fn await_edgli_channels_open(
         Duration::from_secs(5),
         || {
             format!(
-                "timeout ({timeout:?}) waiting for Edgli strategy to open {min_open} channel(s)"
+                "timeout ({timeout:?}) waiting for Edgli strategy to open {min_open} channel(s) to connected peers"
             )
         },
         || async {
+            let peers = edgli.connected_peer_addresses().await?;
+            let peer_set: std::collections::HashSet<Address> = peers.into_iter().collect();
             let channels: Vec<ChannelEntry> = edgli.my_outgoing_channels().await?;
             let open = channels
                 .iter()
-                .filter(|ch| ch.status == ChannelStatus::Open)
+                .filter(|ch| ch.status == ChannelStatus::Open && peer_set.contains(&ch.destination))
                 .count();
             if open >= min_open {
                 tracing::info!(
@@ -889,7 +943,7 @@ pub async fn await_edgli_channels_open(
                 return Ok(true);
             }
             tracing::debug!(
-                "Edgli: {open}/{min_open} outgoing channels Open (waiting for strategy)"
+                "Edgli: {open}/{min_open} outgoing channels to peers Open (waiting for strategy)"
             );
             Ok(false)
         },
@@ -940,8 +994,10 @@ async fn await_edgli_exit_peer_ready(edgli: &Edgli, target: Address) -> anyhow::
 
 /// Select session destinations that work for both 0-hop and 1-hop.
 ///
-/// 0-hop target: the first open outgoing channel counterparty (Edgli has a
-/// direct channel to it, so a 0-hop session is routable).
+/// 0-hop target: the first open outgoing channel whose destination is also a
+/// connected peer (Edgli has a direct channel to it, so a 0-hop session is
+/// routable).  Pre-existing genesis channels to non-running accounts are
+/// excluded by intersecting with the connected-peer set.
 ///
 /// 1-hop target: any connected peer that is different from the 0-hop target
 /// (the 0-hop target acts as the relay, with its intranetwork channels
@@ -951,11 +1007,15 @@ async fn select_session_targets(edgli: &Edgli) -> anyhow::Result<(Address, Addre
         edgli.my_outgoing_channels(),
         edgli.connected_peer_addresses()
     )?;
+    let peer_set: std::collections::HashSet<Address> = peers.iter().copied().collect();
     let channels: Vec<ChannelEntry> = raw_channels
         .into_iter()
-        .filter(|c| c.status == ChannelStatus::Open)
+        .filter(|c| c.status == ChannelStatus::Open && peer_set.contains(&c.destination))
         .collect();
-    anyhow::ensure!(!channels.is_empty(), "no open outgoing channels");
+    anyhow::ensure!(
+        !channels.is_empty(),
+        "no open outgoing channels to connected peers"
+    );
     let zero_hop = channels[0].destination;
 
     let one_hop = peers
@@ -1021,17 +1081,8 @@ pub fn sha256_digest(data: &[u8]) -> Vec<u8> {
     h.finalize().to_vec()
 }
 
-/// Write `payload` into `session`, read exactly `payload.len()` bytes back from
-/// the echo server, and verify SHA-256 integrity.
-///
-/// Writes in `PUMP_BATCH_BYTES`-sized chunks with a 100 ms pause between each
-/// batch.  Without pacing, `write_all(1 MiB)` submits ~1030 HOPR packets to
-/// the Rayon encoding pool simultaneously.  The pool's `PACKET_ENCODING_TIMEOUT`
-/// is 150 ms; with `then_concurrent(8×cpus)` concurrent encoding futures sharing
-/// a pool of only `cpus` Rayon threads, tasks queued near the end wait ≈
-/// 7×encode_time ≥ 150 ms and are silently dropped, causing the echo read to
-/// time out.  Writing 16 packets per batch keeps Rayon queue wait ≈ 1×encode_time
-/// (≤ 30 ms), well inside the timeout window.
+/// Sends `payload` as fast as backpressure allows over `session`, reads the echo back,
+/// then reports and asserts send/receive throughput and packet-loss metrics.
 ///
 /// Does NOT call `shutdown()` on the write half: HOPR sessions do not support
 /// TCP half-close.
@@ -1045,43 +1096,168 @@ pub async fn pump_and_verify(
     let payload_bytes = payload.to_vec();
     let expected = sha256_digest(payload);
     let n = payload.len();
+    let overall_start = std::time::Instant::now();
 
+    let writer_offset = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let writer_offset_clone = writer_offset.clone();
     let writer = tokio::spawn(async move {
-        let mut offset = 0;
+        let write_start = tokio::time::Instant::now();
+        let mut offset = 0usize;
         while offset < payload_bytes.len() {
             let end = (offset + PUMP_BATCH_BYTES).min(payload_bytes.len());
             w.write_all(&payload_bytes[offset..end]).await?;
             w.flush().await?;
             offset = end;
+            writer_offset_clone.store(offset, std::sync::atomic::Ordering::Relaxed);
+            // Pace the send under the Exit's echo/ack ceiling. HOPR Segmentation-only sessions
+            // have no end-to-end flow control, and a full-speed burst overruns the return path
+            // (Exit ack-amplification + mixer saturation) — see the investigation writeup. We
+            // still send the entire payload, just metered to ~PUMP_SEND_RATE_PPS packets/sec.
             if offset < payload_bytes.len() {
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(PUMP_BATCH_DELAY_MS)).await;
             }
         }
-        Ok::<_, std::io::Error>(())
+        Ok::<_, std::io::Error>(write_start.elapsed())
     });
 
     let mut received = vec![0u8; n];
-    if let Err(err) = tokio::time::timeout(timeout, r.read_exact(&mut received))
-        .await
-        .map_err(|_| anyhow::anyhow!("{label}: read timeout ({timeout:?}) after {n} B"))
-        .and_then(|r| r.map_err(|e| anyhow::anyhow!("{label}: read error: {e}")))
-    {
-        writer.abort();
-        let _ = writer.await;
-        return Err(err);
+    let mut cursor = 0usize;
+    let deadline = tokio::time::Instant::now() + timeout;
+    // Log progress roughly every 5% of total payload.
+    let progress_interval = (n / 20).max(1);
+    let mut next_progress = progress_interval;
+
+    // Monitor task: log writer send progress every 15 s. (The reader logs its own receive
+    // progress inline from the loop below, keyed off `next_progress`.)
+    let monitor_offset = writer_offset.clone();
+    let monitor_label = label.to_string();
+    let monitor_n = n;
+    let monitor_deadline = deadline;
+    let monitor = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
+        interval.tick().await; // skip the immediate first tick
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    let wo = monitor_offset.load(std::sync::atomic::Ordering::Relaxed);
+                    tracing::info!(
+                        "[monitor] {monitor_label}: writer_sent={wo}/{monitor_n} B ({pct}%)",
+                        pct = wo * 100 / monitor_n.max(1)
+                    );
+                }
+                _ = tokio::time::sleep_until(monitor_deadline) => break,
+            }
+        }
+    });
+
+    // Reader: accumulate bytes until all received, the overall deadline expires, or the
+    // stream goes idle. HOPR sessions have no half-close, so the sender never signals
+    // end-of-stream: after the last echo arrives, a small tail may remain unflushed on the
+    // sender forever. Rather than block until the 300 s deadline (which would make the
+    // throughput metric meaningless), we stop after `PUMP_RECV_IDLE_TIMEOUT` with no new
+    // bytes and report the residual as loss. Throughput is measured against the instant of
+    // the *last received byte*, not the deadline, so it reflects real delivery speed.
+    let mut last_recv = overall_start;
+    'recv: loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            break 'recv;
+        }
+        let wait = PUMP_RECV_IDLE_TIMEOUT.min(deadline - now);
+        match tokio::time::timeout(wait, r.read(&mut received[cursor..])).await {
+            Ok(Ok(0)) => break 'recv,
+            Ok(Ok(nbytes)) => {
+                cursor += nbytes;
+                last_recv = std::time::Instant::now();
+                if cursor >= next_progress || cursor >= n {
+                    let pct = cursor * 100 / n;
+                    let elapsed = overall_start.elapsed();
+                    let kbs = cursor as f64 / elapsed.as_secs_f64() / 1024.0;
+                    let wo = writer_offset.load(std::sync::atomic::Ordering::Relaxed);
+                    tracing::info!(
+                        "{label}: recv progress {cursor}/{n} B ({pct}%) in {elapsed:.2?} ({kbs:.1} kB/s) [writer_sent={wo}]"
+                    );
+                    next_progress = cursor + progress_interval;
+                }
+                if cursor >= n {
+                    break 'recv;
+                }
+            }
+            Ok(Err(e)) => {
+                monitor.abort();
+                writer.abort();
+                let _ = writer.await;
+                return Err(anyhow::anyhow!("{label}: read error: {e}"));
+            }
+            Err(_) => {
+                // No new bytes for PUMP_RECV_IDLE_TIMEOUT — delivery has drained. The
+                // remaining bytes (if any) are an unflushable tail; report them as loss.
+                tracing::info!(
+                    "{label}: recv idle for {PUMP_RECV_IDLE_TIMEOUT:?} at {cursor}/{n} B — ending read"
+                );
+                break 'recv;
+            }
+        }
+    }
+    monitor.abort();
+    // Throughput reflects time-to-last-byte, not the idle/deadline wait after delivery ended.
+    let recv_elapsed = last_recv
+        .saturating_duration_since(overall_start)
+        .max(Duration::from_millis(1));
+    let bytes_received = cursor;
+
+    // Wait for the writer to finish. The reader loop above already ran until `deadline`
+    // (pump start + `timeout`), so bound this join to the *remaining* budget (with a small
+    // floor to reap a writer that is essentially done) — a second full `timeout` here would let
+    // `pump_and_verify` run for up to twice its stated budget.
+    let writer_budget = deadline
+        .saturating_duration_since(tokio::time::Instant::now())
+        .max(Duration::from_secs(5));
+    let write_elapsed = match tokio::time::timeout(writer_budget, writer).await {
+        Ok(Ok(Ok(dur))) => dur,
+        Ok(Ok(Err(e))) => return Err(anyhow::anyhow!("{label}: write error: {e}")),
+        Ok(Err(e)) => return Err(anyhow::anyhow!("{label}: writer panicked: {e}")),
+        Err(_) => return Err(anyhow::anyhow!("{label}: writer timeout")),
+    };
+
+    // Metrics
+    let send_kbs = n as f64 / write_elapsed.as_secs_f64() / 1024.0;
+    let recv_kbs = bytes_received as f64 / recv_elapsed.as_secs_f64() / 1024.0;
+    let loss_pct = (n - bytes_received) as f64 / n as f64 * 100.0;
+    tracing::info!(
+        "{label}: send {send_kbs:.1} kB/s ({:.2?}) | recv {recv_kbs:.1} kB/s ({:.2?}) | loss {loss_pct:.2}% ({bytes_received}/{n} B)",
+        write_elapsed,
+        recv_elapsed,
+    );
+
+    // Verify the integrity of whatever arrived — not only the full-payload case. The echo of a
+    // byte range must equal the same range of the payload; checking only `bytes_received == n`
+    // would let a corrupted-but-lossy run (within PUMP_MAX_LOSS_PCT) pass the loss assertion
+    // below without any integrity check.
+    if bytes_received == n {
+        anyhow::ensure!(
+            sha256_digest(&received) == expected,
+            "{label}: SHA-256 mismatch — {n} bytes corrupted in transit"
+        );
+        tracing::info!("{label}: SHA-256 OK");
+    } else {
+        anyhow::ensure!(
+            received[..bytes_received] == payload[..bytes_received],
+            "{label}: content mismatch in the {bytes_received} received bytes — corruption in transit"
+        );
+        tracing::info!("{label}: received-prefix integrity OK ({bytes_received}/{n} B)");
     }
 
-    tokio::time::timeout(timeout, writer)
-        .await
-        .map_err(|_| anyhow::anyhow!("{label}: writer timeout ({timeout:?})"))?
-        .map_err(|e| anyhow::anyhow!("{label}: writer panicked: {e}"))?
-        .map_err(|e| anyhow::anyhow!("{label}: write error: {e}"))?;
-
+    // Assertions.
     anyhow::ensure!(
-        sha256_digest(&received) == expected,
-        "{label}: SHA-256 mismatch — {n} bytes corrupted in transit"
+        loss_pct <= PUMP_MAX_LOSS_PCT,
+        "{label}: packet loss {loss_pct:.1}% > {PUMP_MAX_LOSS_PCT}% max (received {bytes_received}/{n} B)"
     );
-    tracing::info!("{label}: ✓ {n} B verified (SHA-256 match)");
+    anyhow::ensure!(
+        recv_kbs >= PUMP_MIN_RECV_RATE_KBS,
+        "{label}: recv throughput {recv_kbs:.1} kB/s < {PUMP_MIN_RECV_RATE_KBS} kB/s min"
+    );
+
     Ok(())
 }
 
@@ -1319,7 +1495,7 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     };
 
     // Wait for dest_1h to appear in the probe graph before attempting 1-hop
-    // sessions — same reason as in run_one_megabyte_session_test (§6.3).
+    // sessions — same reason as in run_session_throughput_test (§6.3).
     tracing::info!(%dest_1h, "waiting for 1-hop destination to be probed");
     await_edgli_exit_peer_ready(&edgli, dest_1h).await?;
 
@@ -1488,11 +1664,93 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
 // Top-level harness
 // ────────────────────────────────────────────────────────────────────────────
 
-/// Run the 1 MiB session pump (0-hop + 1-hop) against the given network.
+/// Initialise a layered tracing subscriber.
 ///
+/// Always installs an `EnvFilter`-gated `fmt` layer for console output.
+/// When `CHROME_TRACE_OUTPUT` is set, also installs a
+/// [`tracing_chrome::ChromeLayer`] that writes a Perfetto/Chrome-DevTools
+/// trace JSON to that path (open in `chrome://tracing` or
+/// <https://ui.perfetto.dev>).
+/// When `FLAME_OUTPUT` is set, also installs a [`tracing_flame::FlameLayer`]
+/// that writes folded stacks to that path (usable with `inferno-flamegraph`).
+///
+/// Returns guards that must be held for the duration of the test; dropping
+/// them flushes the trace files.
+pub fn init_tracing() -> (
+    Option<tracing_chrome::FlushGuard>,
+    Option<tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>>,
+) {
+    // Strip high-volume tokio/runtime targets from the fmt filter: formatting
+    // and writing thousands of tokio poll events to stdout per second consumes
+    // CPU on every tokio worker thread, starving the session drive task.
+    // Those targets are still captured by the Chrome layer (async writer).
+    let stdout_filter = {
+        let rust_log = std::env::var("RUST_LOG").unwrap_or_default();
+        let stripped: String = rust_log
+            .split(',')
+            .filter(|d| {
+                let target = d.split('=').next().unwrap_or("").trim();
+                target != "tokio" && target != "runtime"
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        EnvFilter::new(if stripped.is_empty() {
+            "info".to_string()
+        } else {
+            stripped
+        })
+    };
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_ansi(true)
+        .with_filter(stdout_filter);
+
+    let chrome_path = std::env::var("CHROME_TRACE_OUTPUT").ok();
+    let flame_path = std::env::var("FLAME_OUTPUT").ok();
+
+    // Chrome layer keeps the full RUST_LOG filter (including tokio=trace).
+    // The writer runs on a background thread and does not block tokio.
+    let (chrome_layer, chrome_guard) = if let Some(ref path) = chrome_path {
+        let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+            .file(path)
+            .include_args(true)
+            .build();
+        // Fall back to a trace-capturing filter if RUST_LOG is unset/empty — an empty
+        // `from_default_env` would enable nothing and the Chrome trace would be empty.
+        let chrome_filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("info,tokio=trace,runtime=trace"));
+        (Some(layer.with_filter(chrome_filter)), Some(guard))
+    } else {
+        (None, None)
+    };
+
+    let (flame_layer, flame_guard) = if let Some(ref path) = flame_path {
+        let (layer, guard) =
+            tracing_flame::FlameLayer::with_file(path).expect("cannot open FLAME_OUTPUT file");
+        (Some(layer), Some(guard))
+    } else {
+        (None, None)
+    };
+
+    // `try_init` (not `init`) so this coexists with a subscriber already installed by the
+    // `#[test_log::test]` attribute: if one is set, we keep it rather than panicking.
+    let _ = tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(chrome_layer)
+        .with(flame_layer)
+        .try_init();
+
+    (chrome_guard, flame_guard)
+}
+
+/// Run the session throughput pump (0-hop + 1-hop) against the given network.
+///
+/// Sends a `PAYLOAD_SIZE` payload (currently 20 MiB) each way, measuring throughput and loss.
 /// Orchestrates: provision → Edgli boot → strategy reactor → channel wait →
 /// target selection → 0-hop pump → 1-hop pump → final assertion.
-pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
+pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
+    let (_chrome_guard, _flame_guard) = init_tracing();
+
     // ── 1. Provision the network ─────────────────────────────────────────────
     let (summary, _guard, tuning) = provision(net).await?;
 
@@ -1538,12 +1796,35 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     await_edgli_peers_connected(&edgli, 2).await?;
 
     // ── 5. Start the channel-lifecycle strategy reactor ──────────────────────
-    // Channel capacities are derived from the live winning probability (see
-    // edgli::strategy::compute_funding_config) so each channel's stake covers a
-    // fixed number of ticket face values.
+    // Channel capacity is sized by the strategy's built-in winning-ticket buffer
+    // (see edgli::strategy::compute_funding_config): only winning tickets drain
+    // channel balance, so a few face values per channel cover both test and
+    // background probe traffic.
+    //
+    // The hardcoded extra identity (EXTRA_KEYS[0]) may have pre-existing Open
+    // channels to genesis accounts that are not running hoprd nodes.  The
+    // channel-lifecycle strategy counts ALL open channels, so those genesis
+    // channels reduce the deficit.  We count them upfront and add them to the
+    // target so the strategy still opens CLUSTER_SIZE channels to the actual
+    // running cluster nodes.
+    let connected_at_start = edgli.connected_peer_addresses().await?;
+    let peer_set_at_start: std::collections::HashSet<Address> =
+        connected_at_start.into_iter().collect();
+    let genesis_channel_count = edgli
+        .my_outgoing_channels()
+        .await?
+        .into_iter()
+        .filter(|c| c.status == ChannelStatus::Open && !peer_set_at_start.contains(&c.destination))
+        .count();
+    if genesis_channel_count > 0 {
+        tracing::info!(
+            genesis_channel_count,
+            "compensating for pre-existing genesis channels in target"
+        );
+    }
     let sizing = IncentiveConfiguration {
         min_open_channels: 1,
-        target_open_channels: CLUSTER_SIZE,
+        target_open_channels: CLUSTER_SIZE + genesis_channel_count,
         ..Default::default()
     };
     let mut strat_cfg = default_strategy_cfg(&edgli, &sizing).await?;
@@ -1552,6 +1833,9 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
         let EdgeStrategyKind::ChannelLifecycle(lc) = kind;
         lc.selector = tuning.selector.clone();
         lc.tick_interval = tuning.strategy_tick;
+        // Disable the peer-quality gate in tests so the strategy opens channels
+        // to cluster nodes even before the first probe response arrives.
+        lc.eligibility.min_peer_quality_score = 0.0;
     }
 
     let EdgeStrategyKind::ChannelLifecycle(lc0) = &strat_cfg.strategies[0];
@@ -1594,10 +1878,6 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
     rand::rng().fill(&mut payload[..]);
 
     // ── 10. 0-hop session — direct path, no relay ────────────────────────────
-    // NoRateControl disables the exit node's egress rate limiter (default: 10
-    // pkt/s initial rate).  Without it, returning 1 MiB (~1030 packets) at
-    // 10 pkt/s takes ~103 s, nearly exhausting the pump timeout before the
-    // rate-adaptive controller has time to ramp up.
     tracing::info!("opening 0-hop session (loopback)");
     let (session_0h, _) = edgli
         .connect_to(
@@ -1606,21 +1886,15 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
             HoprSessionClientConfig {
                 forward_path: HopRouting::try_from(0_usize)?,
                 return_path: HopRouting::try_from(0_usize)?,
-                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
-                // Keep the SURB pre-fill burst below the per-peer send-channel capacity
-                // (1000 slots). The default target of 7000 SURBs saturates the channel,
-                // causing session data to time out and be dropped silently with no
-                // reconnect (hoprnet eb21c1354c removed cache invalidation on timeout).
-                // 600 SURBs fit in one burst; the balancer replenishes as they are consumed.
-                surb_management: Some(SurbBalancerConfig {
-                    target_surb_buffer_size: 600,
-                    max_surbs_per_sec: 300,
-                    ..SurbBalancerConfig::default()
-                }),
+                capabilities: SessionCapability::Segmentation.into(),
+                always_max_out_surbs: true,
                 ..Default::default()
             },
         )
         .await?;
+    // Allow SURBs to accumulate before pumping data.
+    // Default balancer target=7000; EXIT's pool reaches ~7000 SURBs after 5 s.
+    tokio::time::sleep(Duration::from_secs(5)).await;
     pump_and_verify(session_0h, &payload, "0-hop", tuning.pump_timeout).await?;
 
     // ── 11. 1-hop session — full relay path ──────────────────────────────────
@@ -1632,16 +1906,14 @@ pub async fn run_one_megabyte_session_test(net: Network) -> anyhow::Result<()> {
             HoprSessionClientConfig {
                 forward_path: HopRouting::try_from(1_usize)?,
                 return_path: HopRouting::try_from(1_usize)?,
-                capabilities: (SessionCapability::Segmentation | SessionCapability::NoRateControl),
-                surb_management: Some(SurbBalancerConfig {
-                    target_surb_buffer_size: 600,
-                    max_surbs_per_sec: 300,
-                    ..SurbBalancerConfig::default()
-                }),
+                capabilities: SessionCapability::Segmentation.into(),
+                always_max_out_surbs: true,
                 ..Default::default()
             },
         )
         .await?;
+    // Same SURB pre-fill delay as the 0-hop session above.
+    tokio::time::sleep(Duration::from_secs(5)).await;
     pump_and_verify(session_1h, &payload, "1-hop", tuning.pump_timeout).await?;
 
     // ── 12. Final state assertion ─────────────────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1279,12 +1279,22 @@ fn throughput_kibs(bytes: usize, elapsed: Duration) -> f64 {
 ///
 /// Does NOT call `shutdown()` on the write half: HOPR sessions do not support
 /// TCP half-close.
+/// Throughput/loss metrics computed by [`pump_and_verify`] over the *transfer* window
+/// (not the wall-clock of the whole call, which includes the idle drain). Call sites should
+/// report these rather than recomputing from `payload_len / total_elapsed`.
+pub struct PumpMetrics {
+    pub send_kibs: f64,
+    pub recv_kibs: f64,
+    pub bytes_received: usize,
+    pub loss_pct: f64,
+}
+
 pub async fn pump_and_verify(
     session: HoprSession,
     payload: &[u8],
     label: &str,
     timeout: Duration,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PumpMetrics> {
     let (mut r, mut w) = tokio::io::split(session);
     let payload_bytes = payload.to_vec();
     let n = payload.len();
@@ -1475,7 +1485,12 @@ pub async fn pump_and_verify(
         "{label}: recv throughput {recv_kibs:.1} KiB/s < {PUMP_MIN_RECV_RATE_KIBS} KiB/s min"
     );
 
-    Ok(())
+    Ok(PumpMetrics {
+        send_kibs,
+        recv_kibs,
+        bytes_received,
+        loss_pct,
+    })
 }
 
 /// Write `payload` into `session` in a single un-paced `write_all`, read back
@@ -1740,18 +1755,14 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
             },
         )
         .await?;
-    let t0 = std::time::Instant::now();
-    pump_and_verify(
+    let m = pump_and_verify(
         session_0h_paced,
         &payload,
         "paced 0-hop",
         tuning.pump_timeout,
     )
     .await?;
-    tracing::info!(
-        "paced 0-hop: {:.0} KiB/s",
-        throughput_kibs(PAYLOAD_SIZE, t0.elapsed())
-    );
+    tracing::info!("paced 0-hop: {:.0} KiB/s recv", m.recv_kibs);
 
     // ── 5. Continuous variant (pump_continuous) ───────────────────────────────
     tracing::info!("=== CONTINUOUS (NO PACING): opening 0-hop session ===");
@@ -1814,18 +1825,14 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
             },
         )
         .await?;
-    let t1 = std::time::Instant::now();
-    pump_and_verify(
+    let m = pump_and_verify(
         session_1h_paced,
         &payload,
         "paced 1-hop",
         tuning.pump_timeout,
     )
     .await?;
-    tracing::info!(
-        "paced 1-hop: {:.0} KiB/s",
-        throughput_kibs(PAYLOAD_SIZE, t1.elapsed())
-    );
+    tracing::info!("paced 1-hop: {:.0} KiB/s recv", m.recv_kibs);
 
     // ── 7. 1-hop continuous variant ───────────────────────────────────────────
     tracing::info!("=== CONTINUOUS (NO PACING): opening 1-hop session ===");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -60,9 +60,9 @@ pub const PUMP_SEND_RATE_PPS: u64 = 1000;
 /// after retuning — truncating division would silently push the rate above the cap.
 pub const PUMP_BATCH_DELAY_MS: u64 =
     (PUMP_BATCH_PACKETS as u64 * 1000).div_ceil(PUMP_SEND_RATE_PPS);
-/// Minimum acceptable receive throughput. At 1000 pkt/sec paced send the echo returns at the
-/// same rate; this floor sits well below that so it only catches a genuine stall.
-pub const PUMP_MIN_RECV_RATE_KBS: f64 = 100.0;
+/// Minimum acceptable receive throughput (KiB/s). At 1000 pkt/sec paced send the echo returns at
+/// the same rate; this floor sits well below that so it only catches a genuine stall.
+pub const PUMP_MIN_RECV_RATE_KIBS: f64 = 100.0;
 /// Maximum acceptable packet loss percentage.
 pub const PUMP_MAX_LOSS_PCT: f64 = 5.0;
 /// How long the reader waits with no new bytes before concluding delivery has drained.
@@ -76,11 +76,24 @@ pub const PUMP_RECV_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 /// target selection always has two distinct peers). Counting the edge client, that is 3 total for
 /// 0/1-hop, 4 for 2-hop, 5 for 3-hop. Defaults to 3 when unset (covers the default 0/1-hop run).
 pub fn cluster_size() -> usize {
-    std::env::var("EDGLI_E2E_CLUSTER_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n >= 2)
-        .unwrap_or(3)
+    match std::env::var("EDGLI_E2E_CLUSTER_SIZE") {
+        // Unset (or empty) → keep the documented 3-node default.
+        Err(_) => 3,
+        Ok(v) if v.trim().is_empty() => 3,
+        // Set-but-invalid must fail loudly in a measurement harness rather than silently
+        // provisioning a topology the operator did not request.
+        Ok(v) => {
+            let n: usize = v.trim().parse().unwrap_or_else(|e| {
+                panic!("EDGLI_E2E_CLUSTER_SIZE={v:?} is not a valid usize: {e}")
+            });
+            assert!(
+                n >= 2,
+                "EDGLI_E2E_CLUSTER_SIZE={n} is below the minimum of 2 (target selection needs two \
+                 distinct peers)"
+            );
+            n
+        }
+    }
 }
 const API_PORT_BASE: u16 = 13000;
 const P2P_PORT_BASE: u16 = 19000;
@@ -1102,23 +1115,42 @@ fn env_flag(var: &str) -> bool {
 /// tears down its own cluster.
 pub fn hop_counts() -> Vec<usize> {
     match std::env::var("EDGLI_E2E_HOPS") {
-        Ok(v) if !v.trim().is_empty() => v
-            .split(',')
-            .filter_map(|s| s.trim().parse::<usize>().ok())
-            .collect(),
+        Ok(v) if !v.trim().is_empty() => {
+            // Reject unparsable entries loudly: silently dropping them could yield an empty
+            // vector and a vacuous pass that transfers no payload.
+            let hops: Vec<usize> = v
+                .split(',')
+                .map(|s| {
+                    s.trim().parse::<usize>().unwrap_or_else(|e| {
+                        panic!(
+                            "EDGLI_E2E_HOPS entry {:?} is not a valid usize: {e}",
+                            s.trim()
+                        )
+                    })
+                })
+                .collect();
+            assert!(
+                !hops.is_empty(),
+                "EDGLI_E2E_HOPS={v:?} parsed to no hop counts"
+            );
+            hops
+        }
         _ => vec![0, 1],
     }
 }
 
 /// Seconds to let the cluster settle after readiness so nodes complete several probing rounds
-/// before path-finding runs (`EDGLI_E2E_PROBE_SETTLE_SECS`, default 20 s). At hoprd's local probe
+/// before path-finding runs (`EDGLI_E2E_PROBE_SETTLE_SECS`, default 60 s). At hoprd's local probe
 /// cadence this comfortably covers ≥3 rounds, warming edge scores for reliable multi-hop paths
 /// (RFC-0010 §6.2, RFC-0014 §6.3).
 fn probe_settle_duration() -> Duration {
-    let secs = std::env::var("EDGLI_E2E_PROBE_SETTLE_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(60);
+    let secs = match std::env::var("EDGLI_E2E_PROBE_SETTLE_SECS") {
+        Err(_) => 60,
+        Ok(v) if v.trim().is_empty() => 60,
+        Ok(v) => v.trim().parse::<u64>().unwrap_or_else(|e| {
+            panic!("EDGLI_E2E_PROBE_SETTLE_SECS={v:?} is not a valid u64: {e}")
+        }),
+    };
     Duration::from_secs(secs)
 }
 
@@ -1180,10 +1212,12 @@ fn loopback_session_config(hops: usize) -> anyhow::Result<HoprSessionClientConfi
         flow_control: flow_control_config(),
         ..Default::default()
     };
-    if let Some(max_surbs_per_sec) = std::env::var("HOPR_SESSION_MAX_SURBS_PER_SEC")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
+    if let Ok(v) = std::env::var("HOPR_SESSION_MAX_SURBS_PER_SEC")
+        && !v.trim().is_empty()
     {
+        let max_surbs_per_sec = v.trim().parse::<u64>().unwrap_or_else(|e| {
+            panic!("HOPR_SESSION_MAX_SURBS_PER_SEC={v:?} is not a valid u64: {e}")
+        });
         cfg.surb_management = Some(SurbBalancerConfig {
             max_surbs_per_sec,
             ..cfg.surb_management.unwrap_or_default()
@@ -1235,9 +1269,9 @@ pub fn sha256_digest(data: &[u8]) -> Vec<u8> {
     h.finalize().to_vec()
 }
 
-/// Throughput of `bytes` transferred over `elapsed`, expressed in kB/s (1 kB = 1024 B).
-fn throughput_kbs(bytes: usize, elapsed: Duration) -> f64 {
-    bytes as f64 / elapsed.as_secs_f64() / 1024.0
+/// Throughput of `bytes` transferred over `elapsed`, expressed in KiB/s (1 KiB = 1024 B).
+fn throughput_kibs(bytes: usize, elapsed: Duration) -> f64 {
+    bytes as f64 / elapsed.as_secs_f64().max(f64::EPSILON) / 1024.0
 }
 
 /// Sends `payload` as fast as backpressure allows over `session`, reads the echo back,
@@ -1263,6 +1297,10 @@ pub async fn pump_and_verify(
 
     let writer_offset = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let writer_offset_clone = writer_offset.clone();
+    // Resolve the pacing mode once, up front: `flow_control_enabled()` reads the process
+    // environment (taking the global env lock and allocating a config), so calling it per
+    // batch inside the timed loop would perturb the very `send_kbs` we are measuring.
+    let paced = !flow_control_enabled();
     let mut writer = tokio::spawn(async move {
         let write_start = tokio::time::Instant::now();
         let mut offset = 0usize;
@@ -1279,7 +1317,7 @@ pub async fn pump_and_verify(
             //
             // When client-side flow control is enabled the adaptive send window replaces this
             // manual pacing, so we send unpaced and let the window self-size against the drain rate.
-            if offset < payload_bytes.len() && !flow_control_enabled() {
+            if offset < payload_bytes.len() && paced {
                 tokio::time::sleep(Duration::from_millis(PUMP_BATCH_DELAY_MS)).await;
             }
         }
@@ -1338,10 +1376,10 @@ pub async fn pump_and_verify(
                 if cursor >= next_progress || cursor >= n {
                     let pct = cursor * 100 / n;
                     let elapsed = overall_start.elapsed();
-                    let kbs = throughput_kbs(cursor, elapsed);
+                    let kibs = throughput_kibs(cursor, elapsed);
                     let wo = writer_offset.load(std::sync::atomic::Ordering::Relaxed);
                     tracing::info!(
-                        "{label}: recv progress {cursor}/{n} B ({pct}%) in {elapsed:.2?} ({kbs:.1} kB/s) [writer_sent={wo}]"
+                        "{label}: recv progress {cursor}/{n} B ({pct}%) in {elapsed:.2?} ({kibs:.1} KiB/s) [writer_sent={wo}]"
                     );
                     next_progress = cursor + progress_interval;
                 }
@@ -1398,11 +1436,11 @@ pub async fn pump_and_verify(
     };
 
     // Metrics
-    let send_kbs = throughput_kbs(n, write_elapsed);
-    let recv_kbs = throughput_kbs(bytes_received, recv_elapsed);
+    let send_kibs = throughput_kibs(n, write_elapsed);
+    let recv_kibs = throughput_kibs(bytes_received, recv_elapsed);
     let loss_pct = (n - bytes_received) as f64 / n as f64 * 100.0;
     tracing::info!(
-        "{label}: send {send_kbs:.1} kB/s ({:.2?}) | recv {recv_kbs:.1} kB/s ({:.2?}) | loss {loss_pct:.2}% ({bytes_received}/{n} B)",
+        "{label}: send {send_kibs:.1} KiB/s ({:.2?}) | recv {recv_kibs:.1} KiB/s ({:.2?}) | loss {loss_pct:.2}% ({bytes_received}/{n} B)",
         write_elapsed,
         recv_elapsed,
     );
@@ -1433,8 +1471,8 @@ pub async fn pump_and_verify(
         "{label}: packet loss {loss_pct:.1}% > {PUMP_MAX_LOSS_PCT}% max (received {bytes_received}/{n} B)"
     );
     anyhow::ensure!(
-        recv_kbs >= PUMP_MIN_RECV_RATE_KBS,
-        "{label}: recv throughput {recv_kbs:.1} kB/s < {PUMP_MIN_RECV_RATE_KBS} kB/s min"
+        recv_kibs >= PUMP_MIN_RECV_RATE_KIBS,
+        "{label}: recv throughput {recv_kibs:.1} KiB/s < {PUMP_MIN_RECV_RATE_KIBS} KiB/s min"
     );
 
     Ok(())
@@ -1500,12 +1538,12 @@ pub async fn pump_continuous(
     let read_result = tokio::time::timeout(timeout, r.read_exact(&mut received)).await;
 
     let elapsed = start.elapsed();
-    let throughput_kbps = (n as f64 / 1024.0) / elapsed.as_secs_f64();
+    let throughput_kibs = throughput_kibs(n, elapsed);
 
     match read_result {
         Ok(Ok(_)) => {
             tracing::info!(
-                "{label}: ✓ {n} B in {elapsed:.2?} ({throughput_kbps:.0} KB/s) — continuous"
+                "{label}: ✓ {n} B in {elapsed:.2?} ({throughput_kibs:.0} KiB/s) — continuous"
             );
             writer
                 .await
@@ -1580,12 +1618,12 @@ pub async fn pump_yielding(
     let read_result = tokio::time::timeout(timeout, r.read_exact(&mut received)).await;
 
     let elapsed = start.elapsed();
-    let throughput_kbps = (n as f64 / 1024.0) / elapsed.as_secs_f64();
+    let throughput_kibs = throughput_kibs(n, elapsed);
 
     match read_result {
         Ok(Ok(_)) => {
             tracing::info!(
-                "{label}: ✓ {n} B in {elapsed:.2?} ({throughput_kbps:.0} KB/s) — yielding"
+                "{label}: ✓ {n} B in {elapsed:.2?} ({throughput_kibs:.0} KiB/s) — yielding"
             );
             writer
                 .await
@@ -1606,7 +1644,7 @@ pub async fn pump_yielding(
             let _ = writer.await;
             tracing::warn!(
                 "{label}: read timeout ({timeout:?}) after {elapsed:.2?} \
-                 ({throughput_kbps:.0} KB/s before stall)"
+                 ({throughput_kibs:.0} KiB/s before stall)"
             );
         }
     }
@@ -1711,8 +1749,8 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     )
     .await?;
     tracing::info!(
-        "paced 0-hop: {:.0} KB/s",
-        (PAYLOAD_SIZE as f64 / 1024.0) / t0.elapsed().as_secs_f64()
+        "paced 0-hop: {:.0} KiB/s",
+        throughput_kibs(PAYLOAD_SIZE, t0.elapsed())
     );
 
     // ── 5. Continuous variant (pump_continuous) ───────────────────────────────
@@ -1785,8 +1823,8 @@ pub async fn run_throughput_comparison_test(net: Network) -> anyhow::Result<()> 
     )
     .await?;
     tracing::info!(
-        "paced 1-hop: {:.0} KB/s",
-        (PAYLOAD_SIZE as f64 / 1024.0) / t1.elapsed().as_secs_f64()
+        "paced 1-hop: {:.0} KiB/s",
+        throughput_kibs(PAYLOAD_SIZE, t1.elapsed())
     );
 
     // ── 7. 1-hop continuous variant ───────────────────────────────────────────
@@ -2062,7 +2100,7 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
         let peers = edgli.connected_peer_addresses().await?;
         anyhow::ensure!(
             peers.len() > max_hops,
-            "need ≥{} connected peers for {}-hop path-finding, have {} (raise CLUSTER_SIZE)",
+            "need ≥{} connected peers for {}-hop path-finding, have {} (raise EDGLI_E2E_CLUSTER_SIZE)",
             max_hops + 1,
             max_hops,
             peers.len()
@@ -2098,7 +2136,25 @@ pub async fn run_session_throughput_test(net: Network) -> anyhow::Result<()> {
     rand::rng().fill(&mut payload[..]);
 
     // ── 10. Run each requested hop count over the (warm) cluster ──────────────
-    for &h in &hops {
+    //
+    // NOTE on cross-hop comparability: only the first iteration starts from the freshly settled
+    // state (steps 8–9); every later one inherits the residual state the previous 20 MiB pump left
+    // behind (drained SURB pool, warm mixer queues, exit ticket state). The SURB pool depth is not
+    // exposed to the harness, so we cannot gate on it directly. To make consecutive iterations
+    // start from a comparable state we re-apply the same `probe_settle_duration()` mature-window
+    // before every iteration after the first, on top of the per-hop SURB pre-fill below. For
+    // strictly comparable absolute numbers still run ONE hop count per process (`EDGLI_E2E_HOPS=N`),
+    // as `hop_counts()` documents — each run then provisions and settles its own fresh cluster.
+    for (i, &h) in hops.iter().enumerate() {
+        if i > 0 {
+            let resettle = probe_settle_duration();
+            tracing::info!(
+                hops = h,
+                ?resettle,
+                "re-settling before the next hop so it starts from a state comparable to the first"
+            );
+            tokio::time::sleep(resettle).await;
+        }
         tracing::info!(hops = h, "opening {h}-hop loopback session");
         let (session, _) = edgli
             .connect_to(exit, loopback_target(), loopback_session_config(h)?)

--- a/tests/edgli_profiling.rs
+++ b/tests/edgli_profiling.rs
@@ -126,7 +126,7 @@ fn init_subscriber(filename: &str) -> tracing_chrome::FlushGuard {
 #[tokio::test(flavor = "multi_thread")]
 async fn edgli_profiling_paced_pump_baseline() -> anyhow::Result<()> {
     let _guard = init_subscriber("edgli-trace-paced.json");
-    common::run_one_megabyte_session_test(common::Network::Local).await
+    common::run_session_throughput_test(common::Network::Local).await
 }
 
 /// Continuous-pump starvation case with tokio-console + Chrome trace active.

--- a/tests/edgli_session_e2e.rs
+++ b/tests/edgli_session_e2e.rs
@@ -72,6 +72,6 @@ mod common;
 /// Gated behind `#[ignore]` — see module-level docs for required setup.
 #[ignore]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn edgli_sends_one_megabyte_through_local_cluster() -> anyhow::Result<()> {
-    common::run_one_megabyte_session_test(common::Network::Local).await
+async fn edgli_sends_payload_through_local_cluster() -> anyhow::Result<()> {
+    common::run_session_throughput_test(common::Network::Local).await
 }

--- a/tests/edgli_session_rotsee.rs
+++ b/tests/edgli_session_rotsee.rs
@@ -39,6 +39,6 @@ mod common;
 /// Gated behind `#[ignore]` — see module-level docs for required setup.
 #[ignore]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn edgli_sends_one_megabyte_through_rotsee() -> anyhow::Result<()> {
-    common::run_one_megabyte_session_test(common::Network::Rotsee).await
+async fn edgli_sends_payload_through_rotsee() -> anyhow::Result<()> {
+    common::run_session_throughput_test(common::Network::Rotsee).await
 }


### PR DESCRIPTION
## Summary

Refines the session e2e loopback throughput test (`edgli_session_e2e`) to measure 0-hop and
1-hop throughput/loss reliably for a 20 MiB payload:

- **Paced send** — transmit the full payload but meter it (~1000 pkt/sec) under the Exit's
  echo/ack ceiling. HOPR `Segmentation`-only sessions have no end-to-end flow control, so a
  full-speed burst overruns the return path (Exit **ack-amplification** + return-path/mixer
  saturation) and deterministically stalls at ~32%. Pacing keeps the sender under the
  sustainable rate.
- **Time-of-last-byte measurement** — compute recv throughput against the instant of the last
  received byte and stop the reader on a 15s idle timeout, so the small unflushable
  end-of-stream tail (HOPR sessions have no half-close) doesn't skew the metric to a false
  ~17 kB/s.
- **`EDGLI_DATA_DIR`** — opt-in persistent data dir so hoprd node logs survive the run for
  post-mortem analysis.

Also in this PR:

- **Docs** — the README `## Testing` section is restructured into a single reference for all
  CI-excluded tests (`#[ignore]` / feature-gated): local-cluster session, Rotsee testnet, and
  the executor-yield profiling harness, with a discovery command and per-suite table.
- **Refactor (`/simplify`)** — dedup the pump harness: `throughput_kbs()` helper for the
  repeated rate calc, `loopback_session_config(hops)` for the identical 0-/1-hop config
  blocks, and hash the payload only on the full-transfer path. No behavior change.

## Result

0-hop **935.3 / 837.0 kB/s**, 1-hop **936.5 / 934.4 kB/s** (send/recv), **0.00% loss**,
20 MiB each way, SHA-256 verified, both hops pass — near the Exit SURB-balancer echo ceiling
(1400 pkt/sec ≈ 1.4 MB/s).