### PR TITLE
feat(strategy)!: size channels from a requested transfer volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ target
 .direnv/
 /result
 /.pre-commit-config.yaml
+
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,8 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.24.0"
-source = "git+https://github.com/hoprnet/hopr-strategy?rev=139b6b2#139b6b2c68e05265a7102adc430ff41116562840"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62774a0f288bc2e99ec1c4c9cc36eecec0cb5ef641c94b671a320372bb3d66f4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.5.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2879,6 +2879,7 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "smart-default",
+ "statrs",
  "strum",
  "thiserror 2.0.19",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62774a0f288bc2e99ec1c4c9cc36eecec0cb5ef641c94b671a320372bb3d66f4"
+checksum = "777c6a3d4148f0bab96ce9ddc8d627d9e5c1249d63cf6618c2a896d9c3e1d032"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,6 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "smart-default",
- "statrs",
  "strum",
  "thiserror 2.0.19",
  "tokio",
@@ -4110,9 +4109,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1f49bc6a2bec90301732e3fbeee65eb3e67f82341b657e865adf51f0f6a024"
+version = "0.24.0"
+source = "git+https://github.com/hoprnet/hopr-strategy?rev=139b6b2#139b6b2c68e05265a7102adc430ff41116562840"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b7849a82fe53e861a4938d1fab94123a16ba55917ff187de358610c07d599a"
+checksum = "ea1f49bc6a2bec90301732e3fbeee65eb3e67f82341b657e865adf51f0f6a024"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4121,7 +4121,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.4.1",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4373,13 +4373,15 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95680cead4b551cdeb76b016e99197f17b3528e790d1b37a7978b8e38e5f36b7"
+checksum = "c3fb9c92de05424fd684bc1a0ac2f7df91ec2b6958f2733b2ff1c830a4390a34"
 dependencies = [
  "auto_impl",
+ "const-hex",
  "futures",
  "indexmap 2.14.0",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgli"
-version = "3.5.1"
+version = "4.0.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Light client implementing the minimum HOPR protocol to serve as an entry node into the mixnet."
@@ -56,6 +56,9 @@ multiaddr = "0.18.2"
 lazy_static = "1.5.0"
 signal-hook = "0.4.4"
 serde_yaml = { version = "0.9.34" }
+# Pinned to the version hopr-strategy uses so the z-score `capacity_stake` mirrors
+# comes from the exact code path the strategy sizes channels with.
+statrs = "0.19.0"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,6 @@ multiaddr = "0.18.2"
 lazy_static = "1.5.0"
 signal-hook = "0.4.4"
 serde_yaml = { version = "0.9.34" }
-# Pinned to the version hopr-strategy uses so the z-score `capacity_stake` mirrors
-# comes from the exact code path the strategy sizes channels with.
-statrs = "0.19.0"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = [
@@ -90,7 +87,10 @@ hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee
 ] }
 hopr-chain-connector = { version = "0.22.1", features = ["runtime-tokio"] }
 hopr-ct-full-network = { version = "0.3.0" }
-hopr-strategy = { version = "0.23.0", features = [
+# TEMPORARY: tracks hoprnet/hopr-strategy#27, which makes `FundingConfig::resolve`
+# public so this crate can read funding figures off the strategy instead of
+# mirroring them. Switch back to a registry version once 0.24.0 is published.
+hopr-strategy = { git = "https://github.com/hoprnet/hopr-strategy", rev = "139b6b2", features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-ticket-manager = { version = "0.5.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,10 +87,7 @@ hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee
 ] }
 hopr-chain-connector = { version = "0.22.1", features = ["runtime-tokio"] }
 hopr-ct-full-network = { version = "0.3.0" }
-# TEMPORARY: tracks hoprnet/hopr-strategy#27, which makes `FundingConfig::resolve`
-# public so this crate can read funding figures off the strategy instead of
-# mirroring them. Switch back to a registry version once 0.24.0 is published.
-hopr-strategy = { git = "https://github.com/hoprnet/hopr-strategy", rev = "139b6b2", features = [
+hopr-strategy = { version = "0.24.1", features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-ticket-manager = { version = "0.5.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee
 ] }
 hopr-chain-connector = { version = "0.22.1", features = ["runtime-tokio"] }
 hopr-ct-full-network = { version = "0.3.0" }
-hopr-strategy = { version = "0.22.0", features = [
+hopr-strategy = { version = "0.23.0", features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-ticket-manager = { version = "0.5.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee
 ] }
 hopr-chain-connector = { version = "0.22.1", features = ["runtime-tokio"] }
 hopr-ct-full-network = { version = "0.3.0" }
-hopr-strategy = { version = "0.24.1", features = [
+hopr-strategy = { version = "0.25.0", features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-ticket-manager = { version = "0.5.1" }

--- a/src/client.rs
+++ b/src/client.rs
@@ -446,14 +446,14 @@ impl Edgli {
         let strategies = cfg
             .strategies
             .into_iter()
-            .map(|kind| -> Box<dyn Strategy + Send> {
+            .map(|kind| -> anyhow::Result<Box<dyn Strategy + Send>> {
                 match kind {
                     EdgeStrategyKind::ChannelLifecycle(sub_cfg) => {
-                        ChannelLifecycleStrategy::new(sub_cfg).build(Arc::clone(&node))
+                        Ok(ChannelLifecycleStrategy::new(sub_cfg).build(Arc::clone(&node))?)
                     }
                 }
             })
-            .collect();
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         let mut multi_strategy = MultiStrategy::new(strategies);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -361,7 +361,13 @@ impl Edgli {
         // verified on-chain rather than assumed.
         // A running node cannot start without a Safe, so it is always deployed here.
         let costs = super::strategy::compute_costs_to_start(chain, Some(source), true).await?;
-        super::strategy::compute_balance_recommendation(ticket_price, win_prob, missing, costs)
+        super::strategy::compute_balance_recommendation(
+            ticket_price,
+            win_prob,
+            missing,
+            costs,
+            cfg.channel_capacity,
+        )
     }
 
     /// Returns a map of data-throughput capacities keyed by [`super::strategy::CapacityAllocator`].

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -836,7 +836,8 @@ mod tests {
     }
 
     #[test]
-    fn compute_capacity_balance_below_ticket_price() {
+    fn compute_capacity_balance_below_one_message_drain() {
+        // 5 is below the 10 × 3 a single message costs, so nothing is payable.
         let cap =
             compute_capacity(HoprBalance::new_base(5), HoprBalance::new_base(10), 1.0).unwrap();
         assert_eq!(cap.expected_messages, 0);
@@ -850,16 +851,6 @@ mod tests {
         assert_eq!(cap.expected_messages, 0);
         assert_eq!(cap.min_guaranteed_messages, 0);
         assert_eq!(cap.byte_capacity, 0);
-    }
-
-    #[test]
-    fn compute_capacity_win_prob_one_matches_expected() {
-        // win_prob=1.0 → face_value = per-message drain → min_guaranteed == expected
-        // 300 / (10 × 3 hops) = 10
-        let cap =
-            compute_capacity(HoprBalance::new_base(300), HoprBalance::new_base(10), 1.0).unwrap();
-        assert_eq!(cap.expected_messages, 10);
-        assert_eq!(cap.min_guaranteed_messages, 10);
     }
 
     #[test]

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use bytesize::ByteSize;
 use hopr_lib::api::types::primitive::prelude::{
-    Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
+    Address, HoprBalance, U256, UnitaryFloatOps as _, XDaiBalance,
 };
 pub use hopr_strategy::channel_lifecycle::{
     CapacitySizingMode, ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
@@ -23,6 +23,26 @@ const TOPUP_FACE_VALUES: u64 = 4;
 /// Face values the balance may decay to before a top-up triggers. Above one so
 /// tickets keep being issued while the top-up confirms.
 const LOWER_THRESHOLD_FACE_VALUES: u64 = 2;
+
+/// Confidence level the channel stake is sized for.
+///
+/// [`CapacitySizingMode::Deterministic`] sizes a channel to the *mean* drain, so its
+/// lower threshold bottoms out near a single ticket face value. Payouts are lumpy —
+/// the number of winning tickets is `Binomial(N, win_prob)` — so a channel resting on
+/// that floor starves: it cannot issue the next ticket and relaying stalls until a
+/// top-up confirms. Sizing for 99% adds `k·σ` (`k = Φ⁻¹(0.99) ≈ 2.33`) above the mean,
+/// enough headroom to carry the configured capacity in 99% of fund cycles.
+const SIZING_SUCCESS_PROBABILITY: f64 = 0.99;
+
+/// The mode every capacity in [`compute_funding_config`] resolves through.
+///
+/// Deliberately *not* exposed on [`IncentiveConfiguration`]: [`capacity_stake`] mirrors
+/// this exact mode to derive balance recommendations, so a caller overriding it on the
+/// returned [`FundingConfig`] would silently desync the recommendation from the stake
+/// the strategy actually locks.
+const SIZING_MODE: CapacitySizingMode = CapacitySizingMode::Probabilistic {
+    success_probability: SIZING_SUCCESS_PROBABILITY,
+};
 
 #[cfg(any(feature = "blokli", feature = "runtime-tokio"))]
 use hopr_lib::api::chain::{AccountSelector, ChainReadAccountOperations, ChainValues};
@@ -58,6 +78,22 @@ pub struct IncentiveConfiguration {
     /// ensure channels exist to the required relayers. Default: `None` (open to any peer).
     #[default(None)]
     pub channel_allowlist: Option<HashSet<Address>>,
+
+    /// Data volume a single channel should be able to carry before it needs a top-up.
+    ///
+    /// This is the only sizing input a caller supplies — the funding capacities, the
+    /// sizing mode, and the resulting stakes are all derived from it. Top-up and
+    /// lower-threshold capacities keep the same proportions to the requested volume
+    /// that the face-value defaults use (`4/5` and `2/5`).
+    ///
+    /// Raising the volume only ever raises a capacity: every field stays floored at its
+    /// face-value minimum, because a channel that cannot cover one winning ticket
+    /// cannot relay at all. Requesting less than that floor therefore has no effect.
+    ///
+    /// Default: `None` — size to [`INITIAL_FACE_VALUES`] face values, the smallest
+    /// stake that keeps ticket issuance running.
+    #[default(None)]
+    pub channel_capacity: Option<ByteSize>,
 }
 
 impl IncentiveConfiguration {
@@ -103,31 +139,118 @@ fn capacity_for_face_values(face_values: u64, win_prob: f64) -> anyhow::Result<B
     Ok(ByteSize::b(bytes))
 }
 
-/// wxHOPR the strategy locks for a channel funded to `capacity`.
+/// Rounds `bytes` up to a whole number of packets.
 ///
-/// Mirrors the strategy's crate-private `capacity_to_balance` for
-/// [`CapacitySizingMode::Deterministic`]; an upper bound for the other modes.
-fn capacity_stake(capacity: ByteSize, ticket_price: HoprBalance, hops: u32) -> HoprBalance {
-    let packets = capacity.as_u64().div_ceil(packet_payload_size());
-    ticket_price * packets * hops as u64
+/// The strategy divides every capacity by the packet payload and rounds up, so an
+/// exact multiple keeps [`capacity_stake`] an exact mirror of that conversion.
+fn packet_aligned(bytes: u64) -> anyhow::Result<ByteSize> {
+    let payload = packet_payload_size();
+    let packets = bytes.div_ceil(payload).max(1);
+    let bytes = packets
+        .checked_mul(payload)
+        .ok_or_else(|| anyhow::anyhow!("capacity of {bytes} bytes overflows u64 when aligned"))?;
+    Ok(ByteSize::b(bytes))
 }
 
-/// Capacity-based [`FundingConfig`] for the given winning probability.
+/// `capacity × numer / denom`, rounded up to a whole number of packets.
+fn scale_capacity(capacity: ByteSize, numer: u64, denom: u64) -> anyhow::Result<ByteSize> {
+    let scaled = (capacity.as_u64() as u128) * (numer as u128) / (denom as u128);
+    packet_aligned(
+        u64::try_from(scaled)
+            .map_err(|_| anyhow::anyhow!("scaled capacity overflows u64 bytes"))?,
+    )
+}
+
+/// wxHOPR the strategy locks for a channel funded to `capacity`.
 ///
-/// Each capacity is sized so the stake the strategy resolves it to covers a fixed
-/// number of ticket face values; below one face value no ticket can be issued.
-/// [`CapacitySizingMode::Deterministic`] is the expected-drain model here, and the
-/// only mode this crate can mirror exactly for balance recommendations.
-pub fn compute_funding_config(win_prob: f64) -> anyhow::Result<FundingConfig> {
-    let initial_capacity = capacity_for_face_values(INITIAL_FACE_VALUES, win_prob)?;
+/// Mirrors the strategy's crate-private `capacity_to_balance` for [`SIZING_MODE`],
+/// including the one-winning-ticket floor. Kept in lockstep with
+/// [`compute_funding_config`] so a balance recommendation can never under-report the
+/// stake the strategy actually locks.
+fn capacity_stake(
+    capacity: ByteSize,
+    ticket_price: HoprBalance,
+    hops: u32,
+    win_prob: f64,
+) -> HoprBalance {
+    let bytes = capacity.as_u64();
+    if bytes == 0 {
+        return HoprBalance::zero();
+    }
+
+    let n = bytes.div_ceil(packet_payload_size()) as f64;
+    // Same clamp the strategy applies: a zero or NaN win_prob would send the
+    // one-ticket floor to infinity and saturate the stake.
+    let p = if win_prob.is_nan() {
+        f64::EPSILON
+    } else {
+        win_prob.clamp(f64::EPSILON, 1.0_f64)
+    };
+    let h = hops as f64;
+    let price = ticket_price.amount().low_u128() as f64;
+
+    // Mean drain E[D] = N × h × tp, independent of p.
+    let mean_drain = n * h * price;
+    let target = match SIZING_MODE {
+        CapacitySizingMode::Deterministic => mean_drain,
+        CapacitySizingMode::Probabilistic {
+            success_probability,
+        } => {
+            use statrs::distribution::{ContinuousCDF, Normal};
+            let alpha = success_probability.clamp(0.5001, 0.99999);
+            let k = Normal::standard().inverse_cdf(alpha);
+            // σ[D] = tp·h × √(N(1−p)/p) — see `CapacitySizingMode::Probabilistic`.
+            let sigma = price * h * (n * (1.0 - p) / p).sqrt();
+            mean_drain + k * sigma
+        }
+    };
+
+    // One-winning-ticket floor: below a full-path face value no ticket can issue.
+    let floor = price * h / p;
+    let stake = target.max(floor).max(0.0);
+    HoprBalance::from(U256::from(stake.ceil() as u128))
+}
+
+/// Capacity-based [`FundingConfig`] for a requested transfer volume and winning
+/// probability.
+///
+/// `channel_capacity` is the data volume one channel should carry before needing a
+/// top-up; `None` sizes it to [`INITIAL_FACE_VALUES`] ticket face values. Top-up and
+/// lower-threshold capacities keep the `4/5` and `2/5` proportions of the initial
+/// capacity, and every field is floored at its face-value minimum — below one face
+/// value no ticket can be issued at all.
+///
+/// All capacities resolve through [`SIZING_MODE`], which [`capacity_stake`] mirrors.
+pub fn compute_funding_config(
+    channel_capacity: Option<ByteSize>,
+    win_prob: f64,
+) -> anyhow::Result<FundingConfig> {
+    let face_initial = capacity_for_face_values(INITIAL_FACE_VALUES, win_prob)?;
+    let face_topup = capacity_for_face_values(TOPUP_FACE_VALUES, win_prob)?;
+    let face_lower = capacity_for_face_values(LOWER_THRESHOLD_FACE_VALUES, win_prob)?;
+
+    // With no requested volume the face-value capacities are used verbatim; scaling
+    // them instead would round differently and shift the long-standing defaults.
+    let (initial_capacity, topup_capacity, lower_capacity_threshold) = match channel_capacity {
+        None => (face_initial, face_topup, face_lower),
+        Some(requested) => {
+            let initial = packet_aligned(requested.as_u64())?.max(face_initial);
+            let topup =
+                scale_capacity(initial, TOPUP_FACE_VALUES, INITIAL_FACE_VALUES)?.max(face_topup);
+            let lower = scale_capacity(initial, LOWER_THRESHOLD_FACE_VALUES, INITIAL_FACE_VALUES)?
+                .max(face_lower);
+            (initial, topup, lower)
+        }
+    };
+
     Ok(FundingConfig {
         initial_capacity,
-        topup_capacity: capacity_for_face_values(TOPUP_FACE_VALUES, win_prob)?,
-        lower_capacity_threshold: capacity_for_face_values(LOWER_THRESHOLD_FACE_VALUES, win_prob)?,
+        topup_capacity,
+        lower_capacity_threshold,
         min_safe_capacity_required: initial_capacity,
         assumed_hops: ASSUMED_HOPS,
         stop_when_unfunded: true,
-        sizing_mode: CapacitySizingMode::Deterministic,
+        sizing_mode: SIZING_MODE,
     })
 }
 
@@ -135,12 +258,17 @@ pub fn compute_funding_config(win_prob: f64) -> anyhow::Result<FundingConfig> {
 ///
 /// Read off [`compute_funding_config`] so the recommendation cannot drift from
 /// what the strategy locks.
-fn initial_channel_stake(ticket_price: HoprBalance, win_prob: f64) -> anyhow::Result<HoprBalance> {
-    let funding = compute_funding_config(win_prob)?;
+fn initial_channel_stake(
+    ticket_price: HoprBalance,
+    win_prob: f64,
+    channel_capacity: Option<ByteSize>,
+) -> anyhow::Result<HoprBalance> {
+    let funding = compute_funding_config(channel_capacity, win_prob)?;
     Ok(capacity_stake(
         funding.initial_capacity,
         ticket_price,
         funding.assumed_hops,
+        win_prob,
     ))
 }
 
@@ -231,11 +359,12 @@ pub(crate) fn compute_balance_recommendation(
     win_prob: f64,
     missing_channels: usize,
     costs: StartupCosts,
+    channel_capacity: Option<ByteSize>,
 ) -> anyhow::Result<BalanceRecommendation> {
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
     } else {
-        initial_channel_stake(ticket_price, win_prob)? * (missing_channels as u64)
+        initial_channel_stake(ticket_price, win_prob, channel_capacity)? * (missing_channels as u64)
     };
     Ok(BalanceRecommendation {
         channel_stakes: stake,
@@ -344,6 +473,7 @@ pub async fn minimum_balance_recommendation(
         win_prob,
         cfg.target_open_channels,
         costs,
+        cfg.channel_capacity,
     )
 }
 
@@ -364,11 +494,13 @@ pub async fn default_strategy_cfg(
         .minimum_incoming_ticket_win_prob()
         .await?
         .as_f64();
-    let funding = compute_funding_config(win_prob)?;
+    let funding = compute_funding_config(sizing.channel_capacity, win_prob)?;
     tracing::info!(
         win_prob,
+        requested_capacity = ?sizing.channel_capacity,
         initial_capacity = %funding.initial_capacity,
         topup_capacity = %funding.topup_capacity,
+        sizing_mode = ?funding.sizing_mode,
         "channel-lifecycle funding sized from live winning probability"
     );
     let cfg = ChannelLifecycleConfig {
@@ -429,7 +561,7 @@ mod tests {
 
     #[test]
     fn compute_funding_config_capacity_is_a_whole_number_of_packets() {
-        let cfg = compute_funding_config(0.001).unwrap();
+        let cfg = compute_funding_config(None, 0.001).unwrap();
         let payload = packet_payload_size();
         assert_eq!(
             cfg.initial_capacity.as_u64(),
@@ -445,7 +577,7 @@ mod tests {
         // Verify lower < topup < initial and min_safe == initial at every win_prob;
         // the per-field ceil could otherwise invert the ordering.
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(p).unwrap();
+            let cfg = compute_funding_config(None, p).unwrap();
             assert_eq!(
                 cfg.min_safe_capacity_required, cfg.initial_capacity,
                 "p={p}"
@@ -461,8 +593,8 @@ mod tests {
         // could fall below the balance needed to issue a ticket before a top-up fires.
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(p).unwrap();
-            let stake = capacity_stake(cfg.lower_capacity_threshold, price, cfg.assumed_hops);
+            let cfg = compute_funding_config(None, p).unwrap();
+            let stake = capacity_stake(cfg.lower_capacity_threshold, price, cfg.assumed_hops, p);
             assert!(
                 covers_face_values(stake, price, p, 1),
                 "p={p}, stake={stake}"
@@ -471,13 +603,18 @@ mod tests {
     }
 
     #[test]
-    fn compute_funding_config_uses_deterministic_sizing() {
-        // `capacity_stake` mirrors `capacity_to_balance` for this mode only; a change
-        // here silently breaks the balance recommendations.
-        let cfg = compute_funding_config(1.0).unwrap();
+    fn compute_funding_config_uses_probabilistic_sizing() {
+        // `capacity_stake` mirrors `capacity_to_balance` for whichever mode is set
+        // here; the two must not drift, or the balance recommendations under-report
+        // what the strategy actually locks.
+        let cfg = compute_funding_config(None, 1.0).unwrap();
         assert!(
-            matches!(cfg.sizing_mode, CapacitySizingMode::Deterministic),
-            "expected Deterministic, got {:?}",
+            matches!(
+                cfg.sizing_mode,
+                CapacitySizingMode::Probabilistic { success_probability }
+                    if success_probability == SIZING_SUCCESS_PROBABILITY
+            ),
+            "expected Probabilistic({SIZING_SUCCESS_PROBABILITY}), got {:?}",
             cfg.sizing_mode
         );
     }
@@ -488,8 +625,8 @@ mod tests {
         // 5 face values; the stake must still cover them at every win_prob.
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(p).unwrap();
-            let stake = capacity_stake(cfg.initial_capacity, price, cfg.assumed_hops);
+            let cfg = compute_funding_config(None, p).unwrap();
+            let stake = capacity_stake(cfg.initial_capacity, price, cfg.assumed_hops, p);
             assert!(
                 covers_face_values(stake, price, p, INITIAL_FACE_VALUES),
                 "p={p}, stake={stake}"
@@ -501,8 +638,8 @@ mod tests {
     fn funding_config_topup_stake_covers_face_values() {
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(p).unwrap();
-            let stake = capacity_stake(cfg.topup_capacity, price, cfg.assumed_hops);
+            let cfg = compute_funding_config(None, p).unwrap();
+            let stake = capacity_stake(cfg.topup_capacity, price, cfg.assumed_hops, p);
             assert!(
                 covers_face_values(stake, price, p, TOPUP_FACE_VALUES),
                 "p={p}, stake={stake}"
@@ -516,7 +653,7 @@ mod tests {
         // exact multiples keep `capacity_stake` an exact mirror of that conversion.
         let payload = packet_payload_size();
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(p).unwrap();
+            let cfg = compute_funding_config(None, p).unwrap();
             for cap in [
                 cfg.initial_capacity,
                 cfg.topup_capacity,
@@ -531,7 +668,7 @@ mod tests {
     #[test]
     fn funding_config_win_prob_one_matches_face_value_counts() {
         // Pins the pre-0.22 economics: 5 / 4 / 2 packets at win_prob = 1.
-        let cfg = compute_funding_config(1.0).unwrap();
+        let cfg = compute_funding_config(None, 1.0).unwrap();
         let payload = packet_payload_size();
         assert_eq!(cfg.initial_capacity.as_u64(), INITIAL_FACE_VALUES * payload);
         assert_eq!(cfg.topup_capacity.as_u64(), TOPUP_FACE_VALUES * payload);
@@ -543,10 +680,10 @@ mod tests {
 
     #[test]
     fn compute_funding_config_rejects_invalid_win_prob() {
-        assert!(compute_funding_config(0.0).is_err());
-        assert!(compute_funding_config(1.1).is_err());
-        assert!(compute_funding_config(f64::NAN).is_err());
-        assert!(compute_funding_config(f64::INFINITY).is_err());
+        assert!(compute_funding_config(None, 0.0).is_err());
+        assert!(compute_funding_config(None, 1.1).is_err());
+        assert!(compute_funding_config(None, f64::NAN).is_err());
+        assert!(compute_funding_config(None, f64::INFINITY).is_err());
     }
 
     #[test]
@@ -555,16 +692,158 @@ mod tests {
         // so 2⁻⁵² is the smallest value the chain can report. Its capacity exceeds
         // `u64::MAX` bytes and must be rejected rather than clamped — clamping makes
         // `lower < topup < initial` false and `min_safe` unfundable.
-        assert!(compute_funding_config(2f64.powi(-52)).is_err());
-        assert!(compute_funding_config(f64::MIN_POSITIVE).is_err());
+        assert!(compute_funding_config(None, 2f64.powi(-52)).is_err());
+        assert!(compute_funding_config(None, f64::MIN_POSITIVE).is_err());
     }
 
     #[test]
     fn compute_funding_config_smallest_usable_win_prob_keeps_ordering() {
         // One encoding step above the rejected value the config is still well formed.
-        let cfg = compute_funding_config(2f64.powi(-51)).unwrap();
+        let cfg = compute_funding_config(None, 2f64.powi(-51)).unwrap();
         assert!(cfg.lower_capacity_threshold < cfg.topup_capacity);
         assert!(cfg.topup_capacity < cfg.initial_capacity);
+    }
+
+    #[test]
+    fn channel_capacity_none_matches_face_value_capacities() {
+        // `None` must reproduce the face-value sizing verbatim: scaling from the initial
+        // capacity instead rounds differently and would silently shift the defaults for
+        // every caller that does not request a volume.
+        for p in WIN_PROBS {
+            let cfg = compute_funding_config(None, p).unwrap();
+            assert_eq!(
+                cfg.initial_capacity,
+                capacity_for_face_values(INITIAL_FACE_VALUES, p).unwrap(),
+                "p={p}"
+            );
+            assert_eq!(
+                cfg.topup_capacity,
+                capacity_for_face_values(TOPUP_FACE_VALUES, p).unwrap(),
+                "p={p}"
+            );
+            assert_eq!(
+                cfg.lower_capacity_threshold,
+                capacity_for_face_values(LOWER_THRESHOLD_FACE_VALUES, p).unwrap(),
+                "p={p}"
+            );
+        }
+    }
+
+    #[test]
+    fn channel_capacity_sizes_initial_and_keeps_proportions() {
+        // A requested volume drives the initial capacity; top-up and lower threshold
+        // keep the 4/5 and 2/5 proportions, each rounded up to a whole packet.
+        let payload = packet_payload_size();
+        let requested = ByteSize::mb(100);
+        let cfg = compute_funding_config(Some(requested), 1.0).unwrap();
+
+        let initial = cfg.initial_capacity.as_u64();
+        assert_eq!(initial, requested.as_u64().div_ceil(payload) * payload);
+        assert_eq!(cfg.min_safe_capacity_required, cfg.initial_capacity);
+
+        // Within one packet of the exact proportion (the alignment rounds up).
+        let expect = |numer: u64| ((initial as u128) * numer as u128 / 5u128) as u64;
+        assert!(cfg.topup_capacity.as_u64() - expect(4) < payload);
+        assert!(cfg.lower_capacity_threshold.as_u64() - expect(2) < payload);
+        assert!(cfg.lower_capacity_threshold < cfg.topup_capacity);
+        assert!(cfg.topup_capacity < cfg.initial_capacity);
+    }
+
+    #[test]
+    fn channel_capacity_below_face_value_floor_is_ignored() {
+        // A channel that cannot cover one winning ticket cannot relay, so a requested
+        // volume under the face-value floor must not shrink the capacities.
+        for p in WIN_PROBS {
+            let floored = compute_funding_config(Some(ByteSize::b(1)), p).unwrap();
+            let default = compute_funding_config(None, p).unwrap();
+            assert_eq!(floored.initial_capacity, default.initial_capacity, "p={p}");
+            assert_eq!(floored.topup_capacity, default.topup_capacity, "p={p}");
+            assert_eq!(
+                floored.lower_capacity_threshold, default.lower_capacity_threshold,
+                "p={p}"
+            );
+        }
+    }
+
+    #[test]
+    fn channel_capacity_keeps_ordering_across_win_probs() {
+        for p in WIN_PROBS {
+            for requested in [ByteSize::kb(1), ByteSize::mb(10), ByteSize::gb(1)] {
+                let cfg = compute_funding_config(Some(requested), p).unwrap();
+                assert!(
+                    cfg.lower_capacity_threshold < cfg.topup_capacity,
+                    "p={p}, requested={requested}"
+                );
+                assert!(
+                    cfg.topup_capacity < cfg.initial_capacity,
+                    "p={p}, requested={requested}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn balance_recommendation_tracks_requested_capacity() {
+        // Regression: the recommendation is derived from the same funding config the
+        // reactor runs on. If it ignored `channel_capacity` it would report the
+        // face-value stake while the strategy locked the requested-volume stake, and a
+        // node funded to the recommendation could never open a channel.
+        let price = HoprBalance::new_base(10);
+        for p in [1.0, 0.01, 0.001] {
+            let cfg = compute_funding_config(Some(ByteSize::mb(50)), p).unwrap();
+            let expected = capacity_stake(cfg.initial_capacity, price, cfg.assumed_hops, p);
+            let rec = compute_balance_recommendation(
+                price,
+                p,
+                1,
+                no_startup_costs(),
+                Some(ByteSize::mb(50)),
+            )
+            .unwrap();
+            assert_eq!(rec.channel_stakes, expected, "p={p}");
+
+            let default =
+                compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
+            assert!(
+                rec.channel_stakes > default.channel_stakes,
+                "p={p}: a 50 MB request must cost more than the face-value floor"
+            );
+        }
+    }
+
+    #[test]
+    fn capacity_stake_carries_the_variance_buffer() {
+        // Guards the mirror against silently collapsing back to the mean drain: below
+        // win_prob = 1 the Probabilistic term must add k·σ on top of N × hops × price.
+        let price = HoprBalance::new_base(10);
+        for p in [0.5, 0.1, 0.01, 0.001] {
+            let cfg = compute_funding_config(None, p).unwrap();
+            let packets = cfg.initial_capacity.as_u64() / packet_payload_size();
+            let mean_drain = price * packets * ASSUMED_HOPS as u64;
+            let stake = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, p);
+            assert!(
+                stake > mean_drain,
+                "p={p}: stake {stake} should exceed mean drain {mean_drain}"
+            );
+        }
+    }
+
+    #[test]
+    fn capacity_stake_at_win_prob_one_equals_mean_drain() {
+        // At win_prob = 1 the variance vanishes, so Probabilistic collapses onto
+        // Deterministic and the stake is exactly the mean drain.
+        let price = HoprBalance::new_base(10);
+        let cfg = compute_funding_config(None, 1.0).unwrap();
+        let packets = cfg.initial_capacity.as_u64() / packet_payload_size();
+        assert_eq!(
+            capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, 1.0),
+            price * packets * ASSUMED_HOPS as u64
+        );
+    }
+
+    #[test]
+    fn incentive_configuration_default_channel_capacity_is_none() {
+        assert!(IncentiveConfiguration::default().channel_capacity.is_none());
     }
 
     #[test]
@@ -572,12 +851,13 @@ mod tests {
         // The recommendation must equal what the strategy locks, never less.
         for price in [HoprBalance::new_base(10), HoprBalance::from(100u32)] {
             for p in [1.0, 0.01, 0.001] {
-                let cfg = compute_funding_config(p).unwrap();
-                let expected = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS);
-                let one = compute_balance_recommendation(price, p, 1, no_startup_costs()).unwrap();
+                let cfg = compute_funding_config(None, p).unwrap();
+                let expected = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, p);
+                let one =
+                    compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
                 assert_eq!(one.channel_stakes, expected, "price={price}, p={p}");
                 let eight =
-                    compute_balance_recommendation(price, p, 8, no_startup_costs()).unwrap();
+                    compute_balance_recommendation(price, p, 8, no_startup_costs(), None).unwrap();
                 assert_eq!(
                     eight.channel_stakes,
                     expected * 8u64,
@@ -592,9 +872,11 @@ mod tests {
         // `stop_when_unfunded` blocks every open below min_safe_capacity_required.
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(p).unwrap();
-            let min_safe = capacity_stake(cfg.min_safe_capacity_required, price, cfg.assumed_hops);
-            let rec = compute_balance_recommendation(price, p, 1, no_startup_costs()).unwrap();
+            let cfg = compute_funding_config(None, p).unwrap();
+            let min_safe =
+                capacity_stake(cfg.min_safe_capacity_required, price, cfg.assumed_hops, p);
+            let rec =
+                compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
             assert!(rec.channel_stakes >= min_safe, "p={p}");
         }
     }
@@ -602,7 +884,7 @@ mod tests {
     #[test]
     fn compute_funding_config_default_sizing_has_one_strategy_shape() {
         // Smoke-test: can build a MultiStrategyConfig from compute_funding_config output
-        let funding = compute_funding_config(1.0).unwrap();
+        let funding = compute_funding_config(None, 1.0).unwrap();
         let lifecycle_cfg = ChannelLifecycleConfig {
             funding,
             ..Default::default()
@@ -627,9 +909,14 @@ mod tests {
 
     #[test]
     fn compute_balance_recommendation_zero_missing_returns_zero_wxhopr() {
-        let rec =
-            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 0, no_startup_costs())
-                .unwrap();
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            0,
+            no_startup_costs(),
+            None,
+        )
+        .unwrap();
         assert_eq!(rec.total_wxhopr(), HoprBalance::zero());
         assert_eq!(rec.xdai_fee_per_tx, *hopr_lib::SUGGESTED_NATIVE_BALANCE);
     }
@@ -647,6 +934,7 @@ mod tests {
                 fee_to_start: fee,
                 txs_to_start: 3,
             },
+            None,
         )
         .unwrap();
         // stake per channel = ticket_price × INITIAL_FACE_VALUES at win_prob = 1
@@ -670,6 +958,7 @@ mod tests {
                 fee_to_start: fee,
                 txs_to_start: 2,
             },
+            None,
         )
         .unwrap();
         assert_eq!(rec.channel_stakes, HoprBalance::zero());
@@ -681,9 +970,14 @@ mod tests {
     #[test]
     fn compute_balance_recommendation_scales_by_missing_channels() {
         // win_prob=1.0, ticket_price=10, hops=1: stake = 10 × 5 face values; 8 channels
-        let rec =
-            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 8, no_startup_costs())
-                .unwrap();
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            8,
+            no_startup_costs(),
+            None,
+        )
+        .unwrap();
         let per_channel = HoprBalance::new_base(10) * 5u64;
         assert_eq!(rec.channel_stakes, per_channel * 8u64);
         assert_eq!(rec.fee_to_start, HoprBalance::zero());
@@ -693,23 +987,44 @@ mod tests {
     }
 
     #[test]
-    fn compute_balance_recommendation_halved_win_prob_doubles_stake() {
-        // The derived capacity is ceil(INITIAL_FACE_VALUES / win_prob) packets, so
-        // halving win_prob doubles the packet count and with it the stake.
-        let full =
-            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 1, no_startup_costs())
-                .unwrap();
-        let half =
-            compute_balance_recommendation(HoprBalance::new_base(10), 0.5, 1, no_startup_costs())
-                .unwrap();
-        assert_eq!(half.channel_stakes, full.channel_stakes * 2u64);
+    fn compute_balance_recommendation_halved_win_prob_more_than_doubles_stake() {
+        // The derived capacity is ceil(INITIAL_FACE_VALUES / win_prob) packets, so halving
+        // win_prob doubles the mean drain. Probabilistic sizing adds k·σ on top and σ grows
+        // as 1/√p, so the stake must rise by strictly more than that factor of two.
+        let full = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            1,
+            no_startup_costs(),
+            None,
+        )
+        .unwrap();
+        let half = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            0.5,
+            1,
+            no_startup_costs(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            half.channel_stakes > full.channel_stakes * 2u64,
+            "expected more than 2x, got {} vs {}",
+            half.channel_stakes,
+            full.channel_stakes
+        );
     }
 
     #[test]
     fn compute_balance_recommendation_zero_target_yields_zero() {
-        let rec =
-            compute_balance_recommendation(HoprBalance::new_base(10), 1.0, 0, no_startup_costs())
-                .unwrap();
+        let rec = compute_balance_recommendation(
+            HoprBalance::new_base(10),
+            1.0,
+            0,
+            no_startup_costs(),
+            None,
+        )
+        .unwrap();
         assert_eq!(rec.total_wxhopr(), HoprBalance::zero());
     }
 

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -19,6 +19,10 @@ const ASSUMED_HOPS: u32 = 1;
 /// The strategy's own default is a fixed volume that does not track a requested one, so a
 /// larger request would otherwise clear the gate on a Safe that cannot then top the
 /// channel up. Twice covers the channel and its first top-up.
+///
+/// Applied as a floor *alongside* that default, not in place of it: the gate is the larger
+/// of the two, so a small request cannot lower it below what the strategy would have
+/// required on its own.
 const MIN_SAFE_MULTIPLE: u64 = 2;
 
 /// Confidence level the channel stake is sized for.
@@ -94,10 +98,11 @@ pub struct IncentiveConfiguration {
     ///
     /// # Funding is all-or-nothing
     ///
-    /// Raising this also raises the balance below which the node refuses to operate — the
-    /// safe gate tracks it at [`MIN_SAFE_MULTIPLE`]. Under `stop_when_unfunded`, a Safe
-    /// below that gate opens **zero** channels, not smaller ones and not fewer. Size to a
-    /// volume the Safe is funded for; [`minimum_balance_recommendation`] reports it.
+    /// Raising this also raises the balance below which the node refuses to operate. The
+    /// safe gate is the larger of [`MIN_SAFE_MULTIPLE`] × this volume and the strategy's
+    /// own default, so a small request does not lower it. Under `stop_when_unfunded`, a
+    /// Safe below that gate opens **zero** channels, not smaller ones and not fewer — read
+    /// the figure off [`minimum_balance_recommendation`] rather than deriving it here.
     ///
     /// Default: `None` — the strategy's own initial capacity.
     #[default(None)]

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -46,6 +46,24 @@ const MIN_SAFE_FRACTION: (u64, u64) = (5, 4);
 /// enough headroom to carry the configured capacity in 99% of fund cycles.
 const SIZING_SUCCESS_PROBABILITY: f64 = 0.99;
 
+/// Range `hopr_strategy` accepts for a `Probabilistic` success probability.
+///
+/// Its `validate_sizing_mode` rejects anything outside these bounds, and
+/// `capacity_to_balance` clamps to them. [`capacity_stake`] mirrors that clamp, so the
+/// bounds are repeated here to keep the mirror faithful rather than to validate input —
+/// [`SIZING_SUCCESS_PROBABILITY`] is asserted into the range below, which makes the
+/// clamp a provable no-op instead of something that could silently rewrite a bad value.
+const SIZING_PROBABILITY_BOUNDS: (f64, f64) = (0.5001, 0.99999);
+
+// A `SIZING_SUCCESS_PROBABILITY` outside the accepted range would otherwise be clamped
+// at runtime, silently sizing channels for a confidence nobody asked for. Fail the build
+// instead.
+const _: () = assert!(
+    SIZING_SUCCESS_PROBABILITY >= SIZING_PROBABILITY_BOUNDS.0
+        && SIZING_SUCCESS_PROBABILITY <= SIZING_PROBABILITY_BOUNDS.1,
+    "SIZING_SUCCESS_PROBABILITY must lie within the range hopr-strategy accepts"
+);
+
 /// The mode every capacity in [`compute_funding_config`] resolves through.
 ///
 /// Deliberately *not* exposed on [`IncentiveConfiguration`]: [`capacity_stake`] mirrors
@@ -157,20 +175,22 @@ fn capacity_for_face_values(face_values: u64, win_prob: f64) -> anyhow::Result<B
 /// exact multiple keeps [`capacity_stake`] an exact mirror of that conversion.
 fn packet_aligned(bytes: u64) -> anyhow::Result<ByteSize> {
     let payload = packet_payload_size();
-    let packets = bytes.div_ceil(payload).max(1);
-    let bytes = packets
+    let aligned = bytes
+        .div_ceil(payload)
+        .max(1)
         .checked_mul(payload)
         .ok_or_else(|| anyhow::anyhow!("capacity of {bytes} bytes overflows u64 when aligned"))?;
-    Ok(ByteSize::b(bytes))
+    Ok(ByteSize::b(aligned))
 }
 
 /// `capacity × numer / denom`, rounded up to a whole number of packets.
 fn scale_capacity(capacity: ByteSize, (numer, denom): (u64, u64)) -> anyhow::Result<ByteSize> {
-    let scaled = (capacity.as_u64() as u128) * (numer as u128) / (denom as u128);
-    packet_aligned(
-        u64::try_from(scaled)
-            .map_err(|_| anyhow::anyhow!("scaled capacity overflows u64 bytes"))?,
-    )
+    // u128 keeps the product exact; only the result has to fit back into a byte count.
+    let scaled = u128::from(capacity.as_u64()) * u128::from(numer) / u128::from(denom);
+    let scaled = u64::try_from(scaled).map_err(|_| {
+        anyhow::anyhow!("scaling {capacity} by {numer}/{denom} overflows u64 bytes")
+    })?;
+    packet_aligned(scaled)
 }
 
 /// wxHOPR the strategy locks for a channel funded to `capacity`.
@@ -209,8 +229,8 @@ fn capacity_stake(
             success_probability,
         } => {
             use statrs::distribution::{ContinuousCDF, Normal};
-            let alpha = success_probability.clamp(0.5001, 0.99999);
-            let k = Normal::standard().inverse_cdf(alpha);
+            let (lower, upper) = SIZING_PROBABILITY_BOUNDS;
+            let k = Normal::standard().inverse_cdf(success_probability.clamp(lower, upper));
             // σ[D] = tp·h × √(N(1−p)/p) — see `CapacitySizingMode::Probabilistic`.
             let sigma = price * h * (n * (1.0 - p) / p).sqrt();
             mean_drain + k * sigma

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -24,6 +24,18 @@ const TOPUP_FACE_VALUES: u64 = 4;
 /// tickets keep being issued while the top-up confirms.
 const LOWER_THRESHOLD_FACE_VALUES: u64 = 2;
 
+/// Top-up capacity as a fraction of the initial capacity: half the channel back.
+const TOPUP_FRACTION: (u64, u64) = (1, 2);
+
+/// Lower threshold as a fraction of the initial capacity. A top-up fires once the
+/// channel has spent three quarters of what it was funded with.
+const LOWER_THRESHOLD_FRACTION: (u64, u64) = (1, 4);
+
+/// Safe balance required before a channel is opened, as a fraction of the initial
+/// capacity. Always a quarter above it, so a freshly opened channel still has room
+/// in the Safe for its first top-up rather than stranding on the funding gate.
+const MIN_SAFE_FRACTION: (u64, u64) = (5, 4);
+
 /// Confidence level the channel stake is sized for.
 ///
 /// [`CapacitySizingMode::Deterministic`] sizes a channel to the *mean* drain, so its
@@ -82,13 +94,13 @@ pub struct IncentiveConfiguration {
     /// Data volume a single channel should be able to carry before it needs a top-up.
     ///
     /// This is the only sizing input a caller supplies — the funding capacities, the
-    /// sizing mode, and the resulting stakes are all derived from it. Top-up and
-    /// lower-threshold capacities keep the same proportions to the requested volume
-    /// that the face-value defaults use (`4/5` and `2/5`).
+    /// sizing mode, and the resulting stakes are all derived from it. The top-up
+    /// capacity is half this volume and the lower threshold a quarter of it, while the
+    /// Safe balance required to open a channel sits a quarter above it.
     ///
-    /// Raising the volume only ever raises a capacity: every field stays floored at its
-    /// face-value minimum, because a channel that cannot cover one winning ticket
-    /// cannot relay at all. Requesting less than that floor therefore has no effect.
+    /// Raising the volume only ever raises a capacity: top-up and lower threshold stay
+    /// floored at their face-value minimums, because a channel that cannot cover one
+    /// winning ticket cannot relay at all. Requesting less than that floor has no effect.
     ///
     /// Default: `None` — size to [`INITIAL_FACE_VALUES`] face values, the smallest
     /// stake that keeps ticket issuance running.
@@ -153,7 +165,7 @@ fn packet_aligned(bytes: u64) -> anyhow::Result<ByteSize> {
 }
 
 /// `capacity × numer / denom`, rounded up to a whole number of packets.
-fn scale_capacity(capacity: ByteSize, numer: u64, denom: u64) -> anyhow::Result<ByteSize> {
+fn scale_capacity(capacity: ByteSize, (numer, denom): (u64, u64)) -> anyhow::Result<ByteSize> {
     let scaled = (capacity.as_u64() as u128) * (numer as u128) / (denom as u128);
     packet_aligned(
         u64::try_from(scaled)
@@ -215,10 +227,14 @@ fn capacity_stake(
 /// probability.
 ///
 /// `channel_capacity` is the data volume one channel should carry before needing a
-/// top-up; `None` sizes it to [`INITIAL_FACE_VALUES`] ticket face values. Top-up and
-/// lower-threshold capacities keep the `4/5` and `2/5` proportions of the initial
-/// capacity, and every field is floored at its face-value minimum — below one face
-/// value no ticket can be issued at all.
+/// top-up; `None` sizes it to [`INITIAL_FACE_VALUES`] ticket face values. The remaining
+/// capacities are fractions of that initial capacity — [`TOPUP_FRACTION`] and
+/// [`LOWER_THRESHOLD_FRACTION`] — with [`MIN_SAFE_FRACTION`] always a quarter above it.
+///
+/// Top-up and lower threshold are additionally floored at their face-value minimums:
+/// below one face value no ticket can be issued at all. At the default sizing those
+/// floors dominate the fractions, so requesting no volume reproduces the previous
+/// `5 / 4 / 2` face-value capacities exactly.
 ///
 /// All capacities resolve through [`SIZING_MODE`], which [`capacity_stake`] mirrors.
 pub fn compute_funding_config(
@@ -229,47 +245,40 @@ pub fn compute_funding_config(
     let face_topup = capacity_for_face_values(TOPUP_FACE_VALUES, win_prob)?;
     let face_lower = capacity_for_face_values(LOWER_THRESHOLD_FACE_VALUES, win_prob)?;
 
-    // With no requested volume the face-value capacities are used verbatim; scaling
-    // them instead would round differently and shift the long-standing defaults.
-    let (initial_capacity, topup_capacity, lower_capacity_threshold) = match channel_capacity {
-        None => (face_initial, face_topup, face_lower),
-        Some(requested) => {
-            let initial = packet_aligned(requested.as_u64())?.max(face_initial);
-            let topup =
-                scale_capacity(initial, TOPUP_FACE_VALUES, INITIAL_FACE_VALUES)?.max(face_topup);
-            let lower = scale_capacity(initial, LOWER_THRESHOLD_FACE_VALUES, INITIAL_FACE_VALUES)?
-                .max(face_lower);
-            (initial, topup, lower)
-        }
+    let initial_capacity = match channel_capacity {
+        None => face_initial,
+        Some(requested) => packet_aligned(requested.as_u64())?.max(face_initial),
     };
 
     Ok(FundingConfig {
         initial_capacity,
-        topup_capacity,
-        lower_capacity_threshold,
-        min_safe_capacity_required: initial_capacity,
+        topup_capacity: scale_capacity(initial_capacity, TOPUP_FRACTION)?.max(face_topup),
+        lower_capacity_threshold: scale_capacity(initial_capacity, LOWER_THRESHOLD_FRACTION)?
+            .max(face_lower),
+        min_safe_capacity_required: scale_capacity(initial_capacity, MIN_SAFE_FRACTION)?,
         assumed_hops: ASSUMED_HOPS,
         stop_when_unfunded: true,
         sizing_mode: SIZING_MODE,
     })
 }
 
-/// wxHOPR a single new channel's initial stake locks.
+/// wxHOPR the Safe must hold to fund `missing_channels` new channels.
 ///
-/// Read off [`compute_funding_config`] so the recommendation cannot drift from
-/// what the strategy locks.
-fn initial_channel_stake(
+/// Read off [`compute_funding_config`] so the recommendation cannot drift from what
+/// the strategy locks. `stop_when_unfunded` blocks every open while the Safe holds
+/// less than `min_safe_capacity_required`, so the recommendation is raised to that
+/// gate — otherwise a node funded to exactly `missing × initial` would sit at the
+/// threshold and never open its first channel.
+fn channel_stakes(
     ticket_price: HoprBalance,
     win_prob: f64,
     channel_capacity: Option<ByteSize>,
+    missing_channels: usize,
 ) -> anyhow::Result<HoprBalance> {
     let funding = compute_funding_config(channel_capacity, win_prob)?;
-    Ok(capacity_stake(
-        funding.initial_capacity,
-        ticket_price,
-        funding.assumed_hops,
-        win_prob,
-    ))
+    let stake = |capacity| capacity_stake(capacity, ticket_price, funding.assumed_hops, win_prob);
+    let total = stake(funding.initial_capacity) * (missing_channels as u64);
+    Ok(total.max(stake(funding.min_safe_capacity_required)))
 }
 
 /// One-time costs still owed before this node can be fully up and running,
@@ -364,7 +373,7 @@ pub(crate) fn compute_balance_recommendation(
     let stake = if missing_channels == 0 {
         HoprBalance::zero()
     } else {
-        initial_channel_stake(ticket_price, win_prob, channel_capacity)? * (missing_channels as u64)
+        channel_stakes(ticket_price, win_prob, channel_capacity, missing_channels)?
     };
     Ok(BalanceRecommendation {
         channel_stakes: stake,
@@ -567,23 +576,26 @@ mod tests {
             cfg.initial_capacity.as_u64(),
             (INITIAL_FACE_VALUES as f64 / 0.001).ceil() as u64 * payload
         );
-        assert_eq!(cfg.min_safe_capacity_required, cfg.initial_capacity);
+        assert_eq!(
+            cfg.min_safe_capacity_required,
+            scale_capacity(cfg.initial_capacity, MIN_SAFE_FRACTION).unwrap()
+        );
         assert_eq!(cfg.assumed_hops, ASSUMED_HOPS);
         assert!(cfg.stop_when_unfunded);
     }
 
     #[test]
     fn compute_funding_config_proportional_fields() {
-        // Verify lower < topup < initial and min_safe == initial at every win_prob;
-        // the per-field ceil could otherwise invert the ordering.
+        // Verify lower < topup < initial < min_safe at every win_prob; the per-field
+        // ceil could otherwise invert the ordering.
         for p in WIN_PROBS {
             let cfg = compute_funding_config(None, p).unwrap();
-            assert_eq!(
-                cfg.min_safe_capacity_required, cfg.initial_capacity,
-                "p={p}"
-            );
             assert!(cfg.lower_capacity_threshold < cfg.topup_capacity, "p={p}");
             assert!(cfg.topup_capacity < cfg.initial_capacity, "p={p}");
+            assert!(
+                cfg.min_safe_capacity_required > cfg.initial_capacity,
+                "p={p}: the Safe gate must sit above one channel's initial capacity"
+            );
         }
     }
 
@@ -731,22 +743,29 @@ mod tests {
 
     #[test]
     fn channel_capacity_sizes_initial_and_keeps_proportions() {
-        // A requested volume drives the initial capacity; top-up and lower threshold
-        // keep the 4/5 and 2/5 proportions, each rounded up to a whole packet.
+        // A requested volume drives the initial capacity; the rest are fractions of it —
+        // half for the top-up, a quarter for the threshold, and a quarter *above* for the
+        // Safe gate. Each is rounded up to a whole packet.
         let payload = packet_payload_size();
         let requested = ByteSize::mb(100);
         let cfg = compute_funding_config(Some(requested), 1.0).unwrap();
 
         let initial = cfg.initial_capacity.as_u64();
         assert_eq!(initial, requested.as_u64().div_ceil(payload) * payload);
-        assert_eq!(cfg.min_safe_capacity_required, cfg.initial_capacity);
 
-        // Within one packet of the exact proportion (the alignment rounds up).
-        let expect = |numer: u64| ((initial as u128) * numer as u128 / 5u128) as u64;
-        assert!(cfg.topup_capacity.as_u64() - expect(4) < payload);
-        assert!(cfg.lower_capacity_threshold.as_u64() - expect(2) < payload);
+        // Within one packet of the exact fraction (the alignment rounds up).
+        let expect =
+            |(numer, denom): (u64, u64)| ((initial as u128) * numer as u128 / denom as u128) as u64;
+        assert!(cfg.topup_capacity.as_u64() - expect(TOPUP_FRACTION) < payload);
+        assert!(cfg.lower_capacity_threshold.as_u64() - expect(LOWER_THRESHOLD_FRACTION) < payload);
+        assert!(
+            cfg.min_safe_capacity_required.as_u64() - expect(MIN_SAFE_FRACTION) < payload,
+            "min_safe must be a quarter above the initial capacity"
+        );
+
         assert!(cfg.lower_capacity_threshold < cfg.topup_capacity);
         assert!(cfg.topup_capacity < cfg.initial_capacity);
+        assert!(cfg.initial_capacity < cfg.min_safe_capacity_required);
     }
 
     #[test]
@@ -791,7 +810,9 @@ mod tests {
         let price = HoprBalance::new_base(10);
         for p in [1.0, 0.01, 0.001] {
             let cfg = compute_funding_config(Some(ByteSize::mb(50)), p).unwrap();
-            let expected = capacity_stake(cfg.initial_capacity, price, cfg.assumed_hops, p);
+            // One channel: the Safe gate dominates `1 × initial`.
+            let expected =
+                capacity_stake(cfg.min_safe_capacity_required, price, cfg.assumed_hops, p);
             let rec = compute_balance_recommendation(
                 price,
                 p,
@@ -848,19 +869,24 @@ mod tests {
 
     #[test]
     fn balance_recommendation_matches_strategy_initial_stake() {
-        // The recommendation must equal what the strategy locks, never less.
+        // The recommendation must equal what the strategy locks, never less: `missing ×
+        // initial`, raised to the Safe gate when a single channel would fall under it.
         for price in [HoprBalance::new_base(10), HoprBalance::from(100u32)] {
             for p in [1.0, 0.01, 0.001] {
                 let cfg = compute_funding_config(None, p).unwrap();
-                let expected = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, p);
+                let per_channel = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, p);
+                let min_safe =
+                    capacity_stake(cfg.min_safe_capacity_required, price, ASSUMED_HOPS, p);
+
                 let one =
                     compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
-                assert_eq!(one.channel_stakes, expected, "price={price}, p={p}");
+                assert_eq!(one.channel_stakes, min_safe, "price={price}, p={p}");
+
                 let eight =
                     compute_balance_recommendation(price, p, 8, no_startup_costs(), None).unwrap();
                 assert_eq!(
                     eight.channel_stakes,
-                    expected * 8u64,
+                    per_channel * 8u64,
                     "price={price}, p={p}"
                 );
             }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
 
 use bytesize::ByteSize;
+use hopr_lib::api::node::PacketTransport;
 use hopr_lib::api::types::primitive::prelude::{
-    Address, HoprBalance, U256, UnitaryFloatOps as _, XDaiBalance,
+    Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
 };
 pub use hopr_strategy::channel_lifecycle::{
     CapacitySizingMode, ChannelLifecycleConfig, EligibilityConfig, FundingConfig, PopulationConfig,
-    SelectorProfile,
+    ResolvedFunding, SelectorProfile,
 };
 
 /// Paid downstream relay hops assumed when sizing a channel's stake. Edge nodes
@@ -49,10 +50,9 @@ const SIZING_SUCCESS_PROBABILITY: f64 = 0.99;
 /// Range `hopr_strategy` accepts for a `Probabilistic` success probability.
 ///
 /// Its `validate_sizing_mode` rejects anything outside these bounds, and
-/// `capacity_to_balance` clamps to them. [`capacity_stake`] mirrors that clamp, so the
-/// bounds are repeated here to keep the mirror faithful rather than to validate input —
-/// [`SIZING_SUCCESS_PROBABILITY`] is asserted into the range below, which makes the
-/// clamp a provable no-op instead of something that could silently rewrite a bad value.
+/// `capacity_to_balance` silently clamps to them. Restated here only so the assertion
+/// below can reject an out-of-range [`SIZING_SUCCESS_PROBABILITY`] at build time,
+/// rather than letting the strategy quietly size channels for a different confidence.
 const SIZING_PROBABILITY_BOUNDS: (f64, f64) = (0.5001, 0.99999);
 
 // A `SIZING_SUCCESS_PROBABILITY` outside the accepted range would otherwise be clamped
@@ -66,10 +66,9 @@ const _: () = assert!(
 
 /// The mode every capacity in [`compute_funding_config`] resolves through.
 ///
-/// Deliberately *not* exposed on [`IncentiveConfiguration`]: [`capacity_stake`] mirrors
-/// this exact mode to derive balance recommendations, so a caller overriding it on the
-/// returned [`FundingConfig`] would silently desync the recommendation from the stake
-/// the strategy actually locks.
+/// Deliberately *not* exposed on [`IncentiveConfiguration`]. The reactor and the balance
+/// recommendations must agree on the mode, and a caller able to override it on the
+/// returned [`FundingConfig`] could set one without the other.
 const SIZING_MODE: CapacitySizingMode = CapacitySizingMode::Probabilistic {
     success_probability: SIZING_SUCCESS_PROBABILITY,
 };
@@ -179,8 +178,8 @@ fn capacity_for_face_values(face_values: u64, win_prob: f64) -> anyhow::Result<B
 
 /// Rounds `bytes` up to a whole number of packets.
 ///
-/// The strategy divides every capacity by the packet payload and rounds up, so an
-/// exact multiple keeps [`capacity_stake`] an exact mirror of that conversion.
+/// The strategy divides every capacity by the packet payload and rounds up, so an exact
+/// multiple keeps a capacity's packet count stable through that conversion.
 fn packet_aligned(bytes: u64) -> anyhow::Result<ByteSize> {
     let payload = packet_payload_size();
     let aligned = bytes
@@ -201,59 +200,35 @@ fn scale_capacity(capacity: ByteSize, (numer, denom): (u64, u64)) -> anyhow::Res
     packet_aligned(scaled)
 }
 
-/// wxHOPR the strategy locks for a channel funded to `capacity`.
+/// Supplies the packet payload size to the strategy's funding resolution.
 ///
-/// Mirrors the strategy's crate-private `capacity_to_balance` for [`SIZING_MODE`],
-/// including the one-winning-ticket floor. Kept in lockstep with
-/// [`compute_funding_config`] so a balance recommendation cannot drift from the stake the
-/// strategy actually locks.
-///
-/// The mirror is faithful rather than exact: it reproduces the strategy's own `f64`
-/// pipeline step for step, `low_u128()` narrowing and all, so both sides round
-/// identically. Fixing the rounding on this side alone would *introduce* a mismatch —
-/// any change here has to land upstream in the same commit.
-fn capacity_stake(
-    capacity: ByteSize,
-    ticket_price: HoprBalance,
-    hops: u32,
-    win_prob: f64,
-) -> HoprBalance {
-    let bytes = capacity.as_u64();
-    if bytes == 0 {
-        return HoprBalance::zero();
+/// [`FundingConfig::resolve`] is generic over the transport purely to read
+/// [`PacketTransport::packet_payload_size`]; this forwards the same value
+/// [`packet_payload_size`] uses, so capacities and balances divide by one number.
+struct EdgePacketTransport;
+
+impl PacketTransport for EdgePacketTransport {
+    fn packet_payload_size() -> usize {
+        self::packet_payload_size() as usize
     }
+}
 
-    let n = bytes.div_ceil(packet_payload_size()) as f64;
-    // Same clamp the strategy applies: a zero or NaN win_prob would send the
-    // one-ticket floor to infinity and saturate the stake.
-    let p = if win_prob.is_nan() {
-        f64::EPSILON
-    } else {
-        win_prob.clamp(f64::EPSILON, 1.0_f64)
-    };
-    let h = hops as f64;
-    let price = ticket_price.amount().low_u128() as f64;
-
-    // Mean drain E[D] = N × h × tp, independent of p.
-    let mean_drain = n * h * price;
-    let target = match SIZING_MODE {
-        CapacitySizingMode::Deterministic => mean_drain,
-        CapacitySizingMode::Probabilistic {
-            success_probability,
-        } => {
-            use statrs::distribution::{ContinuousCDF, Normal};
-            let (lower, upper) = SIZING_PROBABILITY_BOUNDS;
-            let k = Normal::standard().inverse_cdf(success_probability.clamp(lower, upper));
-            // σ[D] = tp·h × √(N(1−p)/p) — see `CapacitySizingMode::Probabilistic`.
-            let sigma = price * h * (n * (1.0 - p) / p).sqrt();
-            mean_drain + k * sigma
-        }
-    };
-
-    // One-winning-ticket floor: below a full-path face value no ticket can issue.
-    let floor = price * h / p;
-    let stake = target.max(floor).max(0.0);
-    HoprBalance::from(U256::from(stake.ceil() as u128))
+/// The wxHOPR the strategy resolves `funding` to at the current ticket economics.
+///
+/// Delegates to the strategy's own [`FundingConfig::resolve`] rather than reproducing
+/// the capacity-to-balance conversion. A local reimplementation keeps compiling after
+/// the formula changes upstream and then reports figures the strategy does not agree
+/// with — and because `min_safe_balance_required` gates opening at all under
+/// `stop_when_unfunded`, reporting low leaves a node unable to open a single channel.
+///
+/// Honours whichever [`CapacitySizingMode`] `funding` carries, so this tracks
+/// [`SIZING_MODE`] without restating it.
+fn resolve_funding(
+    funding: &FundingConfig,
+    ticket_price: HoprBalance,
+    win_prob: f64,
+) -> ResolvedFunding {
+    funding.resolve::<EdgePacketTransport>(ticket_price, win_prob)
 }
 
 /// Capacity-based [`FundingConfig`] for a requested transfer volume and winning
@@ -269,7 +244,8 @@ fn capacity_stake(
 /// floors dominate the fractions, so requesting no volume reproduces the previous
 /// `5 / 4 / 2` face-value capacities exactly.
 ///
-/// All capacities resolve through [`SIZING_MODE`], which [`capacity_stake`] mirrors.
+/// All capacities resolve through [`SIZING_MODE`]; [`resolve_funding`] turns them into
+/// the wxHOPR the strategy will lock.
 pub fn compute_funding_config(
     channel_capacity: Option<ByteSize>,
     win_prob: f64,
@@ -309,9 +285,9 @@ fn channel_stakes(
     missing_channels: usize,
 ) -> anyhow::Result<HoprBalance> {
     let funding = compute_funding_config(channel_capacity, win_prob)?;
-    let stake = |capacity| capacity_stake(capacity, ticket_price, funding.assumed_hops, win_prob);
-    let total = stake(funding.initial_capacity) * (missing_channels as u64);
-    Ok(total.max(stake(funding.min_safe_capacity_required)))
+    let resolved = resolve_funding(&funding, ticket_price, win_prob);
+    let total = resolved.initial_balance * (missing_channels as u64);
+    Ok(total.max(resolved.min_safe_balance_required))
 }
 
 /// One-time costs still owed before this node can be fully up and running,
@@ -643,7 +619,7 @@ mod tests {
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
             let cfg = compute_funding_config(None, p).unwrap();
-            let stake = capacity_stake(cfg.lower_capacity_threshold, price, cfg.assumed_hops, p);
+            let stake = resolve_funding(&cfg, price, p).lower_balance_threshold;
             assert!(
                 covers_face_values(stake, price, p, 1),
                 "p={p}, stake={stake}"
@@ -653,9 +629,8 @@ mod tests {
 
     #[test]
     fn compute_funding_config_uses_probabilistic_sizing() {
-        // `capacity_stake` mirrors `capacity_to_balance` for whichever mode is set
-        // here; the two must not drift, or the balance recommendations under-report
-        // what the strategy actually locks.
+        // `resolve_funding` asks the strategy to resolve whichever mode is set here, so
+        // this pins the mode itself rather than any restatement of its arithmetic.
         let cfg = compute_funding_config(None, 1.0).unwrap();
         assert!(
             matches!(
@@ -675,7 +650,7 @@ mod tests {
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
             let cfg = compute_funding_config(None, p).unwrap();
-            let stake = capacity_stake(cfg.initial_capacity, price, cfg.assumed_hops, p);
+            let stake = resolve_funding(&cfg, price, p).initial_balance;
             assert!(
                 covers_face_values(stake, price, p, INITIAL_FACE_VALUES),
                 "p={p}, stake={stake}"
@@ -688,7 +663,7 @@ mod tests {
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
             let cfg = compute_funding_config(None, p).unwrap();
-            let stake = capacity_stake(cfg.topup_capacity, price, cfg.assumed_hops, p);
+            let stake = resolve_funding(&cfg, price, p).topup_balance;
             assert!(
                 covers_face_values(stake, price, p, TOPUP_FACE_VALUES),
                 "p={p}, stake={stake}"
@@ -699,7 +674,7 @@ mod tests {
     #[test]
     fn funding_config_capacities_are_exact_packet_multiples() {
         // The strategy divides each capacity by the packet payload and rounds up;
-        // exact multiples keep `capacity_stake` an exact mirror of that conversion.
+        // exact multiples keep the resolved packet count stable.
         let payload = packet_payload_size();
         for p in WIN_PROBS {
             let cfg = compute_funding_config(None, p).unwrap();
@@ -862,8 +837,7 @@ mod tests {
         for p in [1.0, 0.01, 0.001] {
             let cfg = compute_funding_config(Some(ByteSize::mb(50)), p).unwrap();
             // One channel: the Safe gate dominates `1 × initial`.
-            let expected =
-                capacity_stake(cfg.min_safe_capacity_required, price, cfg.assumed_hops, p);
+            let expected = resolve_funding(&cfg, price, p).min_safe_balance_required;
             let rec = compute_balance_recommendation(
                 price,
                 p,
@@ -884,7 +858,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_stake_carries_the_variance_buffer() {
+    fn resolved_stake_carries_the_variance_buffer() {
         // Guards the mirror against silently collapsing back to the mean drain: below
         // win_prob = 1 the Probabilistic term must add k·σ on top of N × hops × price.
         let price = HoprBalance::new_base(10);
@@ -892,7 +866,7 @@ mod tests {
             let cfg = compute_funding_config(None, p).unwrap();
             let packets = cfg.initial_capacity.as_u64() / packet_payload_size();
             let mean_drain = price * packets * ASSUMED_HOPS as u64;
-            let stake = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, p);
+            let stake = resolve_funding(&cfg, price, p).initial_balance;
             assert!(
                 stake > mean_drain,
                 "p={p}: stake {stake} should exceed mean drain {mean_drain}"
@@ -901,14 +875,14 @@ mod tests {
     }
 
     #[test]
-    fn capacity_stake_at_win_prob_one_equals_mean_drain() {
+    fn resolved_stake_at_win_prob_one_equals_mean_drain() {
         // At win_prob = 1 the variance vanishes, so Probabilistic collapses onto
         // Deterministic and the stake is exactly the mean drain.
         let price = HoprBalance::new_base(10);
         let cfg = compute_funding_config(None, 1.0).unwrap();
         let packets = cfg.initial_capacity.as_u64() / packet_payload_size();
         assert_eq!(
-            capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, 1.0),
+            resolve_funding(&cfg, price, 1.0).initial_balance,
             price * packets * ASSUMED_HOPS as u64
         );
     }
@@ -925,9 +899,8 @@ mod tests {
         for price in [HoprBalance::new_base(10), HoprBalance::from(100u32)] {
             for p in [1.0, 0.01, 0.001] {
                 let cfg = compute_funding_config(None, p).unwrap();
-                let per_channel = capacity_stake(cfg.initial_capacity, price, ASSUMED_HOPS, p);
-                let min_safe =
-                    capacity_stake(cfg.min_safe_capacity_required, price, ASSUMED_HOPS, p);
+                let per_channel = resolve_funding(&cfg, price, p).initial_balance;
+                let min_safe = resolve_funding(&cfg, price, p).min_safe_balance_required;
 
                 let one =
                     compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
@@ -950,8 +923,7 @@ mod tests {
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
             let cfg = compute_funding_config(None, p).unwrap();
-            let min_safe =
-                capacity_stake(cfg.min_safe_capacity_required, price, cfg.assumed_hops, p);
+            let min_safe = resolve_funding(&cfg, price, p).min_safe_balance_required;
             let rec =
                 compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
             assert!(rec.channel_stakes >= min_safe, "p={p}");

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use bytesize::ByteSize;
 use hopr_lib::api::node::PacketTransport;
+use hopr_lib::api::types::internal::routing::RoutingOptions;
 use hopr_lib::api::types::primitive::prelude::{
     Address, HoprBalance, UnitaryFloatOps as _, XDaiBalance,
 };
@@ -10,9 +11,16 @@ pub use hopr_strategy::channel_lifecycle::{
     ResolvedFunding, SelectorProfile,
 };
 
-/// Paid downstream relay hops assumed when sizing a channel's stake. Edge nodes
-/// route over a single hop by default, so a channel's tickets pay one relay.
-const ASSUMED_HOPS: u32 = 1;
+/// Paid downstream relay hops a ticket's face value covers.
+///
+/// Fixed at the protocol's maximum path length rather than the single hop an edge node
+/// typically routes over: the node issuing a ticket cannot know how long a path the packet
+/// will take, so a face value assuming fewer hops cannot pay for a longer one.
+///
+/// `hopr-strategy` sizes stakes from this same constant. Reading it from the protocol here
+/// rather than restating a number keeps [`compute_capacity`] from reporting more payable
+/// tickets than a stake actually covers.
+const ASSUMED_HOPS: u32 = RoutingOptions::MAX_INTERMEDIATE_HOPS as u32;
 
 /// Safe capacity required before a channel opens, as a multiple of the initial capacity.
 ///
@@ -174,7 +182,6 @@ pub fn compute_funding_config(channel_capacity: Option<ByteSize>) -> anyhow::Res
     Ok(FundingConfig {
         initial_capacity,
         min_safe_capacity_required: ByteSize::b(min_safe).max(defaults.min_safe_capacity_required),
-        assumed_hops: ASSUMED_HOPS,
         stop_when_unfunded: true,
         sizing_mode: SIZING_MODE,
         ..defaults
@@ -252,12 +259,14 @@ pub enum CapacityAllocator {
 pub struct Capacity {
     /// wxHOPR stake — locked balance for channels, unallocated balance for the Safe.
     pub stake: HoprBalance,
-    /// Expected long-run session-frame count: `floor(stake / ticket_price)`.
+    /// Expected long-run session-frame count: `floor(stake / (ticket_price × ASSUMED_HOPS))`.
     ///
-    /// `ticket_price` is the *expected* per-hop drain (= `face_value × win_prob`),
-    /// so this figure is win_prob-independent — it reflects average lifetime throughput.
+    /// `ticket_price × ASSUMED_HOPS` is the *expected* per-message drain
+    /// (= `face_value × win_prob`), so this figure is win_prob-independent — it reflects
+    /// average lifetime throughput.
     pub expected_messages: u64,
-    /// Worst-case floor: `floor(stake / face_value)` = `floor(stake × win_prob / ticket_price)`.
+    /// Worst-case floor: `floor(stake / face_value)`, where
+    /// `face_value = ticket_price × ASSUMED_HOPS / win_prob`.
     ///
     /// Reflects the maximum number of tickets the channel can hold simultaneously
     /// before balance drops below one face value and ticket issuance halts.
@@ -312,16 +321,22 @@ pub(crate) fn compute_capacity(
         win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
         "win_prob must be in (0, 1]; got {win_prob}"
     );
-    let expected_messages = if ticket_price == HoprBalance::zero() {
+    // Both counts are per *message*, and a message pays `ASSUMED_HOPS` relays: it issues one
+    // aggregated ticket of face value `ticket_price × ASSUMED_HOPS / win_prob`, whose expected
+    // cost is `ticket_price × ASSUMED_HOPS`. Measuring either against the bare ticket price
+    // would report `ASSUMED_HOPS`× more messages than the stake can actually pay for — and the
+    // strategy funds and gates on the same hop count, so the two must agree.
+    let per_message_drain = ticket_price * ASSUMED_HOPS as u64;
+    let expected_messages = if per_message_drain == HoprBalance::zero() {
         0u64
     } else {
         // Clamp to u64::MAX before converting so astronomically large quotients
         // saturate rather than truncate via low_u64().
-        let quotient = stake.amount() / ticket_price.amount();
+        let quotient = stake.amount() / per_message_drain.amount();
         quotient.min(u64::MAX.into()).low_u64()
     };
-    // face_value = ticket_price / win_prob — minimum balance locked per outstanding ticket.
-    let face_value = ticket_price.div_f64(win_prob)?;
+    // face_value = ticket_price × ASSUMED_HOPS / win_prob — balance locked per outstanding ticket.
+    let face_value = per_message_drain.div_f64(win_prob)?;
     let min_guaranteed_messages = if face_value == HoprBalance::zero() {
         0u64
     } else {
@@ -528,7 +543,6 @@ mod tests {
             "expected Probabilistic({SIZING_SUCCESS_PROBABILITY}), got {:?}",
             cfg.sizing_mode
         );
-        assert_eq!(cfg.assumed_hops, ASSUMED_HOPS);
         assert!(cfg.stop_when_unfunded);
     }
 
@@ -542,7 +556,7 @@ mod tests {
             .initial_capacity
             .as_u64()
             .div_ceil(packet_payload_size());
-        let mean_drain = price * packets * cfg.assumed_hops as u64;
+        let mean_drain = price * packets * ASSUMED_HOPS as u64;
         for p in [0.5, 0.1, 0.01, 0.001] {
             let stake = resolve_funding(&cfg, price, p).initial_balance;
             assert!(
@@ -567,7 +581,7 @@ mod tests {
             .div_ceil(packet_payload_size());
         assert_eq!(
             resolve_funding(&cfg, price, 1.0).initial_balance,
-            price * packets * cfg.assumed_hops as u64
+            price * packets * ASSUMED_HOPS as u64
         );
     }
 
@@ -797,12 +811,28 @@ mod tests {
 
     #[test]
     fn compute_capacity_basic_arithmetic() {
+        // A message pays ASSUMED_HOPS (3) relays, so it drains 10 × 3 = 30 per message:
+        // expected = 900 / 30 = 30, and at win_prob = 1 the face value is the same 30.
         let cap =
-            compute_capacity(HoprBalance::new_base(1000), HoprBalance::new_base(10), 1.0).unwrap();
-        assert_eq!(cap.expected_messages, 100);
-        assert_eq!(cap.min_guaranteed_messages, 100);
-        assert_eq!(cap.byte_capacity, 100 * hopr_lib::SESSION_MTU as u64);
-        assert_eq!(cap.stake, HoprBalance::new_base(1000));
+            compute_capacity(HoprBalance::new_base(900), HoprBalance::new_base(10), 1.0).unwrap();
+        assert_eq!(cap.expected_messages, 30);
+        assert_eq!(cap.min_guaranteed_messages, 30);
+        assert_eq!(cap.byte_capacity, 30 * hopr_lib::SESSION_MTU as u64);
+        assert_eq!(cap.stake, HoprBalance::new_base(900));
+    }
+
+    /// The hop factor must be the one the strategy funds with, or a stake reports more
+    /// payable messages than it can cover and the funding-issue checks under-report.
+    #[test]
+    fn compute_capacity_counts_every_paid_hop() {
+        let price = HoprBalance::new_base(10);
+        let stake = price * 30u64;
+        let cap = compute_capacity(stake, price, 1.0).unwrap();
+        assert_eq!(
+            cap.expected_messages,
+            30 / ASSUMED_HOPS as u64,
+            "a message must be charged for all {ASSUMED_HOPS} paid hops"
+        );
     }
 
     #[test]
@@ -824,30 +854,31 @@ mod tests {
 
     #[test]
     fn compute_capacity_win_prob_one_matches_expected() {
-        // win_prob=1.0 → face_value = ticket_price → min_guaranteed == expected
+        // win_prob=1.0 → face_value = per-message drain → min_guaranteed == expected
+        // 300 / (10 × 3 hops) = 10
         let cap =
             compute_capacity(HoprBalance::new_base(300), HoprBalance::new_base(10), 1.0).unwrap();
-        assert_eq!(cap.expected_messages, 30);
-        assert_eq!(cap.min_guaranteed_messages, 30);
+        assert_eq!(cap.expected_messages, 10);
+        assert_eq!(cap.min_guaranteed_messages, 10);
     }
 
     #[test]
     fn compute_capacity_win_prob_half_halves_guaranteed() {
-        // stake=100, ticket_price=10, win_prob=0.5
-        // expected  = 100/10 = 10
-        // face_value = 10/0.5 = 20 → min_guaranteed = 100/20 = 5
+        // stake=600, ticket_price=10, 3 hops, win_prob=0.5
+        // expected   = 600 / (10 × 3) = 20
+        // face_value = 30 / 0.5 = 60 → min_guaranteed = 600 / 60 = 10
         let cap =
-            compute_capacity(HoprBalance::new_base(100), HoprBalance::new_base(10), 0.5).unwrap();
-        assert_eq!(cap.expected_messages, 10);
-        assert_eq!(cap.min_guaranteed_messages, 5);
+            compute_capacity(HoprBalance::new_base(600), HoprBalance::new_base(10), 0.5).unwrap();
+        assert_eq!(cap.expected_messages, 20);
+        assert_eq!(cap.min_guaranteed_messages, 10);
     }
 
     #[test]
     fn compute_capacity_win_prob_small_floors_guaranteed_to_zero() {
-        // stake=10, ticket_price=10, win_prob=0.5
-        // face_value = 10/0.5 = 20 > stake → min_guaranteed = 0; expected = 1
+        // stake=40, ticket_price=10, 3 hops, win_prob=0.5
+        // face_value = 30 / 0.5 = 60 > stake → min_guaranteed = 0; expected = 40 / 30 = 1
         let cap =
-            compute_capacity(HoprBalance::new_base(10), HoprBalance::new_base(10), 0.5).unwrap();
+            compute_capacity(HoprBalance::new_base(40), HoprBalance::new_base(10), 0.5).unwrap();
         assert_eq!(cap.expected_messages, 1);
         assert_eq!(cap.min_guaranteed_messages, 0);
     }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -14,50 +14,29 @@ pub use hopr_strategy::channel_lifecycle::{
 /// route over a single hop by default, so a channel's tickets pay one relay.
 const ASSUMED_HOPS: u32 = 1;
 
-/// Ticket face values (`ticket_price × ASSUMED_HOPS / win_prob`) a new channel's
-/// stake must cover. A ticket cannot be issued for more than the channel balance.
-const INITIAL_FACE_VALUES: u64 = 5;
-
-/// Face values a top-up adds back. Keeps `lower < topup < initial`.
-const TOPUP_FACE_VALUES: u64 = 4;
-
-/// Face values the balance may decay to before a top-up triggers. Above one so
-/// tickets keep being issued while the top-up confirms.
-const LOWER_THRESHOLD_FACE_VALUES: u64 = 2;
-
-/// Top-up capacity as a fraction of the initial capacity: half the channel back.
-const TOPUP_FRACTION: (u64, u64) = (1, 2);
-
-/// Lower threshold as a fraction of the initial capacity. A top-up fires once the
-/// channel has spent three quarters of what it was funded with.
-const LOWER_THRESHOLD_FRACTION: (u64, u64) = (1, 4);
-
-/// Safe balance required before a channel is opened, as a fraction of the initial
-/// capacity. Always a quarter above it, so a freshly opened channel still has room
-/// in the Safe for its first top-up rather than stranding on the funding gate.
-const MIN_SAFE_FRACTION: (u64, u64) = (5, 4);
+/// Safe capacity required before a channel opens, as a multiple of the initial capacity.
+///
+/// The strategy's own default is a fixed volume that does not track a requested one, so a
+/// larger request would otherwise clear the gate on a Safe that cannot then top the
+/// channel up. Twice covers the channel and its first top-up.
+const MIN_SAFE_MULTIPLE: u64 = 2;
 
 /// Confidence level the channel stake is sized for.
 ///
-/// [`CapacitySizingMode::Deterministic`] sizes a channel to the *mean* drain, so its
-/// lower threshold bottoms out near a single ticket face value. Payouts are lumpy —
-/// the number of winning tickets is `Binomial(N, win_prob)` — so a channel resting on
-/// that floor starves: it cannot issue the next ticket and relaying stalls until a
-/// top-up confirms. Sizing for 99% adds `k·σ` (`k = Φ⁻¹(0.99) ≈ 2.33`) above the mean,
-/// enough headroom to carry the configured capacity in 99% of fund cycles.
+/// [`CapacitySizingMode::Deterministic`] sizes to the *mean* drain, leaving the lower
+/// threshold near one ticket face value. Payouts are lumpy (winning tickets are
+/// `Binomial(N, win_prob)`), so a channel resting there starves — it cannot issue the
+/// next ticket, and relaying stalls until a top-up confirms. 99% adds `k·σ`
+/// (`k = Φ⁻¹(0.99) ≈ 2.33`) above the mean.
 const SIZING_SUCCESS_PROBABILITY: f64 = 0.99;
 
-/// Range `hopr_strategy` accepts for a `Probabilistic` success probability.
-///
-/// Its `validate_sizing_mode` rejects anything outside these bounds, and
-/// `capacity_to_balance` silently clamps to them. Restated here only so the assertion
-/// below can reject an out-of-range [`SIZING_SUCCESS_PROBABILITY`] at build time,
-/// rather than letting the strategy quietly size channels for a different confidence.
+/// Range `hopr_strategy` accepts for a `Probabilistic` success probability, which it
+/// silently clamps to. Restated here only so the assertion below can reject an
+/// out-of-range [`SIZING_SUCCESS_PROBABILITY`] at build time.
 const SIZING_PROBABILITY_BOUNDS: (f64, f64) = (0.5001, 0.99999);
 
-// A `SIZING_SUCCESS_PROBABILITY` outside the accepted range would otherwise be clamped
-// at runtime, silently sizing channels for a confidence nobody asked for. Fail the build
-// instead.
+// Out of range would otherwise be clamped at runtime, sizing channels for a confidence
+// nobody asked for. Fail the build instead.
 const _: () = assert!(
     SIZING_SUCCESS_PROBABILITY >= SIZING_PROBABILITY_BOUNDS.0
         && SIZING_SUCCESS_PROBABILITY <= SIZING_PROBABILITY_BOUNDS.1,
@@ -108,27 +87,19 @@ pub struct IncentiveConfiguration {
     #[default(None)]
     pub channel_allowlist: Option<HashSet<Address>>,
 
-    /// Data volume a single channel should be able to carry before it needs a top-up.
+    /// Data volume a single channel should carry before it needs a top-up.
     ///
-    /// This is the only sizing input a caller supplies — the funding capacities, the
-    /// sizing mode, and the resulting stakes are all derived from it. The top-up
-    /// capacity is half this volume and the lower threshold a quarter of it, while the
-    /// Safe balance required to open a channel sits a quarter above it.
-    ///
-    /// Raising the volume only ever raises a capacity: top-up and lower threshold stay
-    /// floored at their face-value minimums, because a channel that cannot cover one
-    /// winning ticket cannot relay at all. Requesting less than that floor has no effect.
+    /// The only sizing input a caller supplies. It becomes the strategy's initial
+    /// capacity as given; top-up and lower threshold keep the strategy's own defaults.
     ///
     /// # Funding is all-or-nothing
     ///
-    /// This also raises the balance below which the node refuses to operate. The strategy
-    /// runs with `stop_when_unfunded`, so a Safe holding less than the derived
-    /// `min_safe_capacity_required` opens **zero** channels — it does not open a smaller
-    /// channel, and it does not open fewer of them. Size this to a volume the Safe is
-    /// actually funded for; [`minimum_balance_recommendation`] reports the figure needed.
+    /// Raising this also raises the balance below which the node refuses to operate — the
+    /// safe gate tracks it at [`MIN_SAFE_MULTIPLE`]. Under `stop_when_unfunded`, a Safe
+    /// below that gate opens **zero** channels, not smaller ones and not fewer. Size to a
+    /// volume the Safe is funded for; [`minimum_balance_recommendation`] reports it.
     ///
-    /// Default: `None` — size to [`INITIAL_FACE_VALUES`] face values, the smallest
-    /// stake that keeps ticket issuance running.
+    /// Default: `None` — the strategy's own initial capacity.
     #[default(None)]
     pub channel_capacity: Option<ByteSize>,
 }
@@ -151,60 +122,10 @@ fn packet_payload_size() -> u64 {
     hopr_lib::exports::transport::PACKET_PAYLOAD_SIZE as u64
 }
 
-/// Data capacity whose resolved stake covers `face_values` ticket face values.
-///
-/// An exact packet multiple, so the strategy's `ceil` reproduces the packet count.
-/// Errors rather than clamping when a tiny `win_prob` overflows the byte count:
-/// clamped capacities compare equal, breaking `lower < topup < initial`.
-fn capacity_for_face_values(face_values: u64, win_prob: f64) -> anyhow::Result<ByteSize> {
-    anyhow::ensure!(
-        win_prob.is_finite() && win_prob > 0.0 && win_prob <= 1.0,
-        "win_prob must be in (0, 1]; got {win_prob}"
-    );
-    let packets = (face_values as f64 / win_prob).ceil();
-    anyhow::ensure!(
-        packets <= u64::MAX as f64,
-        "win_prob {win_prob} needs more than u64::MAX packets for {face_values} face values"
-    );
-    let bytes = (packets as u64)
-        .checked_mul(packet_payload_size())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "capacity for {face_values} face values at win_prob {win_prob} overflows u64 bytes"
-            )
-        })?;
-    Ok(ByteSize::b(bytes))
-}
-
-/// Rounds `bytes` up to a whole number of packets.
-///
-/// The strategy divides every capacity by the packet payload and rounds up, so an exact
-/// multiple keeps a capacity's packet count stable through that conversion.
-fn packet_aligned(bytes: u64) -> anyhow::Result<ByteSize> {
-    let payload = packet_payload_size();
-    let aligned = bytes
-        .div_ceil(payload)
-        .max(1)
-        .checked_mul(payload)
-        .ok_or_else(|| anyhow::anyhow!("capacity of {bytes} bytes overflows u64 when aligned"))?;
-    Ok(ByteSize::b(aligned))
-}
-
-/// `capacity × numer / denom`, rounded up to a whole number of packets.
-fn scale_capacity(capacity: ByteSize, (numer, denom): (u64, u64)) -> anyhow::Result<ByteSize> {
-    // u128 keeps the product exact; only the result has to fit back into a byte count.
-    let scaled = u128::from(capacity.as_u64()) * u128::from(numer) / u128::from(denom);
-    let scaled = u64::try_from(scaled).map_err(|_| {
-        anyhow::anyhow!("scaling {capacity} by {numer}/{denom} overflows u64 bytes")
-    })?;
-    packet_aligned(scaled)
-}
-
 /// Supplies the packet payload size to the strategy's funding resolution.
 ///
-/// [`FundingConfig::resolve`] is generic over the transport purely to read
-/// [`PacketTransport::packet_payload_size`]; this forwards the same value
-/// [`packet_payload_size`] uses, so capacities and balances divide by one number.
+/// [`FundingConfig::resolve`] is generic over the transport purely to read this value;
+/// forwarding [`packet_payload_size`] keeps capacities and balances on one number.
 struct EdgePacketTransport;
 
 impl PacketTransport for EdgePacketTransport {
@@ -215,14 +136,12 @@ impl PacketTransport for EdgePacketTransport {
 
 /// The wxHOPR the strategy resolves `funding` to at the current ticket economics.
 ///
-/// Delegates to the strategy's own [`FundingConfig::resolve`] rather than reproducing
-/// the capacity-to-balance conversion. A local reimplementation keeps compiling after
-/// the formula changes upstream and then reports figures the strategy does not agree
-/// with — and because `min_safe_balance_required` gates opening at all under
-/// `stop_when_unfunded`, reporting low leaves a node unable to open a single channel.
-///
-/// Honours whichever [`CapacitySizingMode`] `funding` carries, so this tracks
-/// [`SIZING_MODE`] without restating it.
+/// Delegates to [`FundingConfig::resolve`] rather than reproducing the
+/// capacity-to-balance conversion: a local copy keeps compiling after the formula changes
+/// upstream, then reports figures the strategy disagrees with — and since
+/// `min_safe_balance_required` gates opening under `stop_when_unfunded`, reporting low
+/// leaves a node unable to open any channel. Honours whichever [`CapacitySizingMode`]
+/// `funding` carries, so it tracks [`SIZING_MODE`] without restating it.
 fn resolve_funding(
     funding: &FundingConfig,
     ticket_price: HoprBalance,
@@ -231,60 +150,44 @@ fn resolve_funding(
     funding.resolve::<EdgePacketTransport>(ticket_price, win_prob)
 }
 
-/// Capacity-based [`FundingConfig`] for a requested transfer volume and winning
-/// probability.
+/// [`FundingConfig`] for a requested transfer volume.
 ///
-/// `channel_capacity` is the data volume one channel should carry before needing a
-/// top-up; `None` sizes it to [`INITIAL_FACE_VALUES`] ticket face values. The remaining
-/// capacities are fractions of that initial capacity — [`TOPUP_FRACTION`] and
-/// [`LOWER_THRESHOLD_FRACTION`] — with [`MIN_SAFE_FRACTION`] always a quarter above it.
+/// `channel_capacity` is the volume one channel should carry before a top-up. It is the
+/// only field set from it; the rest keep the strategy's own defaults, which now fill in
+/// on partial input. `min_safe_capacity_required` is the exception — see
+/// [`MIN_SAFE_MULTIPLE`].
 ///
-/// Top-up and lower threshold are additionally floored at their face-value minimums:
-/// below one face value no ticket can be issued at all. At the default sizing those
-/// floors dominate the fractions, so requesting no volume reproduces the previous
-/// `5 / 4 / 2` face-value capacities exactly.
-///
-/// All capacities resolve through [`SIZING_MODE`]; [`resolve_funding`] turns them into
-/// the wxHOPR the strategy will lock.
-pub fn compute_funding_config(
-    channel_capacity: Option<ByteSize>,
-    win_prob: f64,
-) -> anyhow::Result<FundingConfig> {
-    let face_initial = capacity_for_face_values(INITIAL_FACE_VALUES, win_prob)?;
-    let face_topup = capacity_for_face_values(TOPUP_FACE_VALUES, win_prob)?;
-    let face_lower = capacity_for_face_values(LOWER_THRESHOLD_FACE_VALUES, win_prob)?;
-
-    let initial_capacity = match channel_capacity {
-        None => face_initial,
-        Some(requested) => packet_aligned(requested.as_u64())?.max(face_initial),
-    };
+/// All resolve through [`SIZING_MODE`]; [`resolve_funding`] converts them to wxHOPR.
+pub fn compute_funding_config(channel_capacity: Option<ByteSize>) -> anyhow::Result<FundingConfig> {
+    let defaults = FundingConfig::default();
+    let initial_capacity = channel_capacity.unwrap_or(defaults.initial_capacity);
+    let min_safe = initial_capacity
+        .as_u64()
+        .checked_mul(MIN_SAFE_MULTIPLE)
+        .ok_or_else(|| anyhow::anyhow!("{initial_capacity} × {MIN_SAFE_MULTIPLE} overflows u64"))?;
 
     Ok(FundingConfig {
         initial_capacity,
-        topup_capacity: scale_capacity(initial_capacity, TOPUP_FRACTION)?.max(face_topup),
-        lower_capacity_threshold: scale_capacity(initial_capacity, LOWER_THRESHOLD_FRACTION)?
-            .max(face_lower),
-        min_safe_capacity_required: scale_capacity(initial_capacity, MIN_SAFE_FRACTION)?,
+        min_safe_capacity_required: ByteSize::b(min_safe).max(defaults.min_safe_capacity_required),
         assumed_hops: ASSUMED_HOPS,
         stop_when_unfunded: true,
         sizing_mode: SIZING_MODE,
+        ..defaults
     })
 }
 
 /// wxHOPR the Safe must hold to fund `missing_channels` new channels.
 ///
-/// Read off [`compute_funding_config`] so the recommendation cannot drift from what
-/// the strategy locks. `stop_when_unfunded` blocks every open while the Safe holds
-/// less than `min_safe_capacity_required`, so the recommendation is raised to that
-/// gate — otherwise a node funded to exactly `missing × initial` would sit at the
-/// threshold and never open its first channel.
+/// Raised to `min_safe_balance_required`, which `stop_when_unfunded` gates every open on:
+/// a node funded to exactly `missing × initial` would sit at the threshold and never open
+/// its first channel.
 fn channel_stakes(
     ticket_price: HoprBalance,
     win_prob: f64,
     channel_capacity: Option<ByteSize>,
     missing_channels: usize,
 ) -> anyhow::Result<HoprBalance> {
-    let funding = compute_funding_config(channel_capacity, win_prob)?;
+    let funding = compute_funding_config(channel_capacity)?;
     let resolved = resolve_funding(&funding, ticket_price, win_prob);
     let total = resolved.initial_balance * (missing_channels as u64);
     Ok(total.max(resolved.min_safe_balance_required))
@@ -497,24 +400,15 @@ pub async fn minimum_balance_recommendation(
 
 /// Returns the default [`MultiStrategyConfig`] for an edge client reactor.
 ///
-/// Reads the winning probability from the chain to size the funding config; see
-/// [`compute_funding_config`]. Read once, so later changes are not tracked.
-#[cfg(feature = "runtime-tokio")]
-pub async fn default_strategy_cfg(
-    node: &crate::client::Edgli,
+/// Takes no chain reading: the capacities are the requested volume and the strategy's own
+/// defaults, and the winning probability only enters when the strategy resolves them to
+/// balances each tick — so this tracks a changing win prob rather than pinning it.
+pub fn default_strategy_cfg(
     sizing: &IncentiveConfiguration,
 ) -> anyhow::Result<MultiStrategyConfig> {
-    use hopr_lib::api::node::HasChainApi as _;
-
     sizing.validate()?;
-    let win_prob = node
-        .chain_api()
-        .minimum_incoming_ticket_win_prob()
-        .await?
-        .as_f64();
-    let funding = compute_funding_config(sizing.channel_capacity, win_prob)?;
+    let funding = compute_funding_config(sizing.channel_capacity)?;
     tracing::info!(
-        win_prob,
         requested_capacity = ?sizing.channel_capacity,
         initial_capacity = %funding.initial_capacity,
         topup_capacity = %funding.topup_capacity,
@@ -523,7 +417,7 @@ pub async fn default_strategy_cfg(
         lower_capacity_threshold = %funding.lower_capacity_threshold,
         min_safe_capacity_required = %funding.min_safe_capacity_required,
         sizing_mode = ?funding.sizing_mode,
-        "channel-lifecycle funding sized from live winning probability"
+        "channel-lifecycle funding configured"
     );
     let cfg = ChannelLifecycleConfig {
         funding,
@@ -560,78 +454,66 @@ mod tests {
     /// Winning probabilities spanning the range the network may run at.
     const WIN_PROBS: [f64; 6] = [1.0, 0.5, 0.1, 0.01, 0.001, 0.0001];
 
-    /// One ticket's face value, computed as the ticket factory does.
-    fn face_value(ticket_price: HoprBalance, win_prob: f64) -> HoprBalance {
-        (ticket_price * ASSUMED_HOPS as u64)
-            .div_f64(win_prob)
-            .unwrap()
-    }
-
-    /// Whether `stake` covers `count` ticket face values.
-    ///
-    /// The 1e-6 slack absorbs `div_f64` rounding a few parts in 1e13 upward; it is
-    /// far below one face value, so an under-funded stake still fails.
-    fn covers_face_values(
-        stake: HoprBalance,
-        ticket_price: HoprBalance,
-        win_prob: f64,
-        count: u64,
-    ) -> bool {
-        let required = face_value(ticket_price, win_prob) * count;
-        stake * 1_000_000u64 >= required * 999_999u64
+    #[test]
+    fn funding_config_uses_the_requested_capacity_verbatim() {
+        // The requested volume is the only field taken from the caller, and it is passed
+        // through as-is: no rounding, no floor, no conversion.
+        let requested = ByteSize::mb(100);
+        let cfg = compute_funding_config(Some(requested)).unwrap();
+        assert_eq!(cfg.initial_capacity, requested);
     }
 
     #[test]
-    fn compute_funding_config_capacity_is_a_whole_number_of_packets() {
-        let cfg = compute_funding_config(None, 0.001).unwrap();
-        let payload = packet_payload_size();
+    fn funding_config_falls_back_to_the_strategy_default_capacity() {
+        let cfg = compute_funding_config(None).unwrap();
         assert_eq!(
-            cfg.initial_capacity.as_u64(),
-            (INITIAL_FACE_VALUES as f64 / 0.001).ceil() as u64 * payload
+            cfg.initial_capacity,
+            FundingConfig::default().initial_capacity
         );
-        assert_eq!(
-            cfg.min_safe_capacity_required,
-            scale_capacity(cfg.initial_capacity, MIN_SAFE_FRACTION).unwrap()
-        );
-        assert_eq!(cfg.assumed_hops, ASSUMED_HOPS);
-        assert!(cfg.stop_when_unfunded);
     }
 
     #[test]
-    fn compute_funding_config_proportional_fields() {
-        // Verify lower < topup < initial < min_safe at every win_prob; the per-field
-        // ceil could otherwise invert the ordering.
-        for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
-            assert!(cfg.lower_capacity_threshold < cfg.topup_capacity, "p={p}");
-            assert!(cfg.topup_capacity < cfg.initial_capacity, "p={p}");
-            assert!(
-                cfg.min_safe_capacity_required > cfg.initial_capacity,
-                "p={p}: the Safe gate must sit above one channel's initial capacity"
+    fn funding_config_defers_topup_and_lower_threshold_to_the_strategy() {
+        // Everything except the initial capacity and the safe gate is the strategy's own
+        // default, so this crate carries no second opinion on how a channel is funded.
+        let defaults = FundingConfig::default();
+        for requested in [None, Some(ByteSize::mb(50)), Some(ByteSize::gib(4))] {
+            let cfg = compute_funding_config(requested).unwrap();
+            assert_eq!(cfg.topup_capacity, defaults.topup_capacity, "{requested:?}");
+            assert_eq!(
+                cfg.lower_capacity_threshold, defaults.lower_capacity_threshold,
+                "{requested:?}"
             );
         }
     }
 
     #[test]
-    fn compute_funding_config_lower_threshold_stays_above_one_face_value() {
-        // The top-up threshold must stay above one face value, otherwise the channel
-        // could fall below the balance needed to issue a ticket before a top-up fires.
-        let price = HoprBalance::new_base(10);
-        for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
-            let stake = resolve_funding(&cfg, price, p).lower_balance_threshold;
+    fn funding_config_min_safe_covers_at_least_two_channels() {
+        // The strategy's default gate is a fixed volume that does not track the request,
+        // so a larger request would otherwise clear it on a safe that cannot then top the
+        // channel up.
+        for requested in [None, Some(ByteSize::mb(1)), Some(ByteSize::gib(4))] {
+            let cfg = compute_funding_config(requested).unwrap();
             assert!(
-                covers_face_values(stake, price, p, 1),
-                "p={p}, stake={stake}"
+                cfg.min_safe_capacity_required.as_u64()
+                    >= cfg.initial_capacity.as_u64() * MIN_SAFE_MULTIPLE,
+                "{requested:?}: {} < 2 x {}",
+                cfg.min_safe_capacity_required,
+                cfg.initial_capacity
             );
         }
     }
 
     #[test]
-    fn compute_funding_config_uses_probabilistic_sizing() {
+    fn funding_config_rejects_a_capacity_that_overflows_the_safe_gate() {
+        assert!(compute_funding_config(Some(ByteSize::b(u64::MAX))).is_err());
+    }
+
+    #[test]
+    fn funding_config_uses_probabilistic_sizing() {
         // `resolve_funding` asks the strategy to resolve whichever mode is set here, so
         // this pins the mode itself rather than any restatement of its arithmetic.
-        let cfg = compute_funding_config(None, 1.0).unwrap();
+        let cfg = compute_funding_config(None).unwrap();
         assert!(
             matches!(
                 cfg.sizing_mode,
@@ -641,231 +523,22 @@ mod tests {
             "expected Probabilistic({SIZING_SUCCESS_PROBABILITY}), got {:?}",
             cfg.sizing_mode
         );
-    }
-
-    #[test]
-    fn funding_config_initial_stake_covers_face_values() {
-        // Regression: under the pre-#17 face-value model a 5-packet capacity locked
-        // 5 face values; the stake must still cover them at every win_prob.
-        let price = HoprBalance::new_base(10);
-        for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
-            let stake = resolve_funding(&cfg, price, p).initial_balance;
-            assert!(
-                covers_face_values(stake, price, p, INITIAL_FACE_VALUES),
-                "p={p}, stake={stake}"
-            );
-        }
-    }
-
-    #[test]
-    fn funding_config_topup_stake_covers_face_values() {
-        let price = HoprBalance::new_base(10);
-        for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
-            let stake = resolve_funding(&cfg, price, p).topup_balance;
-            assert!(
-                covers_face_values(stake, price, p, TOPUP_FACE_VALUES),
-                "p={p}, stake={stake}"
-            );
-        }
-    }
-
-    #[test]
-    fn funding_config_capacities_are_exact_packet_multiples() {
-        // The strategy divides each capacity by the packet payload and rounds up;
-        // exact multiples keep the resolved packet count stable.
-        let payload = packet_payload_size();
-        for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
-            for cap in [
-                cfg.initial_capacity,
-                cfg.topup_capacity,
-                cfg.lower_capacity_threshold,
-                cfg.min_safe_capacity_required,
-            ] {
-                assert_eq!(cap.as_u64() % payload, 0, "p={p}, cap={cap}");
-            }
-        }
-    }
-
-    #[test]
-    fn funding_config_win_prob_one_matches_face_value_counts() {
-        // Pins the pre-0.22 economics: 5 / 4 / 2 packets at win_prob = 1.
-        let cfg = compute_funding_config(None, 1.0).unwrap();
-        let payload = packet_payload_size();
-        assert_eq!(cfg.initial_capacity.as_u64(), INITIAL_FACE_VALUES * payload);
-        assert_eq!(cfg.topup_capacity.as_u64(), TOPUP_FACE_VALUES * payload);
-        assert_eq!(
-            cfg.lower_capacity_threshold.as_u64(),
-            LOWER_THRESHOLD_FACE_VALUES * payload
-        );
-    }
-
-    #[test]
-    fn compute_funding_config_rejects_invalid_win_prob() {
-        assert!(compute_funding_config(None, 0.0).is_err());
-        assert!(compute_funding_config(None, 1.1).is_err());
-        assert!(compute_funding_config(None, f64::NAN).is_err());
-        assert!(compute_funding_config(None, f64::INFINITY).is_err());
-    }
-
-    #[test]
-    fn compute_funding_config_rejects_capacity_overflow() {
-        // `WinningProbability` encodes into 7 bytes and `as_f64` yields `k × 2⁻⁵²`,
-        // so 2⁻⁵² is the smallest value the chain can report. Its capacity exceeds
-        // `u64::MAX` bytes and must be rejected rather than clamped — clamping makes
-        // `lower < topup < initial` false and `min_safe` unfundable.
-        assert!(compute_funding_config(None, 2f64.powi(-52)).is_err());
-        assert!(compute_funding_config(None, f64::MIN_POSITIVE).is_err());
-    }
-
-    #[test]
-    fn compute_funding_config_smallest_usable_win_prob_keeps_ordering() {
-        // One encoding step above the rejected value the config is still well formed.
-        let cfg = compute_funding_config(None, 2f64.powi(-51)).unwrap();
-        assert!(cfg.lower_capacity_threshold < cfg.topup_capacity);
-        assert!(cfg.topup_capacity < cfg.initial_capacity);
-    }
-
-    #[test]
-    fn channel_capacity_none_matches_face_value_capacities() {
-        // `None` must reproduce the face-value sizing verbatim: scaling from the initial
-        // capacity instead rounds differently and would silently shift the defaults for
-        // every caller that does not request a volume.
-        for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
-            assert_eq!(
-                cfg.initial_capacity,
-                capacity_for_face_values(INITIAL_FACE_VALUES, p).unwrap(),
-                "p={p}"
-            );
-            assert_eq!(
-                cfg.topup_capacity,
-                capacity_for_face_values(TOPUP_FACE_VALUES, p).unwrap(),
-                "p={p}"
-            );
-            assert_eq!(
-                cfg.lower_capacity_threshold,
-                capacity_for_face_values(LOWER_THRESHOLD_FACE_VALUES, p).unwrap(),
-                "p={p}"
-            );
-        }
-    }
-
-    #[test]
-    fn channel_capacity_sizes_initial_and_keeps_proportions() {
-        // A requested volume drives the initial capacity; the rest are fractions of it —
-        // half for the top-up, a quarter for the threshold, and a quarter *above* for the
-        // Safe gate. Each is rounded up to a whole packet.
-        let payload = packet_payload_size();
-        let requested = ByteSize::mb(100);
-        let cfg = compute_funding_config(Some(requested), 1.0).unwrap();
-
-        let initial = cfg.initial_capacity.as_u64();
-        assert_eq!(initial, requested.as_u64().div_ceil(payload) * payload);
-
-        // Within one packet of the exact fraction (the alignment rounds up). `abs_diff`
-        // rather than plain subtraction: a downward drift would underflow and abort with
-        // an arithmetic panic naming neither value, hiding the regression this guards.
-        let expect =
-            |(numer, denom): (u64, u64)| ((initial as u128) * numer as u128 / denom as u128) as u64;
-        let within_a_packet = |label: &str, actual: u64, fraction: (u64, u64)| {
-            let expected = expect(fraction);
-            assert!(
-                actual.abs_diff(expected) < payload,
-                "{label}: {actual} is more than one packet ({payload} B) from {expected}"
-            );
-        };
-        within_a_packet("topup", cfg.topup_capacity.as_u64(), TOPUP_FRACTION);
-        within_a_packet(
-            "lower threshold",
-            cfg.lower_capacity_threshold.as_u64(),
-            LOWER_THRESHOLD_FRACTION,
-        );
-        within_a_packet(
-            "min safe",
-            cfg.min_safe_capacity_required.as_u64(),
-            MIN_SAFE_FRACTION,
-        );
-
-        assert!(cfg.lower_capacity_threshold < cfg.topup_capacity);
-        assert!(cfg.topup_capacity < cfg.initial_capacity);
-        assert!(cfg.initial_capacity < cfg.min_safe_capacity_required);
-    }
-
-    #[test]
-    fn channel_capacity_below_face_value_floor_is_ignored() {
-        // A channel that cannot cover one winning ticket cannot relay, so a requested
-        // volume under the face-value floor must not shrink the capacities.
-        for p in WIN_PROBS {
-            let floored = compute_funding_config(Some(ByteSize::b(1)), p).unwrap();
-            let default = compute_funding_config(None, p).unwrap();
-            assert_eq!(floored.initial_capacity, default.initial_capacity, "p={p}");
-            assert_eq!(floored.topup_capacity, default.topup_capacity, "p={p}");
-            assert_eq!(
-                floored.lower_capacity_threshold, default.lower_capacity_threshold,
-                "p={p}"
-            );
-        }
-    }
-
-    #[test]
-    fn channel_capacity_keeps_ordering_across_win_probs() {
-        for p in WIN_PROBS {
-            for requested in [ByteSize::kb(1), ByteSize::mb(10), ByteSize::gb(1)] {
-                let cfg = compute_funding_config(Some(requested), p).unwrap();
-                assert!(
-                    cfg.lower_capacity_threshold < cfg.topup_capacity,
-                    "p={p}, requested={requested}"
-                );
-                assert!(
-                    cfg.topup_capacity < cfg.initial_capacity,
-                    "p={p}, requested={requested}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn balance_recommendation_tracks_requested_capacity() {
-        // Regression: the recommendation is derived from the same funding config the
-        // reactor runs on. If it ignored `channel_capacity` it would report the
-        // face-value stake while the strategy locked the requested-volume stake, and a
-        // node funded to the recommendation could never open a channel.
-        let price = HoprBalance::new_base(10);
-        for p in [1.0, 0.01, 0.001] {
-            let cfg = compute_funding_config(Some(ByteSize::mb(50)), p).unwrap();
-            // One channel: the Safe gate dominates `1 × initial`.
-            let expected = resolve_funding(&cfg, price, p).min_safe_balance_required;
-            let rec = compute_balance_recommendation(
-                price,
-                p,
-                1,
-                no_startup_costs(),
-                Some(ByteSize::mb(50)),
-            )
-            .unwrap();
-            assert_eq!(rec.channel_stakes, expected, "p={p}");
-
-            let default =
-                compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
-            assert!(
-                rec.channel_stakes > default.channel_stakes,
-                "p={p}: a 50 MB request must cost more than the face-value floor"
-            );
-        }
+        assert_eq!(cfg.assumed_hops, ASSUMED_HOPS);
+        assert!(cfg.stop_when_unfunded);
     }
 
     #[test]
     fn resolved_stake_carries_the_variance_buffer() {
-        // Guards the mirror against silently collapsing back to the mean drain: below
-        // win_prob = 1 the Probabilistic term must add k·σ on top of N × hops × price.
+        // Guards against the mode silently collapsing to the mean drain: below
+        // win_prob = 1 the Probabilistic term must add k, sigma on top of N x hops x price.
         let price = HoprBalance::new_base(10);
+        let cfg = compute_funding_config(None).unwrap();
+        let packets = cfg
+            .initial_capacity
+            .as_u64()
+            .div_ceil(packet_payload_size());
+        let mean_drain = price * packets * cfg.assumed_hops as u64;
         for p in [0.5, 0.1, 0.01, 0.001] {
-            let cfg = compute_funding_config(None, p).unwrap();
-            let packets = cfg.initial_capacity.as_u64() / packet_payload_size();
-            let mean_drain = price * packets * ASSUMED_HOPS as u64;
             let stake = resolve_funding(&cfg, price, p).initial_balance;
             assert!(
                 stake > mean_drain,
@@ -878,39 +551,42 @@ mod tests {
     fn resolved_stake_at_win_prob_one_equals_mean_drain() {
         // At win_prob = 1 the variance vanishes, so Probabilistic collapses onto
         // Deterministic and the stake is exactly the mean drain.
+        // A small capacity keeps the packet count well inside f64's exact-integer range;
+        // at the default 1 GiB it is ~1M packets and the strategy's f64 pipeline lands a
+        // few wei off, which says nothing about the mode collapsing.
         let price = HoprBalance::new_base(10);
-        let cfg = compute_funding_config(None, 1.0).unwrap();
-        let packets = cfg.initial_capacity.as_u64() / packet_payload_size();
+        let cfg = compute_funding_config(Some(ByteSize::kb(10))).unwrap();
+        let packets = cfg
+            .initial_capacity
+            .as_u64()
+            .div_ceil(packet_payload_size());
         assert_eq!(
             resolve_funding(&cfg, price, 1.0).initial_balance,
-            price * packets * ASSUMED_HOPS as u64
+            price * packets * cfg.assumed_hops as u64
         );
     }
 
     #[test]
-    fn incentive_configuration_default_channel_capacity_is_none() {
-        assert!(IncentiveConfiguration::default().channel_capacity.is_none());
-    }
-
-    #[test]
     fn balance_recommendation_matches_strategy_initial_stake() {
-        // The recommendation must equal what the strategy locks, never less: `missing ×
-        // initial`, raised to the Safe gate when a single channel would fall under it.
+        // The recommendation must equal what the strategy locks, never less: `missing x
+        // initial`, raised to the safe gate when a single channel would fall under it.
         for price in [HoprBalance::new_base(10), HoprBalance::from(100u32)] {
             for p in [1.0, 0.01, 0.001] {
-                let cfg = compute_funding_config(None, p).unwrap();
-                let per_channel = resolve_funding(&cfg, price, p).initial_balance;
-                let min_safe = resolve_funding(&cfg, price, p).min_safe_balance_required;
+                let cfg = compute_funding_config(None).unwrap();
+                let resolved = resolve_funding(&cfg, price, p);
 
                 let one =
                     compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
-                assert_eq!(one.channel_stakes, min_safe, "price={price}, p={p}");
-
-                let eight =
-                    compute_balance_recommendation(price, p, 8, no_startup_costs(), None).unwrap();
                 assert_eq!(
-                    eight.channel_stakes,
-                    per_channel * 8u64,
+                    one.channel_stakes, resolved.min_safe_balance_required,
+                    "price={price}, p={p}"
+                );
+
+                let many =
+                    compute_balance_recommendation(price, p, 64, no_startup_costs(), None).unwrap();
+                assert_eq!(
+                    many.channel_stakes,
+                    resolved.initial_balance * 64u64,
                     "price={price}, p={p}"
                 );
             }
@@ -922,7 +598,7 @@ mod tests {
         // `stop_when_unfunded` blocks every open below min_safe_capacity_required.
         let price = HoprBalance::new_base(10);
         for p in WIN_PROBS {
-            let cfg = compute_funding_config(None, p).unwrap();
+            let cfg = compute_funding_config(None).unwrap();
             let min_safe = resolve_funding(&cfg, price, p).min_safe_balance_required;
             let rec =
                 compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
@@ -931,9 +607,37 @@ mod tests {
     }
 
     #[test]
+    fn balance_recommendation_tracks_requested_capacity() {
+        // Regression: the recommendation is derived from the same funding config the
+        // reactor runs on. If it ignored `channel_capacity` a node funded to the reported
+        // figure could never open a channel at the requested volume.
+        let price = HoprBalance::new_base(10);
+        let requested = Some(ByteSize::gib(4));
+        for p in [1.0, 0.01, 0.001] {
+            let cfg = compute_funding_config(requested).unwrap();
+            let expected = resolve_funding(&cfg, price, p).min_safe_balance_required;
+            let rec =
+                compute_balance_recommendation(price, p, 1, no_startup_costs(), requested).unwrap();
+            assert_eq!(rec.channel_stakes, expected, "p={p}");
+
+            let default =
+                compute_balance_recommendation(price, p, 1, no_startup_costs(), None).unwrap();
+            assert!(
+                rec.channel_stakes > default.channel_stakes,
+                "p={p}: a 4 GiB request must cost more than the default capacity"
+            );
+        }
+    }
+
+    #[test]
+    fn incentive_configuration_default_channel_capacity_is_none() {
+        assert!(IncentiveConfiguration::default().channel_capacity.is_none());
+    }
+
+    #[test]
     fn compute_funding_config_default_sizing_has_one_strategy_shape() {
         // Smoke-test: can build a MultiStrategyConfig from compute_funding_config output
-        let funding = compute_funding_config(None, 1.0).unwrap();
+        let funding = compute_funding_config(None).unwrap();
         let lifecycle_cfg = ChannelLifecycleConfig {
             funding,
             ..Default::default()
@@ -986,8 +690,12 @@ mod tests {
             None,
         )
         .unwrap();
-        // stake per channel = ticket_price × INITIAL_FACE_VALUES at win_prob = 1
-        let per_channel = HoprBalance::new_base(10) * 5u64;
+        let per_channel = resolve_funding(
+            &compute_funding_config(None).unwrap(),
+            HoprBalance::new_base(10),
+            1.0,
+        )
+        .initial_balance;
         assert_eq!(rec.channel_stakes, per_channel * 8u64);
         assert_eq!(rec.fee_to_start, fee);
         assert_eq!(rec.txs_to_start, 3);
@@ -1018,7 +726,7 @@ mod tests {
 
     #[test]
     fn compute_balance_recommendation_scales_by_missing_channels() {
-        // win_prob=1.0, ticket_price=10, hops=1: stake = 10 × 5 face values; 8 channels
+        // Eight channels clears the safe gate, so the total is 8 x the per-channel stake.
         let rec = compute_balance_recommendation(
             HoprBalance::new_base(10),
             1.0,
@@ -1027,7 +735,12 @@ mod tests {
             None,
         )
         .unwrap();
-        let per_channel = HoprBalance::new_base(10) * 5u64;
+        let per_channel = resolve_funding(
+            &compute_funding_config(None).unwrap(),
+            HoprBalance::new_base(10),
+            1.0,
+        )
+        .initial_balance;
         assert_eq!(rec.channel_stakes, per_channel * 8u64);
         assert_eq!(rec.fee_to_start, HoprBalance::zero());
         assert_eq!(rec.txs_to_start, 0);
@@ -1036,10 +749,10 @@ mod tests {
     }
 
     #[test]
-    fn compute_balance_recommendation_halved_win_prob_more_than_doubles_stake() {
-        // The derived capacity is ceil(INITIAL_FACE_VALUES / win_prob) packets, so halving
-        // win_prob doubles the mean drain. Probabilistic sizing adds k·σ on top and σ grows
-        // as 1/√p, so the stake must rise by strictly more than that factor of two.
+    fn compute_balance_recommendation_rises_as_win_prob_falls() {
+        // The capacity is fixed now, so the mean drain does not move with win_prob. What
+        // still grows is the variance buffer (σ ∝ 1/√p) and the one-winning-ticket floor
+        // (∝ 1/p), so a lower win_prob must cost strictly more.
         let full = compute_balance_recommendation(
             HoprBalance::new_base(10),
             1.0,
@@ -1057,8 +770,8 @@ mod tests {
         )
         .unwrap();
         assert!(
-            half.channel_stakes > full.channel_stakes * 2u64,
-            "expected more than 2x, got {} vs {}",
+            half.channel_stakes > full.channel_stakes,
+            "expected a strictly larger stake at the lower win_prob, got {} vs {}",
             half.channel_stakes,
             full.channel_stakes
         );

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -120,6 +120,14 @@ pub struct IncentiveConfiguration {
     /// floored at their face-value minimums, because a channel that cannot cover one
     /// winning ticket cannot relay at all. Requesting less than that floor has no effect.
     ///
+    /// # Funding is all-or-nothing
+    ///
+    /// This also raises the balance below which the node refuses to operate. The strategy
+    /// runs with `stop_when_unfunded`, so a Safe holding less than the derived
+    /// `min_safe_capacity_required` opens **zero** channels — it does not open a smaller
+    /// channel, and it does not open fewer of them. Size this to a volume the Safe is
+    /// actually funded for; [`minimum_balance_recommendation`] reports the figure needed.
+    ///
     /// Default: `None` — size to [`INITIAL_FACE_VALUES`] face values, the smallest
     /// stake that keeps ticket issuance running.
     #[default(None)]
@@ -197,8 +205,13 @@ fn scale_capacity(capacity: ByteSize, (numer, denom): (u64, u64)) -> anyhow::Res
 ///
 /// Mirrors the strategy's crate-private `capacity_to_balance` for [`SIZING_MODE`],
 /// including the one-winning-ticket floor. Kept in lockstep with
-/// [`compute_funding_config`] so a balance recommendation can never under-report the
-/// stake the strategy actually locks.
+/// [`compute_funding_config`] so a balance recommendation cannot drift from the stake the
+/// strategy actually locks.
+///
+/// The mirror is faithful rather than exact: it reproduces the strategy's own `f64`
+/// pipeline step for step, `low_u128()` narrowing and all, so both sides round
+/// identically. Fixing the rounding on this side alone would *introduce* a mismatch —
+/// any change here has to land upstream in the same commit.
 fn capacity_stake(
     capacity: ByteSize,
     ticket_price: HoprBalance,
@@ -529,6 +542,10 @@ pub async fn default_strategy_cfg(
         requested_capacity = ?sizing.channel_capacity,
         initial_capacity = %funding.initial_capacity,
         topup_capacity = %funding.topup_capacity,
+        // The threshold that decides when a top-up fires, and so the first value
+        // to reach for when investigating a channel that stalled mid-relay.
+        lower_capacity_threshold = %funding.lower_capacity_threshold,
+        min_safe_capacity_required = %funding.min_safe_capacity_required,
         sizing_mode = ?funding.sizing_mode,
         "channel-lifecycle funding sized from live winning probability"
     );
@@ -773,14 +790,28 @@ mod tests {
         let initial = cfg.initial_capacity.as_u64();
         assert_eq!(initial, requested.as_u64().div_ceil(payload) * payload);
 
-        // Within one packet of the exact fraction (the alignment rounds up).
+        // Within one packet of the exact fraction (the alignment rounds up). `abs_diff`
+        // rather than plain subtraction: a downward drift would underflow and abort with
+        // an arithmetic panic naming neither value, hiding the regression this guards.
         let expect =
             |(numer, denom): (u64, u64)| ((initial as u128) * numer as u128 / denom as u128) as u64;
-        assert!(cfg.topup_capacity.as_u64() - expect(TOPUP_FRACTION) < payload);
-        assert!(cfg.lower_capacity_threshold.as_u64() - expect(LOWER_THRESHOLD_FRACTION) < payload);
-        assert!(
-            cfg.min_safe_capacity_required.as_u64() - expect(MIN_SAFE_FRACTION) < payload,
-            "min_safe must be a quarter above the initial capacity"
+        let within_a_packet = |label: &str, actual: u64, fraction: (u64, u64)| {
+            let expected = expect(fraction);
+            assert!(
+                actual.abs_diff(expected) < payload,
+                "{label}: {actual} is more than one packet ({payload} B) from {expected}"
+            );
+        };
+        within_a_packet("topup", cfg.topup_capacity.as_u64(), TOPUP_FRACTION);
+        within_a_packet(
+            "lower threshold",
+            cfg.lower_capacity_threshold.as_u64(),
+            LOWER_THRESHOLD_FRACTION,
+        );
+        within_a_packet(
+            "min safe",
+            cfg.min_safe_capacity_required.as_u64(),
+            MIN_SAFE_FRACTION,
         );
 
         assert!(cfg.lower_capacity_threshold < cfg.topup_capacity);


### PR DESCRIPTION
Moves to `hopr-strategy` 0.24.1 and makes this crate the single owner of channel sizing: a caller says how much data one channel should carry, and everything else is the strategy's answer rather than a restatement of it.

## Why

Sizing ran through two independent paths. `default_strategy_cfg` built a `FundingConfig` whose `sizing_mode` a caller could override, while `compute_balance_recommendation` always mirrored `Deterministic`. Overriding the mode silently desynced the two: the recommendation under-reported what the strategy locks, and because `min_safe_capacity_required` resolves through the same mode, a node funded to the recommendation would fail the strategy's own funding gate and quietly refuse to open channels.

`Deterministic` is also the wrong default here. It sizes to the mean drain, leaving the lower threshold near a single ticket face value. Payouts are lumpy — the winning-ticket count is `Binomial(N, win_prob)` — so a channel resting on that floor starves: it cannot issue the next ticket, and relaying stalls until a top-up confirms.

## What

**`IncentiveConfiguration::channel_capacity: Option<ByteSize>`** — the data volume one channel should carry before needing a top-up, and the only sizing input a caller supplies. It reaches the strategy as the initial capacity unchanged; top-up and lower threshold keep the strategy's own defaults. `None` leaves the strategy's initial capacity in place, so existing callers are unaffected.

**The Safe gate sits above one channel's capacity.** The strategy's default `min_safe_capacity_required` is a fixed volume that does not track a requested one, so a larger request would clear the gate on a Safe that cannot then top the channel up. The gate is now `max(2 × requested capacity, strategy default)` — twice covers the channel and its first top-up, and taking the larger of the two means a *small* request cannot lower the gate below what the strategy would have required alone. The balance recommendation is raised to the same gate (`max(missing × initial, min_safe)`) so it cannot report a figure the strategy would then reject.

**`Probabilistic(0.99)` replaces `Deterministic`.** The `k·σ` buffer (`k = Φ⁻¹(0.99) ≈ 2.33`) covers the drain in 99% of fund cycles. At `win_prob = 1` the variance vanishes and both modes coincide, so the pinned `win_prob = 1` economics are unchanged. The probability is checked against the range `hopr-strategy` accepts by a `const` assertion, so an out-of-range value fails the build instead of being silently clamped at runtime.

**Sizing mode is not caller-tunable.** `SIZING_MODE` is a crate constant. The reactor and the balance recommendations have to agree on the mode, and a caller able to override it on the returned `FundingConfig` could set one without the other.

**Funding figures come from the strategy itself.** The capacity-to-wxHOPR conversion is no longer reimplemented here — `resolve_funding` delegates to `FundingConfig::resolve` (made public in hoprnet/hopr-strategy#27), so a figure reported to an operator cannot drift from what the strategy locks. The local mirror, its face-value tables, and the `statrs` dependency are all gone (−287 lines), and the tests now assert against the strategy's own output instead of agreement between two restatements of it.

**Every paid hop is counted.** `compute_capacity` measured both message counts against the bare ticket price, as if a message paid one relay. That matched the strategy only because this crate configured 1 hop. `hopr-strategy` 0.25.0 sizes and gates at the protocol maximum of 3, so the old assumption would have reported **3× more payable messages than a stake can cover** — and `ChannelsOutOfFunds` / `SafeOutOfFunds` would have under-reported exactly when funding got tight. Both counts now divide by the per-message drain `ticket_price × ASSUMED_HOPS`, and `ASSUMED_HOPS` is read from `RoutingOptions::MAX_INTERMEDIATE_HOPS` rather than restated, so it cannot drift from what the strategy sizes with.

## Upgrade impact — existing nodes need more wxHOPR

This raises what a node must hold before it will open or top up a channel, for **every** node, including ones that never set `channel_capacity`:

- `Probabilistic(0.99)` replaces `Deterministic`, adding `k·σ` (`k ≈ 2.33`) on top of the mean drain.
- the safe gate is `max(2 × initial capacity, strategy default)`, where it previously equalled the initial capacity.
- stakes are sized for **3 hops instead of 1**, tripling the face value each ticket locks.
- each stake is rounded up to a whole winning ticket (hopr-strategy#30).

`stop_when_unfunded` is always set, and the strategy gates every open and every top-up on the safe balance clearing that figure. So a node whose Safe was funded to exactly the pre-upgrade recommendation will, after upgrading, open no channels and perform no top-ups — existing channels drain and connectivity degrades — until more wxHOPR is added.

`minimum_balance_recommendation` reports the new figure, and it now comes from the strategy's own resolution, so it is the number to fund to. **This wants a release note.**

## Dependency

`hopr-strategy` is a plain registry dependency at **0.25.0** — the temporary git rev is gone. That release carries hoprnet/hopr-strategy#27 (public `FundingConfig::resolve`), #30 (stakes rounded to whole winning tickets) and #31 (`assumed_hops` removed, stakes sized at the protocol maximum). It also made the strategy builders fallible, so strategy construction propagates that error rather than assuming it cannot fail.

## Compatibility

**BREAKING.** `IncentiveConfiguration` gains a field, and `compute_funding_config` takes the requested capacity as its first argument. Version bumped 3.5.1 → 4.0.0. Not published to crates.io, so consumers pin by git rev.

Downstream: https://github.com/gnosis/gnosis_vpn-client/pull/727
