### PR TITLE
chore(deps): point hopr-lib at the return-path resilience stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
+source = "git+https://github.com/hoprnet/hoprnet?rev=aee1f8e227cfb9211b8f5a5489a5c16eef23eb88#aee1f8e227cfb9211b8f5a5489a5c16eef23eb88"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,9 +3854,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46949bd2e467a35731823d3a9778a9b2b67b8812160e336f4e15675e4f10e58f"
+version = "1.21.0"
+source = "git+https://github.com/hoprnet/hopr-api?rev=4a53ed13634a5080a63760b9ca84bd9fe7710114#4a53ed13634a5080a63760b9ca84bd9fe7710114"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3924,13 +3923,13 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "serde",
  "serde_bytes",
  "strum",
@@ -3959,8 +3958,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.10"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+version = "4.0.2-rc.11"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3980,7 +3979,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3999,15 +3998,14 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba5b6a91aeb80be5249798c975895d72d348c163317a3976359b5a10c89eb4b"
+version = "0.3.3"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=d9dc437108b59776b8b9673664c88d9b177d7769#d9dc437108b59776b8b9673664c88d9b177d7769"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -4021,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4033,8 +4031,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "5.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+version = "6.0.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4046,7 +4044,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4063,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4077,7 +4075,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4094,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4160,8 +4158,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.40.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+version = "0.41.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4183,7 +4181,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4204,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4243,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4254,7 +4252,7 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
@@ -4269,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4282,7 +4280,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4301,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4400,6 +4398,34 @@ dependencies = [
  "futures-time",
  "hickory-resolver 0.26.1",
  "hopr-api",
+ "hopr-types",
+ "indexmap 2.14.0",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "pin-project",
+ "rand 0.10.2",
+ "serde_json",
+ "socket2 0.6.5",
+ "strum",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-utilities"
+version = "0.7.0"
+source = "git+https://github.com/hoprnet/hopr-utilities?rev=e17451a8db2fd72cecde273ac8ef87de96c8bac0#e17451a8db2fd72cecde273ac8ef87de96c8bac0"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "const-hex",
+ "crossfire",
+ "flume",
+ "futures",
+ "futures-time",
+ "hickory-resolver 0.26.1",
  "hopr-types",
  "indexmap 2.14.0",
  "lazy_static",
@@ -4560,7 +4586,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6650,7 +6676,7 @@ dependencies = [
  "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6690,7 +6716,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6703,7 +6729,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
+source = "git+https://github.com/hoprnet/hoprnet?rev=7811cbfb49e3adbef2bd6b536d29568fe3c46d4b#7811cbfb49e3adbef2bd6b536d29568fe3c46d4b"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=afffc1fc6a5cbf04ee5e906070647cd256ed74c6#afffc1fc6a5cbf04ee5e906070647cd256ed74c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=066f3bbac19e69b5e1927eb272d983d245420b01#066f3bbac19e69b5e1927eb272d983d245420b01"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -243,7 +243,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -269,7 +269,7 @@ dependencies = [
  "borsh",
  "k256 0.13.4",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -401,7 +401,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ dependencies = [
  "rand 0.8.7",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -502,7 +502,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -611,7 +611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -637,7 +637,7 @@ dependencies = [
  "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -653,7 +653,7 @@ dependencies = [
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -780,7 +780,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1230,7 +1230,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1746,7 +1746,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -2052,7 +2052,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2880,7 +2880,7 @@ dependencies = [
  "signal-hook",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3716,7 +3716,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3742,7 +3742,7 @@ dependencies = [
  "rand 0.9.5",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3763,7 +3763,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -3785,7 +3785,7 @@ dependencies = [
  "rand 0.9.5",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3811,7 +3811,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3854,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca8f552df157750ebad001edfa75851da1029461f3a60f60a41541dba39b3aa"
+checksum = "46949bd2e467a35731823d3a9778a9b2b67b8812160e336f4e15675e4f10e58f"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3868,7 +3868,7 @@ dependencies = [
  "libp2p-identity",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -3885,7 +3885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3916,7 +3916,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3935,7 +3935,7 @@ dependencies = [
  "serde_bytes",
  "strum",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.10"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3990,7 +3990,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4014,27 +4014,27 @@ dependencies = [
  "petgraph",
  "rand 0.10.2",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
  "serde",
  "serde_bytes",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+version = "5.1.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4051,20 +4051,19 @@ dependencies = [
  "lazy_static",
  "moka",
  "parking_lot",
- "ringbuffer",
  "serde",
  "serde_with",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+version = "1.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4087,7 +4086,7 @@ dependencies = [
  "serde_bytes",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4095,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4104,7 +4103,7 @@ dependencies = [
  "serde",
  "serde_cbor_2",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4131,7 +4130,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "statrs",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
@@ -4155,14 +4154,14 @@ dependencies = [
  "redb",
  "strum",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport"
-version = "0.37.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+version = "0.40.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4196,7 +4195,7 @@ dependencies = [
  "serde",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio-util",
  "tracing",
  "validator",
@@ -4205,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4215,7 +4214,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "smart-default",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -4237,14 +4236,14 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "quinn-udp 0.6.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4262,15 +4261,15 @@ dependencies = [
  "serde",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.25.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+version = "0.26.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4294,7 +4293,7 @@ dependencies = [
  "serde_repr",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4302,20 +4301,20 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=4a47cdffd9b453708c5e3b6f4e91f58de50ee585#4a47cdffd9b453708c5e3b6f4e91f58de50ee585"
 dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "validator",
 ]
 
 [[package]]
 name = "hopr-types"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bff6165942aa235899cb5084a058db8a00b0885cfc41e8e0f5bf8b2cb007c6"
+checksum = "66c7725edf3080e937b9dcc66633003506c007da24706f6c3bcaf62443e2eb12"
 dependencies = [
  "aes 0.9.2",
  "anyhow",
@@ -4364,7 +4363,7 @@ dependencies = [
  "smart-default",
  "strum",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "typenum",
  "uuid",
@@ -4415,7 +4414,7 @@ dependencies = [
  "serde_json",
  "socket2 0.6.5",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4928,7 +4927,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -5130,7 +5129,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5164,7 +5163,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.7",
  "rand_core 0.6.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "web-time",
 ]
@@ -5199,7 +5198,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.7",
  "rw-stream-sink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -5238,7 +5237,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -5256,7 +5255,7 @@ dependencies = [
  "rand 0.8.7",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "zeroize",
 ]
@@ -5313,7 +5312,7 @@ dependencies = [
  "rand 0.8.7",
  "snow",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5337,7 +5336,7 @@ dependencies = [
  "ring",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -5436,7 +5435,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "x509-parser",
  "yasna",
 ]
@@ -5465,7 +5464,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -5775,7 +5774,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5985,7 +5984,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -6015,7 +6014,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -6058,7 +6057,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6652,7 +6651,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -6676,7 +6675,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7928,7 +7927,7 @@ dependencies = [
  "nalgebra",
  "num-traits",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8117,11 +8116,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -8137,9 +8136,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9123,7 +9122,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=5897a4501f80fbcc2565f09907041f6e92222167#5897a4501f80fbcc2565f09907041f6e92222167"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a4bae34dc0e8ecee2bd43837fa98e338887d4f96#a4bae34dc0e8ecee2bd43837fa98e338887d4f96"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4586,7 +4586,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6676,7 +6676,7 @@ dependencies = [
  "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6716,7 +6716,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6729,7 +6729,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=41ac2a46aa810f519db8f1321233491fe9833429#41ac2a46aa810f519db8f1321233491fe9833429"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3#6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.11"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.41.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.26.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0052286482238657e44b7ec03f00ccf8bd0d39cb#0052286482238657e44b7ec03f00ccf8bd0d39cb"
+source = "git+https://github.com/hoprnet/hoprnet?rev=da2d88751067aaf0ac38640617b65aff2716a5b4#da2d88751067aaf0ac38640617b65aff2716a5b4"
 dependencies = [
  "hopr-protocol-app",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0052286482238657e44b7ec03f00ccf8bd0d39cb", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "da2d88751067aaf0ac38640617b65aff2716a5b4", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "da2d88751067aaf0ac38640617b65aff2716a5b4", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "afffc1fc6a5cbf04ee5e906070647cd256ed74c6", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "066f3bbac19e69b5e1927eb272d983d245420b01", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "aee1f8e227cfb9211b8f5a5489a5c16eef23eb88", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "7811cbfb49e3adbef2bd6b536d29568fe3c46d4b", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "41ac2a46aa810f519db8f1321233491fe9833429", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "4a47cdffd9b453708c5e3b6f4e91f58de50ee585", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "5897a4501f80fbcc2565f09907041f6e92222167", features = [
   "session-client",
   "serde",
 ] }
@@ -122,3 +122,10 @@ anyhow = "1.0.104"
 [profile.tracer]
 inherits = "release"
 debug-assertions = true
+
+# Temporary: pins the unreleased upstreams the hopr-lib rev above depends on. Remove once
+# hopr-api 1.21.0, hopr-utilities 0.7.0 and hopr-network-graph 0.3.3 are published.
+[patch.crates-io]
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "4a53ed13634a5080a63760b9ca84bd9fe7710114" }
+hopr-utilities = { git = "https://github.com/hoprnet/hopr-utilities", rev = "e17451a8db2fd72cecde273ac8ef87de96c8bac0" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hopr-impls", rev = "d9dc437108b59776b8b9673664c88d9b177d7769" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0052286482238657e44b7ec03f00ccf8bd0d39cb", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "5897a4501f80fbcc2565f09907041f6e92222167", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a4bae34dc0e8ecee2bd43837fa98e338887d4f96", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "afffc1fc6a5cbf04ee5e906070647cd256ed74c6", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "066f3bbac19e69b5e1927eb272d983d245420b01", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "4a47cdffd9b453708c5e3b6f4e91f58de50ee585", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "41ac2a46aa810f519db8f1321233491fe9833429", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "6ed6b5f7d30a8c9168d68c0bceeb8c5c1aba51b3", features = [
   "session-client",
   "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a4bae34dc0e8ecee2bd43837fa98e338887d4f96", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "7811cbfb49e3adbef2bd6b536d29568fe3c46d4b", features = [
   "session-client",
   "serde",
 ] }


### PR DESCRIPTION
Moves the `hoprnet` pin from `10f6d80c` to **`4a47cdff`** — the tip of the stacked return-path resilience work — so the whole set can be exercised end to end from here.

## What is in the stack

| PR | Change |
|---|---|
| [hoprnet#8328](https://github.com/hoprnet/hoprnet/pull/8328) | SURB buffer pop order configurable (FIFO default, LIFO opt-in) |
| [hoprnet#8329](https://github.com/hoprnet/hoprnet/pull/8329) | Drop SURBs whose return path starts at a relayer we cannot pay |
| [hoprnet#8331](https://github.com/hoprnet/hoprnet/pull/8331) | Return-path diversity: spread SURBs over K distinct relayers, interleaved |
| [hoprnet#8330](https://github.com/hoprnet/hoprnet/pull/8330) | Data-path frame max-age bound, so stalls surface as loss not latency |

Together they address the 2026-08-10 uplink brownout and the 2026-08-11 return-path break.

## Behavioural impact here

This crate only re-exports `FlowControlConfig` and builds its SURB store config through `Default`, so nothing changes for it directly:

- pop order defaults to `Fifo` (unchanged); LIFO is opt-in per node
- `max_frame_age` defaults to `None` on the clean profile; the `robust()` profile now carries a 2 s bound, which reaches consumers that select that profile
- return-path diversity (hoprnet#8331) is active by default, but only spreads SURBs more evenly across relayers already in use

`hopr-protocol-hopr` crosses a major (4.x → 5.1.0) because `SurbStoreConfig` gained a public `pop_order` field. That breaks downstream *exhaustive struct literals* only; this crate builds its config through `Default`, so it is unaffected — as the clean build confirms.

## Verification

`cargo check --workspace` passes against the new pin.

## Merge order

**Depends on** https://github.com/hoprnet/hoprnet/pull/8330 (and the three PRs beneath it). The rev must be repointed at the merge commit on `master` before this lands — pinning a branch tip is fine for testing, not for merge.

Followed by the corresponding `gnosis_vpn-client` bump, which pins `edgli` to this PR's head.