### PR TITLE
feat(discovery): add gvpn:exit registry discovery for gnosis_vpn-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8d8a7d7e896331d13d94cd50779a843d3fb3d8b0389826e43638f6276bc4b3"
+checksum = "754c72f6ae867220976be4693d870f8f9866437f37fdeb5640aa24991e5ff97f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
+checksum = "e5fdcfed8f106be3df944054aaa42bc13ae103a3ac8a9f4b08d4f053e3a743f8"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9eb70841f76b69b1205bb57b551b7d7afd8407ad57cbda02e833877507c16"
+checksum = "99bdf6a3e99089d97e137009956928b41d645035b220cb303eae88182882e9ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -164,14 +164,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89486e1bd2c5c56522cf18e73460c3fe7b54d50f5e80131466e62b7632edfcb"
+checksum = "18d98872f189ea87063912de45e7e0d6ae44700a8836f8bfa79b3265f0c38bfe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c0dadb2468adc8aaaaad4c9a6cfa6bd055fe6596c40017067b37671f2c45f5"
+checksum = "f69e65d1b6adc7e46c0e93c2cf3cb4e8646e66a2ced4ba38d542b724acd54774"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -200,15 +200,17 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
+ "tokio",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8421a5ee9019b6d89f92935d0f8facd9f6ca088b41d7cc47244a02ccde4545f"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -219,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -243,7 +245,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -269,7 +271,7 @@ dependencies = [
  "borsh",
  "k256 0.13.4",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -283,14 +285,14 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddc9c1868d6331b56926de8ab4c4a80d8dcb7bc4f8f7bebc6a89d0548f79af2"
+checksum = "74bffa6f6440f1ee3c8cd7bc9dc2b01fd837641ef9bd566bd9f8922e75ff8e6c"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -311,23 +313,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe3f812d024acd2a612aea20629130cd59595064f1420953e6e20c84165def9"
+checksum = "aa8a7af8c504c7896dca006666d3d0c69212af69a0b947209c0605fe35b8e66d"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921b3dccecc4e9dd571c9f9a728d913c2fc7a8ecdfce6005ed99751817523d0d"
+checksum = "f48592ff562892af6a2ebb6e214ed1d2795a6c1dc601c601ef0863583c799003"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -365,24 +367,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d701ece9bccec3294991ce4b4a39dd1cecd0979ea58e86b9878679591b4f5"
+checksum = "31de46f2b1948ac9e378212fd79cb963745cbb29cfe08a13c5b675d7e0934a24"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfca49fbbe3b30de8114b9cfd89029f87cb33ca7e8a5f5f48a809caaf085126"
+checksum = "fa3ea75a876a4cd302c15dad628cc55f1f0b2db7fd4865f57f4e24cea2629298"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -401,14 +403,14 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af7b76520abc91b9e0f1aa987d42df55a66494f94a1881cdadd9b8f67e0b924"
+checksum = "f93f09f2bee068dcd80bfdf057109d64e37b318f21d3d64851139ca741366dd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -419,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b81973f768c49fe233d6e43da093765d60c1f9bcc81c82ba4ef31c8e273b4b"
+checksum = "623d5c6b07f1adf11940eff4b8e665d9b7d9db969fbfe872816878906b267152"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -434,7 +436,7 @@ dependencies = [
  "rand 0.8.7",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -470,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3fb53b31526b0f97cdbfaf9d8bb72b3e4a9ac7965148d79ecec4c733c8558e"
+checksum = "4e9070296bd2902aac4d9defd85608116eceb319526746257ab97096da2c5603"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -502,7 +504,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -533,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5274f9ada7f558d2feaba16fadcb96022512566cf424147f9cfa2000bc2e458"
+checksum = "87da7170c18c43a5def51f5f166d0260776b721e184c349fae1cd5466cb67362"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -556,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a456d697d4f639d20ac242981de13b94f911c99199e4175e85eaf52b8f785c"
+checksum = "88813dc63f261e25d158f07063a71e926f36b3ee8076c1e6d8396348452c5f69"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -568,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7e911c628067c406effef5137d0e253d98e117cdb81d47aacfe2816199297e"
+checksum = "2771c42b80531e99e4449e0a3ffd8f9830073f1d38576ac1643d2573fe6d922f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -580,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c88bfdd02271de47f28d69481191a2af6b2907901a3a8c7aff79a6b574eb"
+checksum = "6574846e24e090607d78325e90256c9a5ce4010cf0e663b23d06e01fd74356f0"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -595,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3b805bb9cafaf1362c28b377e2035e49fc5ae0a5ee3ea61bafd9a5d33959e1"
+checksum = "acc71ae98333ab278782d59423bd8317e7658954c356e1f4ce559fcea4f4da85"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -611,14 +613,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
+checksum = "6f11544d72bc87eab3cf4addc61d1f735bf88f3769482eca3deefc0c2558d2d0"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -627,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa150cd076471ef21aa7b181d8186cb86c3239518859a2e5d80fbec74f0ec38"
+checksum = "e76dfc1a6c8337e59624b9f6f02245566b7d24e8dab0eb842d57d4fd8777adc3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -637,14 +639,14 @@ dependencies = [
  "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f125bb730d4772538835d4a31e8e5ed5068e2a991619ba32711fd53ad8c93032"
+checksum = "1a9f88d471c719ce2bdf949191f8a1c08bffd0c030606c6a8da0d414454e8bfe"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -653,18 +655,18 @@ dependencies = [
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error3",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -672,16 +674,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "proc-macro-error3",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
@@ -719,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -731,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd5dbd32cae5d1bc3afaf455064ebd9bcce70b57de220468908717c225225dd"
+checksum = "f9399b22a1d2a82c8c30fd527541ba61e574795d0b95f3b902d3473d11489be5"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -744,7 +746,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -754,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7b1f0e528ae788d05937f5b351afae3b4c1e08f17a061d868bd28e56aa9e3"
+checksum = "59b55d7ccf45bec99db692c1266413498d2c9776c390cf148aa590422e31b2d3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -780,15 +782,15 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e2386593cef5b12c7d439dbcf62d7d51c3a50dc943909b42ae34b48f1b69dc"
+checksum = "de9792a54c0c8cc009883436ff1a60eb091095aced1c167a764bedbbfa0eee79"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1230,7 +1232,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -1375,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1456,9 +1458,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1466,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -1661,6 +1663,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -1721,9 +1729,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6da9d0a178246498baf5e4b9f753affb25c14116ea8fbf75552841c6231a429"
+version = "0.31.0"
+source = "git+https://github.com/hoprnet/blokli-client?rev=2b2d41a387f46d2d7adf4e0e66dd4dff520c0b92#2b2d41a387f46d2d7adf4e0e66dd4dff520c0b92"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1746,7 +1753,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -1886,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1993,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2003,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2052,7 +2059,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2629,6 +2636,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,11 +2895,14 @@ version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-signal",
+ "async-stream",
  "async-trait",
+ "blokli-client",
  "bytesize",
  "cfg-if",
  "clap",
  "console-subscriber",
+ "const-hex",
  "futures",
  "hopr-chain-connector",
  "hopr-ct-full-network",
@@ -2876,11 +2917,13 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "serde",
+ "serde_json",
  "serde_yaml",
  "signal-hook",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3136,9 +3179,9 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixed-cache"
@@ -3248,9 +3291,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3273,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3296,15 +3339,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3313,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -3332,13 +3375,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3354,15 +3397,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-time"
@@ -3387,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3716,7 +3759,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3742,7 +3785,7 @@ dependencies = [
  "rand 0.9.5",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3763,7 +3806,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -3785,7 +3828,7 @@ dependencies = [
  "rand 0.9.5",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3811,7 +3854,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3854,9 +3897,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca8f552df157750ebad001edfa75851da1029461f3a60f60a41541dba39b3aa"
+version = "1.21.0"
+source = "git+https://github.com/hoprnet/hopr-api?rev=7c26c0bee697d33529dc9412c271ce6c8d726fc1#7c26c0bee697d33529dc9412c271ce6c8d726fc1"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3868,15 +3910,14 @@ dependencies = [
  "libp2p-identity",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002389b5e9013a604cb654dc89152bd4c32ea64031f7f4837a8631c27ca2c51"
+version = "4.12.2"
+source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3885,16 +3926,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8326d358c768a169662397a7cd566a6fc4d4b8e394f285cd7cfcc7a6f6e866"
+version = "0.23.0"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f5c44b245f7a52679185acbf244152c5fd5c2199#f5c44b245f7a52679185acbf244152c5fd5c2199"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3902,12 +3942,13 @@ dependencies = [
  "async-trait",
  "atomic_enum",
  "blokli-client",
+ "const-hex",
  "dashmap",
  "futures",
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3916,7 +3957,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
@@ -3924,26 +3965,25 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "serde",
  "serde_bytes",
  "strum",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-ct-full-network"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c670d644ce0535d3fb6beb3b9ade0c67f0a24d6309b888f64f61dd0b9eb51eb3"
+version = "0.3.1"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f5c44b245f7a52679185acbf244152c5fd5c2199#f5c44b245f7a52679185acbf244152c5fd5c2199"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3951,7 +3991,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "smart-default",
  "tracing",
  "validator",
@@ -3960,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.10"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3980,7 +4020,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -3990,7 +4030,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3999,42 +4039,41 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba5b6a91aeb80be5249798c975895d72d348c163317a3976359b5a10c89eb4b"
+version = "0.3.2"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f5c44b245f7a52679185acbf244152c5fd5c2199#f5c44b245f7a52679185acbf244152c5fd5c2199"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
  "petgraph",
  "rand 0.10.2",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
  "serde",
  "serde_bytes",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4046,7 +4085,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4056,7 +4095,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
@@ -4064,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4078,7 +4117,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4087,7 +4126,7 @@ dependencies = [
  "serde_bytes",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4095,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4104,7 +4143,7 @@ dependencies = [
  "serde",
  "serde_cbor_2",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4131,16 +4170,15 @@ dependencies = [
  "serde_with",
  "smart-default",
  "statrs",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8009dca8550d8803bc730bb89e26a68316df041d4a131287e79b5e4fc9d4a413"
+version = "0.5.2"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f5c44b245f7a52679185acbf244152c5fd5c2199#f5c44b245f7a52679185acbf244152c5fd5c2199"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4149,20 +4187,20 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "parking_lot",
  "postcard",
  "redb",
  "strum",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport"
 version = "0.37.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4184,7 +4222,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4196,7 +4234,7 @@ dependencies = [
  "serde",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio-util",
  "tracing",
  "validator",
@@ -4205,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4215,15 +4253,14 @@ dependencies = [
  "parking_lot",
  "serde",
  "smart-default",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e553e6688d8bf422a47cf382673752fbe3086f168e33dde006160481ec317a"
+version = "0.9.5"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f5c44b245f7a52679185acbf244152c5fd5c2199#f5c44b245f7a52679185acbf244152c5fd5c2199"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4231,20 +4268,20 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
  "pin-project",
  "quinn-udp 0.6.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4255,14 +4292,14 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
  "serde",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "validator",
 ]
@@ -4270,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.25.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4283,7 +4320,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.6.0",
+ "hopr-utilities 0.7.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4294,7 +4331,7 @@ dependencies = [
  "serde_repr",
  "smart-default",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4302,20 +4339,19 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=5b1cd68806ee33dcfb50dfed3b4a2866825f8f68#5b1cd68806ee33dcfb50dfed3b4a2866825f8f68"
 dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "validator",
 ]
 
 [[package]]
 name = "hopr-types"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bff6165942aa235899cb5084a058db8a00b0885cfc41e8e0f5bf8b2cb007c6"
+version = "2.3.0"
+source = "git+https://github.com/hoprnet/hopr-types?rev=2a3bb391f1f98475d033b105c69090d050aaff0c#2a3bb391f1f98475d033b105c69090d050aaff0c"
 dependencies = [
  "aes 0.9.2",
  "anyhow",
@@ -4364,7 +4400,7 @@ dependencies = [
  "smart-default",
  "strum",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "typenum",
  "uuid",
@@ -4388,9 +4424,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c557ecaad14224e4ae1df1be73449c24241f4b34e20129b11b8d0e38062eb6a6"
+version = "0.7.0"
+source = "git+https://github.com/hoprnet/hopr-utilities?rev=a43495abdda0d2ee7f5516ccd451021eb0c3f31e#a43495abdda0d2ee7f5516ccd451021eb0c3f31e"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4417,7 +4452,7 @@ dependencies = [
  "serde_json",
  "socket2 0.6.5",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4445,9 +4480,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4919,6 +4954,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,7 +5018,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -4979,9 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5132,7 +5220,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5166,7 +5254,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.7",
  "rand_core 0.6.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "web-time",
 ]
@@ -5201,7 +5289,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.7",
  "rw-stream-sink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -5240,7 +5328,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -5258,7 +5346,7 @@ dependencies = [
  "rand 0.8.7",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "zeroize",
 ]
@@ -5315,7 +5403,7 @@ dependencies = [
  "rand 0.8.7",
  "snow",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5339,7 +5427,7 @@ dependencies = [
  "ring",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -5438,7 +5526,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "x509-parser",
  "yasna",
 ]
@@ -5467,7 +5555,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -5535,11 +5623,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5645,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -5759,7 +5847,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "log",
  "netlink-packet-core",
@@ -5767,9 +5855,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5777,7 +5865,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5799,7 +5887,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5866,9 +5954,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -5987,7 +6075,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -6017,7 +6105,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -6060,7 +6148,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6359,9 +6447,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -6457,7 +6554,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.7.1",
  "impl-serde",
- "uint 0.10.0",
+ "uint 0.10.1",
 ]
 
 [[package]]
@@ -6481,9 +6578,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6498,18 +6595,19 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6576,7 +6674,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -6654,7 +6752,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -6678,7 +6776,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6907,7 +7005,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -7207,7 +7305,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -7281,9 +7379,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7471,7 +7569,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7588,9 +7686,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64",
  "bs58",
@@ -7598,6 +7696,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -7608,9 +7707,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -7761,9 +7860,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834a9952211d4a60ff10ac1d20cc01640a75bdc0a0c688d62f359ea7d17459f3"
+checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
 dependencies = [
  "approx",
  "num-complex",
@@ -7922,15 +8021,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78553aa710187998fc7c7945c18889c59ef199ff7d2146ab90998b431b29eea"
+checksum = "c1837f9a1bd13dabbdbb04489c39451482d3cdd35a6e1a0d0f3570dea2b8c8be"
 dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7939,7 +8038,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83561175f0a962dea437885589480d216d8741debf853e0d36edd526344fd273"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "byteorder",
  "keccak",
  "subtle",
@@ -8056,7 +8155,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8119,11 +8218,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -8139,9 +8238,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8396,7 +8495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8531,9 +8630,9 @@ dependencies = [
 
 [[package]]
 name = "uint"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+checksum = "6f9227a75a5a540a464c832ad4a4195dbdbecd8787610a56262721fde6f04f90"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8722,9 +8821,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8735,9 +8834,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8745,9 +8844,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8755,9 +8854,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8768,9 +8867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -8804,9 +8903,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8833,9 +8932,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -9125,15 +9224,15 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xmltree"
@@ -9215,18 +9314,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,15 @@ telemetry = [
   # "dep:tracing-opentelemetry",
 ]
 testing = ["hopr-lib/testing"]
-blokli = ["dep:tokio", "dep:url"]
+blokli = [
+  "dep:tokio",
+  "dep:url",
+  "dep:async-stream",
+  "dep:blokli-client",
+  "dep:const-hex",
+  "dep:serde",
+  "dep:serde_json",
+]
 
 # tokio-console profiling of the `edgli` binary (see init_logger in src/main.rs). Build with
 # the `tracer` profile so TRACE-level task spans stay compiled in (see [profile.tracer]):
@@ -81,18 +89,36 @@ opentelemetry_sdk = { version = "0.32.1", optional = true }
 # tracing-opentelemetry = { version = "0.32.0", optional = true }
 url = { version = "2.5.8", optional = true }
 
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d", features = [
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "5b1cd68806ee33dcfb50dfed3b4a2866825f8f68", features = [
   "session-client",
   "serde",
 ] }
-hopr-chain-connector = { version = "0.22.1", features = ["runtime-tokio"] }
-hopr-ct-full-network = { version = "0.3.0" }
+# Pinned via git, matching hoprnet's own workspace pin: crates.io hopr-chain-connector
+# does not yet publish the service registry read support (ChainReadServiceOperations)
+# that edge-client's `discovery` module needs.
+hopr-chain-connector = { git = "https://github.com/hoprnet/hopr-impls", rev = "f5c44b245f7a52679185acbf244152c5fd5c2199", features = [
+  "runtime-tokio",
+] }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hopr-impls", rev = "f5c44b245f7a52679185acbf244152c5fd5c2199", default-features = false }
 hopr-strategy = { version = "0.25.0", features = [
   "strategy-channel-lifecycle",
 ] }
-hopr-ticket-manager = { version = "0.5.1" }
-hopr-network-graph = { version = "0.3.1" }
-hopr-transport-p2p = { version = "0.9.4" }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hopr-impls", rev = "f5c44b245f7a52679185acbf244152c5fd5c2199" }
+hopr-network-graph = { git = "https://github.com/hoprnet/hopr-impls", rev = "f5c44b245f7a52679185acbf244152c5fd5c2199", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hopr-impls", rev = "f5c44b245f7a52679185acbf244152c5fd5c2199" }
+# Direct dependency only for the raw subscription selector/update types (`discovery::subscribe_exit_nodes`):
+# `hopr_chain_connector::blokli_client` re-exports the client traits but not these. Pinned to the
+# exact rev hopr-impls' own workspace uses, so Cargo unifies it with hopr-chain-connector's
+# transitive copy instead of duplicating the crate.
+blokli-client = { git = "https://github.com/hoprnet/blokli-client", rev = "2b2d41a387f46d2d7adf4e0e66dd4dff520c0b92", optional = true }
+# `BlokliSubscriptionClient::subscribe_services` ties its returned stream to `&self`'s lifetime;
+# `discovery::subscribe_exit_nodes` needs to return an owned, 'static stream that keeps its
+# client alive for as long as the subscription lives. `stream!` builds that safely (no unsafe
+# lifetime extension) the same way `async fn` bodies already do.
+async-stream = { version = "0.3", optional = true }
+const-hex = { version = "1.19.1", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 
 # Target-specific dependencies for memory allocators
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -102,7 +128,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
 
 [dev-dependencies]
 # `testing` provides the blokli test emulator used by the src/blokli.rs unit tests.
-hopr-chain-connector = { version = "0.22.1", features = [
+hopr-chain-connector = { git = "https://github.com/hoprnet/hopr-impls", rev = "f5c44b245f7a52679185acbf244152c5fd5c2199", features = [
   "runtime-tokio",
   "testing",
 ] }
@@ -111,6 +137,15 @@ tokio = { version = "1.53.1", features = ["full"] }
 
 [build-dependencies]
 anyhow = "1.0.104"
+
+[patch.crates-io]
+# `hopr-strategy` (crates.io) still depends on the crates.io hopr-types/hopr-api, which predate
+# the service registry work and duplicate types (Address, Balance<C>, ...) and traits
+# (ActionableEventSource, PacketTransport, ...) against the git-pinned versions that
+# hopr-chain-connector/hopr-lib pull in above. Redirect both to the same git revs so Cargo unifies
+# the whole graph onto one copy of each.
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "2a3bb391f1f98475d033b105c69090d050aaff0c" }
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "7c26c0bee697d33529dc9412c271ce6c8d726fc1" }
 
 # tokio-console build target for the `prof` binary. hopr-lib forces
 # `tracing/release_max_level_debug`, which compiles out TRACE callsites (incl. tokio's task

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = [
   "rt-multi-thread",
   "macros",
+  "sync",
+  "time",
   "tracing",
 ], optional = true }
 tracing = { version = "0.1.44", features = ["release_max_level_debug"] }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,526 @@
+//! Discovery of `gvpn:exit` nodes registered in the on-chain `HoprServiceRegistry`.
+//!
+//! Reads go through [`hopr_chain_connector::HoprBlockchainReader`], which needs only a Blokli
+//! client (no chain key, no `connect()`), so a client that only wants to discover exit nodes does
+//! not have to sync the whole channel graph first.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use blokli_client::api::{
+    BlokliQueryClient, BlokliSubscriptionClient, ServiceSelector as BlokliServiceSelector,
+    types::{ServiceUpdate, ServiceUpdateKind},
+};
+use futures::{Stream, StreamExt};
+use hopr_chain_connector::HoprBlockchainReader;
+use hopr_lib::api::chain::{ChainReadServiceOperations, ServiceEntry, ServiceSelector};
+use hopr_lib::api::types::internal::prelude::ServiceType;
+use hopr_lib::api::types::primitive::prelude::{Address, ToHex};
+use serde::Deserialize;
+
+use crate::endpoint::BlokliEndpoint;
+
+/// `gvpn:exit` metadata, versioned per `design-service-registry-v3.md` §3.2 (in-band schema
+/// discriminator; each service type documents its own encoding).
+#[derive(Deserialize)]
+struct ExitNodeMetadataV1 {
+    schema_version: u32,
+    /// Where the exit node's gvpn-server process listens on its private overlay: the HTTP
+    /// registration API and the bridge-mode session forwarding target.
+    gnosis_vpn_server: SocketAddr,
+    /// Where the exit node's WireGuard server listens on its private overlay. Required, not
+    /// `Option`: registering under `gvpn:exit` requires running both an exit node and an exit
+    /// server, so a well-formed entry always has one.
+    wireguard_server: SocketAddr,
+    /// Free-form labels the operator publishes (e.g. location), mirroring gnosis_vpn-client's
+    /// existing config `meta` tags.
+    #[serde(flatten)]
+    meta: HashMap<String, String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum MetadataDecodeError {
+    #[error("malformed gvpn:exit metadata: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported gvpn:exit metadata schema version {0}")]
+    UnsupportedVersion(u32),
+}
+
+fn parse_exit_node_metadata(bytes: &[u8]) -> Result<ExitNodeMetadataV1, MetadataDecodeError> {
+    let metadata: ExitNodeMetadataV1 = serde_json::from_slice(bytes)?;
+    if metadata.schema_version != 1 {
+        return Err(MetadataDecodeError::UnsupportedVersion(
+            metadata.schema_version,
+        ));
+    }
+    Ok(metadata)
+}
+
+/// A `gvpn:exit` node, decoded from its on-chain registry entry.
+#[derive(Clone, Debug)]
+pub struct ExitNodeInfo {
+    /// On-chain address of the exit node.
+    pub node: Address,
+    /// Safe that performed the last write to this entry.
+    pub safe: Address,
+    /// The exit node's gvpn-server endpoint (HTTP registration API / bridge-mode target).
+    pub gnosis_vpn_server: SocketAddr,
+    /// The exit node's WireGuard server endpoint.
+    pub wireguard_server: SocketAddr,
+    /// Free-form operator-published labels.
+    pub meta: HashMap<String, String>,
+    /// When the entry was registered.
+    pub registered_at: SystemTime,
+    /// When the entry was last updated; equal to `registered_at` until the first update.
+    pub updated_at: SystemTime,
+}
+
+/// Decodes one registry entry, dropping it (with a log) if the metadata does not parse.
+///
+/// The registry is permissionless — garbage and squatted entries under `gvpn:exit` are expected,
+/// not fatal, so a decode failure is skipped rather than propagated.
+fn decode(entry: ServiceEntry) -> Option<ExitNodeInfo> {
+    match parse_exit_node_metadata(entry.metadata.as_ref()) {
+        Ok(m) => Some(ExitNodeInfo {
+            node: entry.node,
+            safe: entry.safe,
+            gnosis_vpn_server: m.gnosis_vpn_server,
+            wireguard_server: m.wireguard_server,
+            meta: m.meta,
+            registered_at: entry.registered_at,
+            updated_at: entry.updated_at,
+        }),
+        Err(error) => {
+            tracing::warn!(%error, node = %entry.node, "skipping exit node with malformed metadata");
+            None
+        }
+    }
+}
+
+/// Fetches all currently registered, live `gvpn:exit` nodes.
+///
+/// "Live" means the node still has a Safe binding in the node-Safe registry — an entry whose
+/// binding was lost is permanently listed but dead (`design-service-registry-v3.md` §9.5), and
+/// [`ServiceSelector::with_live_only`] filters those out.
+pub async fn list_exit_nodes(blokli_endpoint: BlokliEndpoint) -> anyhow::Result<Vec<ExitNodeInfo>> {
+    list_exit_nodes_with_client(blokli_endpoint.build_client()).await
+}
+
+async fn list_exit_nodes_with_client<C>(client: C) -> anyhow::Result<Vec<ExitNodeInfo>>
+where
+    C: BlokliQueryClient + Send + Sync + 'static,
+{
+    let reader = HoprBlockchainReader::new(client);
+    let selector = ServiceSelector::default()
+        .with_service_type(ServiceType::GVPN_EXIT)
+        .with_live_only(true);
+
+    let entries: Vec<ServiceEntry> = reader.stream_services(selector)?.collect().await;
+    Ok(entries.into_iter().filter_map(decode).collect())
+}
+
+/// What changed about a `gvpn:exit` registry entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExitNodeUpdateKind {
+    Registered,
+    Updated,
+    Deregistered,
+}
+
+/// A live change to a `gvpn:exit` registry entry.
+#[derive(Clone, Debug)]
+pub struct ExitNodeUpdate {
+    pub kind: ExitNodeUpdateKind,
+    pub node: Address,
+    /// `None` for [`ExitNodeUpdateKind::Deregistered`], where the entry no longer exists, or when
+    /// the updated entry's metadata failed to decode.
+    pub entry: Option<ExitNodeInfo>,
+}
+
+fn model_timestamp(seconds: i32) -> Option<SystemTime> {
+    match u64::try_from(seconds) {
+        Ok(seconds) => Some(UNIX_EPOCH + Duration::from_secs(seconds)),
+        Err(_) => {
+            tracing::warn!(
+                seconds,
+                "exit node update timestamp precedes the Unix epoch"
+            );
+            None
+        }
+    }
+}
+
+/// Decodes the raw Blokli model carried by a subscription update, dropping it (with a log) on any
+/// malformed field. Mirrors [`decode`], but for the hex-encoded GraphQL model rather than the
+/// already-parsed domain [`ServiceEntry`] `list_exit_nodes` works with.
+fn decode_model_entry(model: blokli_client::api::types::ServiceEntry) -> Option<ExitNodeInfo> {
+    let node = match Address::from_hex(&model.node) {
+        Ok(node) => node,
+        Err(error) => {
+            tracing::warn!(%error, node = %model.node, "skipping exit node update with malformed node address");
+            return None;
+        }
+    };
+
+    let safe = match Address::from_hex(&model.safe) {
+        Ok(safe) => safe,
+        Err(error) => {
+            tracing::warn!(%error, %node, "skipping exit node update with malformed safe address");
+            return None;
+        }
+    };
+
+    let metadata_bytes = match const_hex::decode(&model.metadata) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!(%error, %node, "skipping exit node update with malformed metadata encoding");
+            return None;
+        }
+    };
+
+    let metadata = match parse_exit_node_metadata(&metadata_bytes) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::warn!(%error, %node, "skipping exit node update with malformed metadata");
+            return None;
+        }
+    };
+
+    let registered_at = model_timestamp(model.registered_at)?;
+    let updated_at = model_timestamp(model.updated_at)?;
+
+    Some(ExitNodeInfo {
+        node,
+        safe,
+        gnosis_vpn_server: metadata.gnosis_vpn_server,
+        wireguard_server: metadata.wireguard_server,
+        meta: metadata.meta,
+        registered_at,
+        updated_at,
+    })
+}
+
+/// Decodes one subscription update, dropping it (with a log) on any malformed field.
+fn decode_update(
+    update: Result<ServiceUpdate, blokli_client::errors::BlokliClientError>,
+) -> Option<ExitNodeUpdate> {
+    let update = match update {
+        Ok(update) => update,
+        Err(error) => {
+            tracing::warn!(%error, "gvpn:exit subscription error");
+            return None;
+        }
+    };
+
+    let node = match Address::from_hex(&update.node) {
+        Ok(node) => node,
+        Err(error) => {
+            tracing::warn!(%error, node = %update.node, "skipping update with malformed node address");
+            return None;
+        }
+    };
+
+    match update.kind {
+        ServiceUpdateKind::Deregistered => Some(ExitNodeUpdate {
+            kind: ExitNodeUpdateKind::Deregistered,
+            node,
+            entry: None,
+        }),
+        ServiceUpdateKind::Registered | ServiceUpdateKind::Updated => {
+            let kind = if update.kind == ServiceUpdateKind::Registered {
+                ExitNodeUpdateKind::Registered
+            } else {
+                ExitNodeUpdateKind::Updated
+            };
+            Some(ExitNodeUpdate {
+                kind,
+                node,
+                entry: update.entry.and_then(decode_model_entry),
+            })
+        }
+    }
+}
+
+/// Subscribes to live `gvpn:exit` registrations, updates, and deregistrations.
+///
+/// Built directly on the raw Blokli subscription — [`ChainReadServiceOperations`] has no
+/// subscribe method — so unlike [`list_exit_nodes`], updates here do not get the Safe-binding
+/// liveness cross-check: a node that goes orphaned mid-stream is not flagged until the next
+/// `list_exit_nodes` call. Acceptable for v1; reconcile periodically if that gap matters.
+///
+/// A failure to open the subscription itself (as opposed to a malformed update once open, which
+/// is merely skipped) ends the returned stream after a single log line rather than surfacing an
+/// error to the caller — the selector is always a valid, concrete `gvpn:exit` filter, so this
+/// path is not expected to fail in practice.
+pub fn subscribe_exit_nodes(
+    blokli_endpoint: BlokliEndpoint,
+) -> impl Stream<Item = ExitNodeUpdate> + Send {
+    subscribe_exit_nodes_with_client(blokli_endpoint.build_client())
+}
+
+fn subscribe_exit_nodes_with_client<C>(client: C) -> impl Stream<Item = ExitNodeUpdate> + Send
+where
+    C: BlokliSubscriptionClient + Send + Sync + 'static,
+{
+    // `subscribe_services` ties its returned stream to `&client`'s lifetime; `stream!` lets this
+    // function return an owned, 'static stream that keeps `client` alive for exactly as long as
+    // the inner stream borrowed from it, without unsafe lifetime extension.
+    async_stream::stream! {
+        let selector = BlokliServiceSelector::ServiceType(ServiceType::GVPN_EXIT.as_encoded());
+        let updates = match client.subscribe_services(selector) {
+            Ok(updates) => updates,
+            Err(error) => {
+                tracing::error!(%error, "failed to open the gvpn:exit registry subscription");
+                return;
+            }
+        };
+
+        let mut updates = std::pin::pin!(updates);
+        while let Some(update) = updates.next().await {
+            if let Some(mapped) = decode_update(update) {
+                yield mapped;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use hopr_chain_connector::testing::BlokliTestStateBuilder;
+    use hopr_lib::api::chain::{DeployedSafe, ServiceMetadata};
+
+    use super::*;
+
+    const NODE: [u8; 20] = [0x11; 20];
+    const OTHER_NODE: [u8; 20] = [0x22; 20];
+    const SAFE: [u8; 20] = [0x33; 20];
+
+    fn valid_metadata() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "gnosis_vpn_server": "172.30.0.1:8000",
+            "wireguard_server": "172.30.0.1:51820",
+            "location": "Germany",
+        }))
+        .unwrap()
+    }
+
+    fn entry_with_metadata(node: [u8; 20], metadata: Vec<u8>) -> anyhow::Result<ServiceEntry> {
+        let registered_at = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        Ok(ServiceEntry::new(
+            ServiceType::GVPN_EXIT,
+            node.into(),
+            SAFE.into(),
+            ServiceMetadata::try_from(metadata)?,
+            registered_at,
+            registered_at,
+        )?)
+    }
+
+    fn safe_with_nodes(nodes: &[[u8; 20]]) -> DeployedSafe {
+        DeployedSafe {
+            address: SAFE.into(),
+            owners: vec![[0x44; 20].into()],
+            module: [0x66; 20].into(),
+            registered_nodes: nodes.iter().map(|node| Address::from(*node)).collect(),
+            deployer: [0x44; 20].into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_exit_nodes_decodes_a_well_formed_entry() -> anyhow::Result<()> {
+        let client = BlokliTestStateBuilder::default()
+            .with_services([entry_with_metadata(NODE, valid_metadata())?])
+            .with_deployed_safes([safe_with_nodes(&[NODE])])
+            .build_static_client();
+
+        let nodes = list_exit_nodes_with_client(client).await?;
+
+        assert_eq!(1, nodes.len());
+        assert_eq!(Address::from(NODE), nodes[0].node);
+        assert_eq!(
+            "172.30.0.1:8000".parse::<SocketAddr>()?,
+            nodes[0].gnosis_vpn_server
+        );
+        assert_eq!(
+            "172.30.0.1:51820".parse::<SocketAddr>()?,
+            nodes[0].wireguard_server
+        );
+        assert_eq!(Some(&"Germany".to_string()), nodes[0].meta.get("location"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_exit_nodes_skips_malformed_metadata() -> anyhow::Result<()> {
+        let client = BlokliTestStateBuilder::default()
+            .with_services([
+                entry_with_metadata(NODE, b"not json".to_vec())?,
+                entry_with_metadata(OTHER_NODE, valid_metadata())?,
+            ])
+            .with_deployed_safes([safe_with_nodes(&[NODE, OTHER_NODE])])
+            .build_static_client();
+
+        let nodes = list_exit_nodes_with_client(client).await?;
+
+        assert_eq!(1, nodes.len());
+        assert_eq!(Address::from(OTHER_NODE), nodes[0].node);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_exit_nodes_skips_unsupported_schema_version() -> anyhow::Result<()> {
+        let metadata = serde_json::to_vec(&serde_json::json!({
+            "schema_version": 2,
+            "gnosis_vpn_server": "172.30.0.1:8000",
+            "wireguard_server": "172.30.0.1:51820",
+        }))?;
+        let client = BlokliTestStateBuilder::default()
+            .with_services([entry_with_metadata(NODE, metadata)?])
+            .with_deployed_safes([safe_with_nodes(&[NODE])])
+            .build_static_client();
+
+        let nodes = list_exit_nodes_with_client(client).await?;
+
+        assert!(nodes.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_exit_nodes_skips_missing_wireguard_server() -> anyhow::Result<()> {
+        let metadata = serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "gnosis_vpn_server": "172.30.0.1:8000",
+        }))?;
+        let client = BlokliTestStateBuilder::default()
+            .with_services([entry_with_metadata(NODE, metadata)?])
+            .with_deployed_safes([safe_with_nodes(&[NODE])])
+            .build_static_client();
+
+        let nodes = list_exit_nodes_with_client(client).await?;
+
+        assert!(nodes.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_exit_nodes_drops_entries_without_a_live_safe_binding() -> anyhow::Result<()> {
+        let client = BlokliTestStateBuilder::default()
+            .with_services([
+                entry_with_metadata(NODE, valid_metadata())?,
+                entry_with_metadata(OTHER_NODE, valid_metadata())?,
+            ])
+            .with_deployed_safes([safe_with_nodes(&[NODE])])
+            .build_static_client();
+
+        let nodes = list_exit_nodes_with_client(client).await?;
+
+        assert_eq!(1, nodes.len());
+        assert_eq!(Address::from(NODE), nodes[0].node);
+
+        Ok(())
+    }
+
+    fn model_entry_with_metadata(
+        node: [u8; 20],
+        metadata: Vec<u8>,
+    ) -> blokli_client::api::types::ServiceEntry {
+        blokli_client::api::types::ServiceEntry {
+            service_type: "gvpn:exit".to_string(),
+            node: const_hex::encode(node),
+            safe: const_hex::encode(SAFE),
+            metadata: const_hex::encode(metadata),
+            registered_at: 1_700_000_000,
+            updated_at: 1_700_000_000,
+        }
+    }
+
+    #[test]
+    fn decode_model_entry_decodes_a_well_formed_entry() {
+        let info = decode_model_entry(model_entry_with_metadata(NODE, valid_metadata()))
+            .expect("should decode");
+
+        assert_eq!(Address::from(NODE), info.node);
+        assert_eq!(Address::from(SAFE), info.safe);
+        assert_eq!(
+            "172.30.0.1:8000".parse::<SocketAddr>().unwrap(),
+            info.gnosis_vpn_server
+        );
+        assert_eq!(
+            "172.30.0.1:51820".parse::<SocketAddr>().unwrap(),
+            info.wireguard_server
+        );
+    }
+
+    #[test]
+    fn decode_model_entry_skips_malformed_node_address() {
+        let mut model = model_entry_with_metadata(NODE, valid_metadata());
+        model.node = "not hex".to_string();
+
+        assert!(decode_model_entry(model).is_none());
+    }
+
+    #[test]
+    fn decode_model_entry_skips_malformed_metadata_encoding() {
+        let mut model = model_entry_with_metadata(NODE, valid_metadata());
+        model.metadata = "not hex".to_string();
+
+        assert!(decode_model_entry(model).is_none());
+    }
+
+    #[test]
+    fn decode_update_maps_registered_and_updated_kinds() {
+        let registered = decode_update(Ok(ServiceUpdate {
+            kind: ServiceUpdateKind::Registered,
+            service_type: "gvpn:exit".to_string(),
+            node: const_hex::encode(NODE),
+            entry: Some(model_entry_with_metadata(NODE, valid_metadata())),
+        }))
+        .expect("should decode");
+        assert_eq!(ExitNodeUpdateKind::Registered, registered.kind);
+        assert_eq!(Address::from(NODE), registered.node);
+        assert!(registered.entry.is_some());
+
+        let updated = decode_update(Ok(ServiceUpdate {
+            kind: ServiceUpdateKind::Updated,
+            service_type: "gvpn:exit".to_string(),
+            node: const_hex::encode(NODE),
+            entry: Some(model_entry_with_metadata(NODE, valid_metadata())),
+        }))
+        .expect("should decode");
+        assert_eq!(ExitNodeUpdateKind::Updated, updated.kind);
+    }
+
+    #[test]
+    fn decode_update_maps_deregistered_with_no_entry() {
+        let deregistered = decode_update(Ok(ServiceUpdate {
+            kind: ServiceUpdateKind::Deregistered,
+            service_type: "gvpn:exit".to_string(),
+            node: const_hex::encode(NODE),
+            entry: None,
+        }))
+        .expect("should decode");
+
+        assert_eq!(ExitNodeUpdateKind::Deregistered, deregistered.kind);
+        assert_eq!(Address::from(NODE), deregistered.node);
+        assert!(deregistered.entry.is_none());
+    }
+
+    #[test]
+    fn decode_update_skips_malformed_node_address() {
+        let update = decode_update(Ok(ServiceUpdate {
+            kind: ServiceUpdateKind::Deregistered,
+            service_type: "gvpn:exit".to_string(),
+            node: "not hex".to_string(),
+            entry: None,
+        }));
+
+        assert!(update.is_none());
+    }
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -58,7 +58,7 @@ fn parse_exit_node_metadata(bytes: &[u8]) -> Result<ExitNodeMetadataV1, Metadata
 }
 
 /// A `gvpn:exit` node, decoded from its on-chain registry entry.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ExitNodeInfo {
     /// On-chain address of the exit node.
     pub node: Address,
@@ -285,6 +285,120 @@ where
     }
 }
 
+/// How often [`ExitNodeRegistry`] re-fetches the full registry to catch nodes that went orphaned
+/// (lost their Safe binding) without emitting a `Deregistered` event — [`subscribe_exit_nodes`]
+/// does not get that liveness cross-check, only [`list_exit_nodes`] does.
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
+
+fn to_map(nodes: Vec<ExitNodeInfo>) -> HashMap<Address, ExitNodeInfo> {
+    nodes.into_iter().map(|node| (node.node, node)).collect()
+}
+
+/// A live, continuously updated view of registered `gvpn:exit` nodes.
+///
+/// Owns the whole discovery lifecycle behind one handle — the initial fetch, the live
+/// subscription, and periodic liveness reconciliation — so a caller never has to see a Blokli
+/// selector or a raw registry update. Dropping the handle stops the background task.
+pub struct ExitNodeRegistry {
+    nodes: tokio::sync::watch::Receiver<HashMap<Address, ExitNodeInfo>>,
+    task: tokio::task::AbortHandle,
+}
+
+impl ExitNodeRegistry {
+    /// The current set of registered, live exit nodes, keyed by node address.
+    pub fn nodes(&self) -> HashMap<Address, ExitNodeInfo> {
+        self.nodes.borrow().clone()
+    }
+
+    /// Waits for the next change to [`Self::nodes`].
+    pub async fn changed(&mut self) -> anyhow::Result<()> {
+        self.nodes.changed().await.map_err(anyhow::Error::from)
+    }
+}
+
+impl Drop for ExitNodeRegistry {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn reconcile_exit_nodes<C>(
+    client: C,
+    tx: tokio::sync::watch::Sender<HashMap<Address, ExitNodeInfo>>,
+) where
+    C: BlokliQueryClient + BlokliSubscriptionClient + Clone + Send + Sync + 'static,
+{
+    // `None` once the live subscription ends (e.g. exhausted its own reconnect attempts); from
+    // then on this task falls back to periodic reconciliation only, rather than busy-polling a
+    // stream that will keep reporting `None`.
+    let mut live_updates = Some(std::pin::pin!(subscribe_exit_nodes_with_client(
+        client.clone()
+    )));
+    let mut reconcile = tokio::time::interval(RECONCILE_INTERVAL);
+    reconcile.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    reconcile.tick().await; // the initial fetch already happened in `watch_exit_nodes`
+
+    loop {
+        tokio::select! {
+            update = async { live_updates.as_mut()?.next().await }, if live_updates.is_some() => {
+                match update {
+                    Some(update) => {
+                        tx.send_modify(|nodes| match update.entry {
+                            Some(entry) => { nodes.insert(update.node, entry); }
+                            None => { nodes.remove(&update.node); }
+                        });
+                    }
+                    None => {
+                        tracing::warn!("gvpn:exit subscription ended; falling back to periodic reconciliation only");
+                        live_updates = None;
+                    }
+                }
+            }
+            _ = reconcile.tick() => {
+                match list_exit_nodes_with_client(client.clone()).await {
+                    Ok(nodes) => {
+                        let nodes = to_map(nodes);
+                        tx.send_if_modified(|current| {
+                            let changed = *current != nodes;
+                            *current = nodes;
+                            changed
+                        });
+                    }
+                    Err(error) => tracing::warn!(%error, "periodic gvpn:exit reconciliation failed"),
+                }
+            }
+        }
+
+        if tx.is_closed() {
+            break;
+        }
+    }
+}
+
+/// Starts discovering registered `gvpn:exit` nodes, returning once the initial fetch completes.
+///
+/// This is the intended entry point for callers that just want a live destination list without
+/// touching Blokli-specific types: it fetches the current registry, then keeps the result fresh
+/// in the background (live subscription plus periodic reconciliation) for as long as the
+/// returned [`ExitNodeRegistry`] stays alive.
+pub async fn watch_exit_nodes(blokli_endpoint: BlokliEndpoint) -> anyhow::Result<ExitNodeRegistry> {
+    watch_exit_nodes_with_client(blokli_endpoint.build_client()).await
+}
+
+async fn watch_exit_nodes_with_client<C>(client: C) -> anyhow::Result<ExitNodeRegistry>
+where
+    C: BlokliQueryClient + BlokliSubscriptionClient + Clone + Send + Sync + 'static,
+{
+    let initial = to_map(list_exit_nodes_with_client(client.clone()).await?);
+    let (tx, rx) = tokio::sync::watch::channel(initial);
+    let task = tokio::spawn(reconcile_exit_nodes(client, tx));
+
+    Ok(ExitNodeRegistry {
+        nodes: rx,
+        task: task.abort_handle(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -423,6 +537,38 @@ mod tests {
 
         assert_eq!(1, nodes.len());
         assert_eq!(Address::from(NODE), nodes[0].node);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn watch_exit_nodes_returns_the_initial_registry() -> anyhow::Result<()> {
+        let client = BlokliTestStateBuilder::default()
+            .with_services([entry_with_metadata(NODE, valid_metadata())?])
+            .with_deployed_safes([safe_with_nodes(&[NODE])])
+            .build_static_client();
+
+        let registry = watch_exit_nodes_with_client(client).await?;
+        let nodes = registry.nodes();
+
+        assert_eq!(1, nodes.len());
+        assert_eq!(Address::from(NODE), nodes[&Address::from(NODE)].node);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn watch_exit_nodes_dropping_the_registry_stops_the_background_task() -> anyhow::Result<()>
+    {
+        let client = BlokliTestStateBuilder::default().build_static_client();
+
+        let registry = watch_exit_nodes_with_client(client).await?;
+        let task = registry.task.clone();
+        drop(registry);
+
+        // `AbortHandle::abort` schedules cancellation; give the runtime a tick to apply it.
+        tokio::task::yield_now().await;
+        assert!(task.is_finished());
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ pub mod errors;
 pub mod blokli;
 
 #[cfg(feature = "blokli")]
+pub mod discovery;
+
+#[cfg(feature = "blokli")]
 pub mod endpoint;
 
 pub mod strategy;
@@ -17,6 +20,8 @@ pub use hopr_lib;
 
 #[cfg(feature = "blokli")]
 pub use blokli::*;
+#[cfg(feature = "blokli")]
+pub use discovery::*;
 #[cfg(feature = "blokli")]
 pub use endpoint::*;
 #[cfg(feature = "blokli")]


### PR DESCRIPTION
Adds list_exit_nodes()/subscribe_exit_nodes(), reading the on-chain HoprServiceRegistry via hopr-chain-connector's HoprBlockchainReader (no chain key or connect() needed) and decoding each entry's gvpn:exit metadata (gnosis_vpn_server/wireguard_server sockets plus free-form labels) so gnosis_vpn-client can discover exit nodes instead of relying on static config.

Bumps hopr-lib/hopr-chain-connector and its hopr-impls siblings to the git revs carrying the service registry read support (not yet published to crates.io), and adds a blokli-client dependency for the raw subscription types. Patches hopr-types/hopr-api to the same git revs so hopr-strategy's crates.io copies unify with them instead of duplicating the types.